### PR TITLE
fix: Broken protobuf varint functions, add tests

### DIFF
--- a/karapace/protobuf/io.py
+++ b/karapace/protobuf/io.py
@@ -3,7 +3,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from io import BytesIO
-from karapace.protobuf.encoding_variants import read_indexes, write_indexes
+from karapace.protobuf.varint import read_indexes, write_indexes
 from karapace.protobuf.exception import IllegalArgumentException, ProtobufSchemaResolutionException, ProtobufTypeException
 from karapace.protobuf.message_element import MessageElement
 from karapace.protobuf.protobuf_to_dict import dict_to_protobuf, protobuf_to_dict

--- a/tests/unit/protobuf/test_varint.py
+++ b/tests/unit/protobuf/test_varint.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import io
+from hypothesis import given, example
+from hypothesis.strategies import integers, lists
+
+from karapace.protobuf.varint import write_varint, read_varint, read_indexes, \
+    write_indexes
+
+varint_values = integers(min_value=0)
+
+
+@given(varint_values)
+@example(0)
+@example(1)
+def test_can_roundtrip_varint(value: int) -> None:
+    with io.BytesIO() as buffer:
+        write_varint(buffer, value)
+        buffer.seek(0)
+        result = read_varint(buffer)
+        assert result == value
+        # Assert buffer is exhausted.
+        assert buffer.read(1) == b""
+
+
+@given(lists(elements=varint_values))
+@example([])
+@example([1, 2, 3])
+def test_can_roundtrip_indexes(value: list[int]) -> None:
+    with io.BytesIO() as buffer:
+        write_indexes(buffer, value)
+        buffer.seek(0)
+        result = read_indexes(buffer)
+        assert result == value
+        # Assert buffer is exhausted.
+        assert buffer.read(1) == b""


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

Fixes #651. I have only looked at the functions locally. I'll leave this in draft until further investigation into why the code that relies on these broken fundamentals is not itself broken. There's a possibility these paths are never exercised, in which case a better course of action is to prune the code.

- Adds round-trip hypothesis tests for `read_indexes` + `write_indexes`.
- Adds round-trip hypothesis tests for `read_varint` + `write_varint`.

Both these tests fails without patching the functions.

- `write_varint` was seemingly entirely broken. Replace `bytearray` casting with `.to_bytes()` invocation.
- `read_indexes` expects first value to be size of array, adjust `write_indexes` to write length before writing values.
- `read_indexes` special-cased `size == 0` for no apparent reason, this is removed as it looks broken and doesn't have symmetry in `write_indexes`.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

