### PR TITLE
chore: run static checks on Python 3.11, cache pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,28 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+          check-latest: true
+
+      - name: Cache pre-commit
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: >-
+            ${{ runner.os }}
+            -pre-commit
+            -${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # https://github.com/andrix/python-snappy/issues/124
+      - name: Install libsnappy-dev (python-snappy legacy-install-failure on Python 3.11)
+        run: sudo apt install libsnappy-dev
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    # https://github.com/andrix/python-snappy/issues/124
     - name: Install libsnappy-dev (python-snappy legacy-install-failure on Python 3.11)
       run: sudo apt install libsnappy-dev
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 ---
 minimum_pre_commit_version: 2.9.2
+default_language_version:
+  python: python3.11
 repos:
   - repo: https://github.com/psf/black
     rev: 22.3.0


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- Use Python 3.11 to run static checks.
- Bump Github Action versions.
- Introduce caching for Python dependencies.
- Introduce caching for pre-commit hooks.
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Caching will make CI checks run faster and waste less cycles.

Bumping to latest Python version enables using bumping flake8, as latest version of flake8 requires Python 3.8 or higher.

These are static checks, so it doesn't matter for compatibility which Python version we run on.