### PR TITLE
chore: Refactor various protobuf modules

### DIFF
--- a/karapace/protobuf/location.py
+++ b/karapace/protobuf/location.py
@@ -4,33 +4,36 @@ See LICENSE for details
 """
 # Ported from square/wire:
 # wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Location.kt
-from typing import Optional
+from __future__ import annotations
+
+from dataclasses import replace
+from karapace.dataclasses import default_dataclass
+from typing import overload
 
 
+@default_dataclass
 class Location:
     """Locates a .proto file, or a self.position within a .proto file, on the file system"""
 
-    def __init__(self, base: str, path: str, line: int = -1, column: int = -1) -> None:
-        """str - The base directory of this location;
-        path - The path to this location relative to [base]
-        line - The line number of this location, or -1 for no specific line number
-        column - The column on the line of this location, or -1 for no specific column
-        """
-        self.base = base
-        self.path = path
-        self.line = line
-        self.column = column
+    base: str
+    """The base directory of this location."""
+    path: str
+    """The path to this location relative to [base]."""
+    line: int = -1
+    """ The line number of this location, or -1 for no specific line number."""
+    column: int = -1
+    """The column on the line of this location, or -1 for no specific column."""
 
-    def at(self, line: int, column: int) -> "Location":
-        return Location(self.base, self.path, line, column)
+    def at(self, line: int, column: int) -> Location:
+        return replace(self, line=line, column=column)
 
-    def without_base(self) -> "Location":
+    def without_base(self) -> Location:
         """Returns a copy of this location with an empty base."""
-        return Location("", self.path, self.line, self.column)
+        return replace(self, base="")
 
-    def with_path_only(self) -> "Location":
+    def with_path_only(self) -> Location:
         """Returns a copy of this location including only its path."""
-        return Location("", self.path, -1, -1)
+        return replace(self, base="", line=-1, column=-1)
 
     def __str__(self) -> str:
         result = ""
@@ -49,16 +52,25 @@ class Location:
         return result
 
     @staticmethod
-    def get(*args) -> Optional["Location"]:
-        result = None
+    @overload
+    def get(path: str, /) -> Location:
+        ...
+
+    @staticmethod
+    @overload
+    def get(base: str, path: str, /) -> Location:
+        ...
+
+    @staticmethod
+    def get(*args: str) -> Location:
         if len(args) == 1:  # (path)
             path = args[0]
-            result = Location.get("", path)
+            return Location.get("", path)
         if len(args) == 2:  # (base,path)
-            path: str = args[1]
-            base: str = args[0]
+            path = args[1]
+            base = args[0]
             if base.endswith("/"):
                 base = base[:-1]
-            result = Location(base, path)
+            return Location(base=base, path=path)
 
-        return result
+        raise NotImplementedError

--- a/karapace/protobuf/proto_file_element.py
+++ b/karapace/protobuf/proto_file_element.py
@@ -10,10 +10,14 @@ from karapace.protobuf.compare_type_storage import CompareTypes
 from karapace.protobuf.location import Location
 from karapace.protobuf.syntax import Syntax
 from karapace.protobuf.type_element import TypeElement
-from typing import Dict, List, Optional
+from typing import List, Mapping, Optional
 
 
-def _collect_dependencies_types(compare_types: CompareTypes, dependencies: Optional[Dict[str, Dependency]], is_self: bool):
+def _collect_dependencies_types(
+    compare_types: CompareTypes,
+    dependencies: Optional[Mapping[str, Dependency]],
+    is_self: bool,
+) -> None:
     for dep in dependencies.values():
         types: List[TypeElement] = dep.schema.schema.proto_file_element.types
         sub_deps = dep.schema.schema.dependencies
@@ -107,11 +111,8 @@ class ProtoFileElement:
         return ProtoFileElement(Location.get(path))
 
     # TODO: there maybe be faster comparison workaround
-    def __eq__(self, other: "ProtoFileElement") -> bool:  # type: ignore
-        a = self.to_schema()
-        b = other.to_schema()
-
-        return a == b
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ProtoFileElement) and self.to_schema() == other.to_schema()
 
     def __repr__(self) -> str:
         return self.to_schema()
@@ -120,8 +121,8 @@ class ProtoFileElement:
         self,
         other: "ProtoFileElement",
         result: CompareResult,
-        self_dependencies: Optional[Dict[str, Dependency]] = None,
-        other_dependencies: Optional[Dict[str, Dependency]] = None,
+        self_dependencies: Optional[Mapping[str, Dependency]] = None,
+        other_dependencies: Optional[Mapping[str, Dependency]] = None,
     ) -> CompareResult:
         from karapace.protobuf.compare_type_lists import compare_type_lists
 

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -18,7 +18,7 @@ from karapace.protobuf.proto_parser import ProtoParser
 from karapace.protobuf.type_element import TypeElement
 from karapace.protobuf.utils import append_documentation, append_indented
 from karapace.schema_references import Reference
-from typing import Dict, List, Optional
+from typing import Mapping, Optional, Sequence
 
 
 def add_slashes(text: str) -> str:
@@ -110,7 +110,10 @@ class ProtobufSchema:
     DEFAULT_LOCATION = Location.get("")
 
     def __init__(
-        self, schema: str, references: Optional[List[Reference]] = None, dependencies: Optional[Dict[str, Dependency]] = None
+        self,
+        schema: str,
+        references: Optional[Sequence[Reference]] = None,
+        dependencies: Optional[Mapping[str, Dependency]] = None,
     ) -> None:
         if type(schema).__name__ != "str":
             raise IllegalArgumentException("Non str type of schema string")

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -59,7 +59,6 @@ def parse_jsonschema_definition(schema_definition: str) -> Draft7Validator:
 
 def parse_protobuf_schema_definition(
     schema_definition: str,
-    references: Sequence[Reference] | None = None,
     dependencies: Mapping[str, Dependency] | None = None,
     validate_references: bool = True,
 ) -> ProtobufSchema:
@@ -69,7 +68,7 @@ def parse_protobuf_schema_definition(
         ProtobufUnresolvedDependencyException if Protobuf dependency cannot be resolved.
 
     """
