### PR TITLE
Add support for '-1' as version

### DIFF
--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -54,6 +54,8 @@ def _resolve_version(
 def validate_version(version: Version) -> Version:
     try:
         version_number = int(version)
+        if version_number == -1:
+            return "latest"
         if version_number > 0:
             return version
         raise InvalidVersion(f"Invalid version {version_number}")

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -43,6 +43,8 @@ def _resolve_version(
     version: Version,
 ) -> ResolvedVersion:
     max_version = max(schema_versions)
+    if version == "-1":
+        return max_version
     if isinstance(version, str) and version == "latest":
         return max_version
     resolved_version = ResolvedVersion(int(version))


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This allows adding '-1' as the version just like 'latest'.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #668

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
This seems like the quickest way to add support for the '-1'