### PR TITLE
Improve error message in case of a Kafka timeout

### DIFF
--- a/karapace/errors.py
+++ b/karapace/errors.py
@@ -44,3 +44,7 @@ class SubjectSoftDeletedException(Exception):
 
 class SchemaTooLargeException(Exception):
     pass
+
+
+class KafkaTimeoutException(Exception):
+    pass

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -11,6 +11,7 @@ from karapace.errors import (
     InvalidSchema,
     InvalidSchemaType,
     InvalidVersion,
+    KafkaTimeoutException,
     SchemasNotFoundException,
     SchemaTooLargeException,
     SchemaVersionNotSoftDeletedException,
@@ -52,6 +53,7 @@ class SchemaErrorCodes(Enum):
     INVALID_SUBJECT = 42208
     SCHEMA_TOO_LARGE_ERROR_CODE = 42209
     NO_MASTER_ERROR = 50003
+    KAFKA_TIMEOUT_ERROR_CODE = 50004
 
 
 @unique
@@ -1016,6 +1018,15 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                     },
                     content_type=content_type,
                     status=HTTPStatus.UNPROCESSABLE_ENTITY,
+                )
+            except KafkaTimeoutException:
+                self.r(
+                    body={
+                        "error_code": SchemaErrorCodes.KAFKA_TIMEOUT_ERROR_CODE.value,
+                        "message": "Kafka timeout",
+                    },
+                    content_type=content_type,
+                    status=HTTPStatus.GATEWAY_TIMEOUT,
                 )
 
         elif not master_url:


### PR DESCRIPTION
In the case that can be seen in the stacktrace below, the customer gets 500 internal error.

Add handling of KafkaTimeoutException and return HTTP 504 in that case.

```
Traceback (most recent call last):
File "/usr/lib/python3.10/site-packages/karapace/rapu.py", line 323, in _handle_request
  data = await callback(**callback_kwargs)
   File "/usr/lib/python3.10/site-packages/karapace/schema_registry_apis.py", line 491, in config_set
     self.schema_registry.send_config_message(compatibility_level=compatibility_level, subject=None)
   File "/usr/lib/python3.10/site-packages/karapace/schema_registry.py", line 483, in send_config_message
     return self.send_kafka_message(key, value)
   File "/usr/lib/python3.10/site-packages/karapace/schema_registry.py", line 408, in send_kafka_message
     future = self.producer.send(
   File "/usr/lib/python3.10/site-packages/kafka/producer/kafka.py", line 581, in send
     self._wait_on_metadata(topic, self.config['max_block_ms'] / 1000.0)
   File "/usr/lib/python3.10/site-packages/kafka/producer/kafka.py", line 707, in _wait_on_metadata
     raise Errors.KafkaTimeoutError(
 kafka.errors.KafkaTimeoutError: KafkaTimeoutError: Failed to update metadata after 2.0 secs.
```