-    protobuf_schema = ProtobufSchema(schema_definition, references, dependencies)
+    protobuf_schema = ProtobufSchema(schema_definition, dependencies)
     if validate_references:
         result = protobuf_schema.verify_schema_dependencies()
         if not result.result:
@@ -132,7 +131,7 @@ class TypedSchema:
                 schema_str = str(schema)
             else:
                 try:
-                    schema_str = str(parse_protobuf_schema_definition(schema_str, None, None, False))
+                    schema_str = str(parse_protobuf_schema_definition(schema_str, None, False))
                 except InvalidSchema as e:
                     LOG.exception("Schema is not valid ProtoBuf definition")
                     raise e
@@ -199,7 +198,7 @@ def parse(
 
     elif schema_type is SchemaType.PROTOBUF:
         try:
-            parsed_schema = parse_protobuf_schema_definition(schema_str, references, dependencies)
+            parsed_schema = parse_protobuf_schema_definition(schema_str, dependencies)
         except (
             TypeError,
             SchemaError,

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -483,12 +483,7 @@ class KafkaSchemaReader(Thread):
                 if schema_references:
                     candidate_references = [reference_from_mapping(reference_data) for reference_data in schema_references]
                     resolved_references, resolved_dependencies = self.resolve_references(candidate_references)
-                parsed_schema = parse_protobuf_schema_definition(
-                    schema_str,
-                    resolved_references,
-                    resolved_dependencies,
-                    validate_references=False,
-                )
+                parsed_schema = parse_protobuf_schema_definition(schema_str, resolved_dependencies, False)
                 schema_str = str(parsed_schema)
             except InvalidSchema:
                 LOG.exception("Schema is not valid ProtoBuf definition")

--- a/karapace/schema_references.py
+++ b/karapace/schema_references.py
@@ -7,9 +7,9 @@ See LICENSE for details
 
 from __future__ import annotations
 
+from karapace.dataclasses import default_dataclass
 from karapace.typing import JsonData, ResolvedVersion, SchemaId, Subject
 from typing import List, Mapping, NewType, TypeVar
-from typing_extensions import Self
 
 Referents = NewType("Referents", List[SchemaId])
 
@@ -28,16 +28,31 @@ def _read_typed(
     return value
 
 
+# Represents a reference with an alias to latest version, where the version has
+# not yet been determined. Representing this as a separate entity gives us nice
+# static type checking semantics, and means we cannot pass an unresolved object
+# where a resolved one is expected.
+@default_dataclass
+class LatestVersionReference:
+    name: str
+    subject: Subject
+
+    def resolve(self, version: ResolvedVersion) -> Reference:
+        return Reference(
+            name=self.name,
+            subject=self.subject,
+            version=version,
+        )
+
+
+@default_dataclass
 class Reference:
-    def __init__(
-        self,
-        name: str,
-        subject: Subject,
-        version: ResolvedVersion,
-    ) -> None:
-        self.name = name
-        self.subject = subject
-        self.version = version
+    name: str
+    subject: Subject
+    version: ResolvedVersion
+
+    def __post_init__(self) -> None:
+        assert self.version != -1
 
     def to_dict(self) -> JsonData:
         return {
@@ -46,21 +61,23 @@ class Reference:
             "version": self.version,
         }
 
-    @classmethod
-    def from_mapping(cls, data: Mapping[str, object]) -> Self:
-        return cls(
-            name=_read_typed(data, "name", str),
-            subject=Subject(_read_typed(data, "subject", str)),
-            version=ResolvedVersion(_read_typed(data, "version", int)),
+
+def reference_from_mapping(
+    data: Mapping[str, object],
+) -> Reference | LatestVersionReference:
+    name = _read_typed(data, "name", str)
+    subject = Subject(_read_typed(data, "subject", str))
+    version = _read_typed(data, "version", int)
+    return (
+        LatestVersionReference(
+            name=name,
+            subject=subject,
         )
-
-    def __repr__(self) -> str:
-        return f"{{name='{self.name}', subject='{self.subject}', version={self.version}}}"
-
-    def __hash__(self) -> int:
-        return hash((self.name, self.subject, self.version))
-
-    def __eq__(self, other: object) -> bool:
-        if other is None or not isinstance(other, Reference):
-            return False
-        return self.name == other.name and self.subject == other.subject and self.version == other.version
+        # -1 is alias to latest version
+        if version == -1
+        else Reference(
+            name=name,
+            subject=subject,
+            version=ResolvedVersion(version),
+        )
+    )

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -307,11 +307,20 @@ class KarapaceSchemaRegistry:
             return list(referenced_by)
         return []
 
+    def _resolve_and_parse(self, schema: TypedSchema) -> ParsedTypedSchema:
+        references, dependencies = self.resolve_references(schema.references) if schema.references else (None, None)
+        return ParsedTypedSchema.parse(
+            schema_type=schema.schema_type,
+            schema_str=schema.schema_str,
+            references=references,
+            dependencies=dependencies,
+        )
+
     async def write_new_schema_local(
         self,
         subject: Subject,
         new_schema: ValidatedTypedSchema,
-        new_schema_references: list[Reference] | None,
+        new_schema_references: Sequence[Reference] | None,
     ) -> int:
         """Write new schema and return new id or return id of matching existing schema
 
@@ -319,7 +328,7 @@ class KarapaceSchemaRegistry:
         """
         LOG.info("Writing new schema locally since we're the master")
         async with self.schema_lock:
-            # When waiting for lock an another writer may have written the schema.
+            # When waiting for a lock, another writer may have written the schema.
             # Fast path check for resolving.
             maybe_schema_id = self.database.get_schema_id_if_exists(
                 subject=subject, schema=new_schema, include_deleted=False
@@ -380,17 +389,7 @@ class KarapaceSchemaRegistry:
                     check_against = [schema_versions[-1]]
 
                 for old_version in check_against:
-                    old_schema = all_schema_versions[old_version].schema
-                    old_schema_dependencies: dict[str, Dependency] | None = None
-                    old_schema_references: list[Reference] | None = old_schema.references
-                    if old_schema_references:
-                        old_schema_dependencies = self.resolve_references(old_schema_references)
-                    parsed_old_schema = ParsedTypedSchema.parse(
-                        schema_type=old_schema.schema_type,
-                        schema_str=old_schema.schema_str,
-                        references=old_schema_references,
-                        dependencies=old_schema_dependencies,
-                    )
+                    parsed_old_schema = self._resolve_and_parse(all_schema_versions[old_version].schema)
                     result = check_compatibility(
                         old_schema=parsed_old_schema,
                         new_schema=new_schema,
@@ -449,7 +448,7 @@ class KarapaceSchemaRegistry:
         schema_id: int,
         version: int,
         deleted: bool,
-        references: list[Reference] | None,
+        references: Sequence[Reference] | None,
     ) -> None:
         key = {"subject": subject, "version": version, "magic": 1, "keytype": "SCHEMA"}
         if schema:
@@ -480,10 +479,8 @@ class KarapaceSchemaRegistry:
     def resolve_references(
         self,
         references: Sequence[Reference] | Sequence[JsonObject] | None,
-    ) -> dict[str, Dependency] | None:
-        if references:
-            return self.schema_reader.resolve_references(references)
-        return None
+    ) -> tuple[Sequence[Reference], dict[str, Dependency]] | tuple[None, None]:
+        return self.schema_reader.resolve_references(references) if references else (None, None)
 
     def send_delete_subject_message(self, subject: Subject, version: ResolvedVersion) -> None:
         key = {"subject": subject, "magic": 0, "keytype": "DELETE_SUBJECT"}

--- a/mypy.ini
+++ b/mypy.ini
@@ -43,9 +43,6 @@ ignore_errors = True
 [mypy-karapace.protobuf.encoding_variants]
 ignore_errors = True
 
-[mypy-karapace.protobuf.schema]
-ignore_errors = True
-
 [mypy-karapace.protobuf.extensions_element]
 ignore_errors = True
 
@@ -65,9 +62,6 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-karapace.protobuf.enum_constant_element]
-ignore_errors = True
-
-[mypy-karapace.protobuf.location]
 ignore_errors = True
 
 [mypy-karapace.protobuf.message_element]


### PR DESCRIPTION
The main goal is to increase type coverage.

The `Location` class is turned into a dataclass to simplify things and gain immutability. It's `.get()` method needs an overload to type accurately, even after simplifying its signature by raising instead of returning `None` when incorrect amount of arguments are given. This was addressed as a side-quest in adding types to `ProtobufSchema`, because it has an attribute that is assigned to from the return value of this method.

The `ProtoFileElement.__eq__()` is altered so that it doesn't assume the compared object is of the same type as itself, and its argument is updated to follow convention of supporting equality check with any other type of object.

`ProtobufSchema.dirty` is removed because it was unused.

`ProtobufSchema.references` along with its init argument are removed because they aren't used. This triggers a chain of removing unused arguments in a few functions.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
