### PR TITLE
chore: bump pre-commit hooks, simplify config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,13 @@
 [flake8]
 max-line-length = 125
 
-# E203,W503: incompatibilities with black
-# E722: also signaled by pylint (disabling here globally and on case-by-case basis with pylint)
+# E203: whitespace before ':', incompatible with black
+# W503: line break before binary operator, incompatible with black
+# E722: do not use bare 'except', also signaled by pylint (disabling here globally and
+#       on case-by-case basis with pylint)
+# E501: ignore line-length
 ignore =
-  E501,  # line length
-  E203,  # whitespace before ':'
-  W503,  # line break before binary operator
-  E722,  # do not use bare 'except'
+  E501,
+  E203,
+  W503,
+  E722,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,16 @@
 minimum_pre_commit_version: 2.9.2
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
-        files: \.py$
         args:
           - --line-length=125
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
-        files: \.py$
         args:
           - --config=.flake8
 
@@ -22,7 +20,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        files: \.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.942
@@ -37,7 +34,7 @@ repos:
           - "karapace"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         exclude: ^vendor/|^tests/.*/fixtures/.*|^tests/integration/test_data/.*
@@ -53,7 +50,6 @@ repos:
         entry: pylint
         language: system
         types: [python]
-        files: \.py$
         exclude: ^vendor/
         args:
           - --rcfile=.pylintrc


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Bump pre-commit hooks and remove superfluous file patterns from pre-commit config.

Restructure flake8 config.
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

There's no need to give file patterns for pre-commit hooks, pre-commit is very good at identifying file types and the hooks themselves are already configured to only run on Python files.

New version of flake8 gave runtime error for our config, specifically because we had inline comments for excluded error codes.

<details>
<summary>flake8 error message</summary>
  
```
Traceback (most recent call last):
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/bin/flake8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
                                 ^^^^^^^^^^^^^^^^
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/options/parse_args.py", line 53, in parse_args
    opts = aggregator.aggregate_options(option_manager, cfg, cfg_dir, rest)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/options/aggregator.py", line 30, in aggregate_options
    parsed_config = config.parse_config(manager, cfg, cfg_dir)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anton/.cache/pre-commit/repoy7ey70wk/py_env-python3/lib/python3.11/site-packages/flake8/options/config.py", line 131, in parse_config
    raise ValueError(
ValueError: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'
```
</details>

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->


