### PR TITLE
fix: respect nested runtime/.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,3 @@ venv
 .python-version
 .hypothesis/
 .DS_Store
-# ignoring protobuf generated files.
-runtime/


### PR DESCRIPTION
### About this change - What it does

#681 added an additional `.gitignore` line for the `runtime/` directory, however, this directory already has a [nested .gitignore](https://github.com/Aiven-Open/karapace/blob/main/runtime/.gitignore).

### Why this way

I think it might be preferable to keep the current nested .gitignore, as otherwise there's nothing stopping removing the `runtime/` directory. 