### PR TITLE
fix(rest:offsets): prevent `not_leader_for_partition` error [HH-2464]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ venv
 .python-version
 .hypothesis/
 .DS_Store
+# ignoring protobuf generated files.
+runtime/

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,3 @@ venv
 .python-version
 .hypothesis/
 .DS_Store
-# ignoring protobuf generated files.
-runtime/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv
 .run
 .python-version
 .hypothesis/
+.DS_Store

--- a/karapace/avro_dataclasses/models.py
+++ b/karapace/avro_dataclasses/models.py
@@ -68,7 +68,7 @@ def optional_parser(parser: Parser | None) -> Parser | None:
         return None
 
     def parse(value: object) -> object:
-        return None if value is None else parser(value)  # type: ignore[misc]
+        return None if value is None else parser(value)
 
     return parse
 

--- a/karapace/client.py
+++ b/karapace/client.py
@@ -90,6 +90,7 @@ class Client:
         json: JsonData = None,
         headers: Optional[Headers] = None,
         auth: Optional[BasicAuth] = None,
+        params: Optional[Mapping[str, str]] = None,
     ) -> Result:
         path = self.path_for(path)
         if not headers:
@@ -101,6 +102,7 @@ class Client:
             headers=headers,
             auth=auth,
             ssl=self.ssl_mode,
+            params=params,
         ) as res:
             # required for forcing the response body conversion to json despite missing valid Accept headers
             json_result = await res.json(content_type=None)

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -810,7 +810,8 @@ class UserRestProxy:
         for record in data["records"]:
             key = record.get("key")
             value = record.get("value")
-            key = await self.serialize(content_type, key, ser_format, key_schema_id)
+            if key is not None:
+                key = await self.serialize(content_type, key, ser_format, key_schema_id)
             value = await self.serialize(content_type, value, ser_format, value_schema_id)
             prepared_records.append((key, value, record.get("partition", default_partition)))
         return prepared_records

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -17,12 +17,15 @@ from karapace.errors import InvalidSchema
 from karapace.kafka_rest_apis.admin import KafkaRestAdminClient
 from karapace.kafka_rest_apis.consumer_manager import ConsumerManager
 from karapace.kafka_rest_apis.error_codes import RESTErrorCodes
+from karapace.kafka_rest_apis.schema_cache import TopicSchemaCache
 from karapace.karapace import KarapaceBase
 from karapace.rapu import HTTPRequest, HTTPResponse, JSON_CONTENT_TYPE
-from karapace.schema_reader import SchemaType
+from karapace.schema_models import TypedSchema, ValidatedTypedSchema
+from karapace.schema_type import SchemaType
 from karapace.serialization import InvalidMessageSchema, InvalidPayload, SchemaRegistrySerializer, SchemaRetrievalError
+from karapace.typing import SchemaId, Subject
 from karapace.utils import convert_to_int, json_encode, KarapaceKafkaClient
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import aiohttp.web
 import asyncio
@@ -416,7 +419,7 @@ class UserRestProxy:
         self.admin_client = None
         self.admin_lock = asyncio.Lock()
         self.metadata_cache = None
-        self.schemas_cache = {}
+        self.topic_schema_cache = TopicSchemaCache()
         self.consumer_manager = ConsumerManager(config=config, deserializer=self.serializer)
         self.init_admin_client()
         self._last_used = time.monotonic()
@@ -739,18 +742,83 @@ class UserRestProxy:
                 return False
         return isinstance(schema, str)
 
-    async def get_schema_id(self, data: dict, topic: str, prefix: str, schema_type: SchemaType) -> int:
-        log.debug("Retrieving schema id for %r", data)
-        if f"{prefix}_schema_id" in data and data[f"{prefix}_schema_id"] is not None:
-            log.debug("Will use schema id %d for serializing %s on topic %s", data[f"{prefix}_schema_id"], prefix, topic)
-            return int(data[f"{prefix}_schema_id"])
-        schema_str = data[f"{prefix}_schema"]
-        log.debug("Registering / Retrieving ID for schema %s", schema_str)
-        if schema_str not in self.schemas_cache:
-            subject_name = self.serializer.get_subject_name(topic, data[f"{prefix}_schema"], prefix, schema_type)
-            schema_id = await self.serializer.get_id_for_schema(data[f"{prefix}_schema"], subject_name, schema_type)
-            self.schemas_cache[schema_str] = schema_id
-        return self.schemas_cache[schema_str]
+    async def get_schema_id(
+        self,
+        data: dict,
+        topic: str,
+        prefix: str,
+        schema_type: SchemaType,
+    ) -> SchemaId:
+        """
+        This method search and validate the SchemaId for a request, it acts as a guard (In case of something wrong
+        throws an error).
+
+        :raises InvalidSchema:
+        """
+        log.debug("[resolve schema id] Retrieving schema id for %r", data)
+        schema_id: Union[SchemaId, None] = (
+            SchemaId(int(data[f"{prefix}_schema_id"])) if f"{prefix}_schema_id" in data else None
+        )
+        schema_str = data.get(f"{prefix}_schema")
+
+        if schema_id is None and schema_str is None:
+            raise InvalidSchema()
+
+        if schema_id is None:
+            parsed_schema = ValidatedTypedSchema.parse(schema_type, schema_str)
+            subject_name = self.serializer.get_subject_name(topic, parsed_schema, prefix, schema_type)
+            schema_id = await self._query_schema_id_from_cache_or_registry(parsed_schema, schema_str, subject_name)
+        else:
+
+            def subject_not_included(schema: TypedSchema, subjects: List[Subject]) -> bool:
+                subject = self.serializer.get_subject_name(topic, schema, prefix, schema_type)
+                return subject not in subjects
+
+            parsed_schema, valid_subjects = await self._query_schema_and_subjects(
+                schema_id,
+                need_new_call=subject_not_included,
+            )
+
+            if subject_not_included(parsed_schema, valid_subjects):
+                raise InvalidSchema()
+
+        return schema_id
+
+    async def _query_schema_and_subjects(
+        self, schema_id: SchemaId, *, need_new_call: Optional[Callable[[TypedSchema, List[Subject]], bool]]
+    ) -> Tuple[TypedSchema, List[Subject]]:
+        try:
+            return await self.serializer.get_schema_for_id(schema_id, need_new_call=need_new_call)
+        except SchemaRetrievalError as schema_error:
+            # if the schema doesn't exist we treated as if the error was due to an invalid schema
+            raise InvalidSchema() from schema_error
+
+    async def _query_schema_id_from_cache_or_registry(
+        self,
+        parsed_schema: ValidatedTypedSchema,
+        schema_str: str,
+        subject_name: Subject,
+    ) -> SchemaId:
+        """
+        Checks if the schema registered with a certain id match with the schema provided (you can provide
+        a valid id but place in the body a totally unrelated schema).
+        Also, here if we don't have a match we query the registry  since the cache could be evicted in the meanwhile
+        or the schema could be registered without passing though the http proxy.
+        """
+        schema_id = self.topic_schema_cache.get_schema_id(subject_name, parsed_schema)
+        if schema_id is None:
+            log.debug("[resolve schema id] Registering / Retrieving ID for %s and schema %s", subject_name, schema_str)
+            schema_id = await self.serializer.upsert_id_for_schema(parsed_schema, subject_name)
+            log.debug("[resolve schema id] Found schema id %s from registry for subject %s", schema_id, subject_name)
+            self.topic_schema_cache.set_schema(subject_name, schema_id, parsed_schema)
+        else:
+            log.debug(
+                "[resolve schema id] schema ID %s found from cache for %s and schema %s",
+                schema_id,
+                subject_name,
+                schema_str,
+            )
+        return schema_id
 
     async def validate_schema_info(self, data: dict, prefix: str, content_type: str, topic: str, schema_type: str):
         try:
@@ -788,10 +856,14 @@ class UserRestProxy:
                 status=HTTPStatus.REQUEST_TIMEOUT,
             )
         except InvalidSchema:
+            if f"{prefix}_schema" in data:
+                err = f'schema = {data[f"{prefix}_schema"]}'
+            else:
+                err = f'schema_id = {data[f"{prefix}_schema_id"]}'
             KafkaRest.r(
                 body={
                     "error_code": RESTErrorCodes.INVALID_DATA.value,
-                    "message": f'Invalid schema. format = {schema_type.value}, schema = {data[f"{prefix}_schema"]}',
+                    "message": f"Invalid schema. format = {schema_type.value}, {err}",
                 },
                 content_type=content_type,
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
@@ -882,7 +954,7 @@ class UserRestProxy:
         raise FormatError(f"Unknown format: {ser_format}")
 
     async def schema_serialize(self, obj: dict, schema_id: Optional[int]) -> bytes:
-        schema = await self.serializer.get_schema_for_id(schema_id)
+        schema, _ = await self.serializer.get_schema_for_id(schema_id)
         bytes_ = await self.serializer.serialize(schema, obj)
         return bytes_
 

--- a/karapace/kafka_rest_apis/admin.py
+++ b/karapace/kafka_rest_apis/admin.py
@@ -37,8 +37,8 @@ class KafkaRestAdminClient(KafkaAdminClient):
             topic_config[name] = val
         return topic_config
 
-    def new_topic(self, name: str) -> None:
-        self.create_topics([NewTopic(name, 1, 1)])
+    def new_topic(self, name: str, *, num_partitions: int = 1, replication_factor: int = 1) -> None:
+        self.create_topics([NewTopic(name, num_partitions, replication_factor)])
 
     def cluster_metadata(self, topics: list[str] | None = None, retries: int = 0) -> dict:
         """Fetch cluster metadata and topic information for given topics or all topics if not given."""

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -526,6 +526,7 @@ class ConsumerManager:
                         "topic": tp.topic,
                         "partition": tp.partition,
                         "offset": msg.offset,
+                        "timestamp": msg.timestamp,
                         "key": key,
                         "value": value,
                     }

--- a/karapace/kafka_rest_apis/schema_cache.py
+++ b/karapace/kafka_rest_apis/schema_cache.py
@@ -1,0 +1,107 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+from abc import ABC, abstractmethod
+from cachetools import TTLCache
+from karapace.schema_models import TypedSchema
+from karapace.typing import SchemaId, Subject
+from typing import Dict, Final, MutableMapping, Optional
+
+import hashlib
+
+
+class SchemaCacheProtocol(ABC):
+    @abstractmethod
+    def get_schema_id(self, schema: TypedSchema) -> Optional[SchemaId]:
+        pass
+
+    @abstractmethod
+    def has_schema_id(self, schema_id: SchemaId) -> bool:
+        pass
+
+    @abstractmethod
+    def set_schema(self, schema_id: SchemaId, schema: TypedSchema) -> None:
+        pass
+
+    @abstractmethod
+    def get_schema(self, schema_id: SchemaId) -> Optional[TypedSchema]:
+        pass
+
+    @abstractmethod
+    def get_schema_str(self, schema_id: SchemaId) -> Optional[str]:
+        pass
+
+
+class TopicSchemaCache:
+    def __init__(self) -> None:
+        self._topic_cache: Dict[Subject, SchemaCache] = {}
+        self._empty_schema_cache: Final = EmptySchemaCache()
+
+    def get_schema_id(self, topic: Subject, schema: TypedSchema) -> Optional[SchemaId]:
+        return self._topic_cache.get(topic, self._empty_schema_cache).get_schema_id(schema)
+
+    def has_schema_id(self, topic: Subject, schema_id: SchemaId) -> bool:
+        return self._topic_cache.get(topic, self._empty_schema_cache).has_schema_id(schema_id)
+
+    def set_schema(self, topic: str, schema_id: SchemaId, schema: TypedSchema) -> None:
+        schema_cache_with_defaults = self._topic_cache.setdefault(Subject(topic), SchemaCache())
+        schema_cache_with_defaults.set_schema(schema_id, schema)
+
+    def get_schema(self, topic: Subject, schema_id: SchemaId) -> Optional[TypedSchema]:
+        schema_cache = self._topic_cache.get(topic, self._empty_schema_cache)
+        return schema_cache.get_schema(schema_id)
+
+    def get_schema_str(self, topic: Subject, schema_id: SchemaId) -> Optional[str]:
+        schema_cache = self._topic_cache.get(topic, self._empty_schema_cache)
+        return schema_cache.get_schema_str(schema_id)
+
+
+class SchemaCache(SchemaCacheProtocol):
+    def __init__(self) -> None:
+        self._schema_hash_str_to_id: Dict[str, SchemaId] = {}
+        self._id_to_schema_str: MutableMapping[SchemaId, TypedSchema] = TTLCache(maxsize=10000, ttl=600)
+
+    def get_schema_id(self, schema: TypedSchema) -> Optional[SchemaId]:
+        fingerprint = hashlib.sha1(str(schema).encode("utf8")).hexdigest()
+
+        maybe_id = self._schema_hash_str_to_id.get(fingerprint)
+
+        if maybe_id is not None and maybe_id not in self._id_to_schema_str:
+            del self._schema_hash_str_to_id[fingerprint]
+            return None
+
+        return maybe_id
+
+    def has_schema_id(self, schema_id: SchemaId) -> bool:
+        return schema_id in self._id_to_schema_str
+
+    def set_schema(self, schema_id: SchemaId, schema: TypedSchema) -> None:
+        fingerprint = hashlib.sha1(str(schema).encode("utf8")).hexdigest()
+        self._schema_hash_str_to_id[fingerprint] = schema_id
+        self._id_to_schema_str[schema_id] = schema
+
+    def get_schema(self, schema_id: SchemaId) -> Optional[TypedSchema]:
+        return self._id_to_schema_str.get(schema_id)
+
+    def get_schema_str(self, schema_id: SchemaId) -> Optional[str]:
+        maybe_schema = self.get_schema(schema_id)
+        return None if maybe_schema is None else str(maybe_schema)
+
+
+class EmptySchemaCache(SchemaCacheProtocol):
+    def get_schema_id(self, schema: TypedSchema) -> None:
+        return None
+
+    def has_schema_id(self, schema_id: SchemaId) -> bool:
+        return False
+
+    def set_schema(self, schema_id: SchemaId, schema: TypedSchema) -> None:
+        raise NotImplementedError("Empty schema cache. Cannot set schemas.")
+
+    def get_schema(self, schema_id: SchemaId) -> None:
+        return None
+
+    def get_schema_str(self, schema_id: SchemaId) -> None:
+        return None

--- a/karapace/kafka_rest_apis/schema_cache.py
+++ b/karapace/kafka_rest_apis/schema_cache.py
@@ -61,7 +61,7 @@ class TopicSchemaCache:
 class SchemaCache(SchemaCacheProtocol):
     def __init__(self) -> None:
         self._schema_hash_str_to_id: Dict[str, SchemaId] = {}
-        self._id_to_schema_str: MutableMapping[SchemaId, TypedSchema] = TTLCache(maxsize=10000, ttl=600)
+        self._id_to_schema_str: MutableMapping[SchemaId, TypedSchema] = TTLCache(maxsize=100, ttl=600)
 
     def get_schema_id(self, schema: TypedSchema) -> Optional[SchemaId]:
         fingerprint = hashlib.sha1(str(schema).encode("utf8")).hexdigest()

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -164,7 +164,10 @@ class ProtobufSchema:
 
         if isinstance(element_type, MessageElement):
             for one_of in element_type.one_ofs:
-                process_one_of(verifier, package_name, parent_name, one_of)
+                # The parent name for nested one of fields is the parent and element type name.
+                # The field type name is handled in process_one_of function.
+                one_of_parent_name = parent_name + "." + element_type.name
+                process_one_of(verifier, package_name, one_of_parent_name, one_of)
             for field in element_type.fields:
                 verifier.add_used_type(parent_name, field.element_type)
         for nested_type in element_type.nested_types:

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -131,7 +131,7 @@ class ProtobufSchema:
     def collect_dependencies(self, verifier: ProtobufDependencyVerifier) -> None:
         if self.dependencies:
             for key in self.dependencies:
-                self.dependencies[key].schema.schema.collect_dependencies(verifier)
+                self.dependencies[key].get_schema().schema.collect_dependencies(verifier)
 
         for i in self.proto_file_element.imports:
             verifier.add_import(i)

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -18,7 +18,7 @@ from karapace.protobuf.proto_parser import ProtoParser
 from karapace.protobuf.type_element import TypeElement
 from karapace.protobuf.utils import append_documentation, append_indented
 from karapace.schema_references import Reference
-from typing import Dict, List, Optional
+from typing import Mapping, Optional, Sequence
 
 
 def add_slashes(text: str) -> str:
@@ -110,7 +110,10 @@ class ProtobufSchema:
     DEFAULT_LOCATION = Location("", "")
 
     def __init__(
-        self, schema: str, references: Optional[List[Reference]] = None, dependencies: Optional[Dict[str, Dependency]] = None
+        self,
+        schema: str,
+        references: Optional[Sequence[Reference]] = None,
+        dependencies: Optional[Mapping[str, Dependency]] = None,
     ) -> None:
         if type(schema).__name__ != "str":
             raise IllegalArgumentException("Non str type of schema string")

--- a/karapace/schema_references.py
+++ b/karapace/schema_references.py
@@ -7,9 +7,9 @@ See LICENSE for details
 
 from __future__ import annotations
 
+from karapace.dataclasses import default_dataclass
 from karapace.typing import JsonData, ResolvedVersion, SchemaId, Subject
 from typing import List, Mapping, NewType, TypeVar
-from typing_extensions import Self
 
 Referents = NewType("Referents", List[SchemaId])
 
@@ -28,16 +28,34 @@ def _read_typed(
     return value
 
 
+# Represents a reference with an alias to latest version, where the version has
+# not yet been determined. Representing this as a separate entity gives us nice
+# static type checking semantics, and means we cannot pass an unresolved object
+# where a resolved one is expected.
+@default_dataclass
+class LatestVersionReference:
+    name: str
+    subject: Subject
+
+    def resolve(self, version: ResolvedVersion) -> Reference:
+        return Reference(
+            name=self.name,
+            subject=self.subject,
+            version=version,
+        )
+
+
+@default_dataclass
 class Reference:
-    def __init__(
-        self,
-        name: str,
-        subject: Subject,
-        version: ResolvedVersion,
-    ) -> None:
-        self.name = name
-        self.subject = subject
-        self.version = version
+    name: str
+    subject: Subject
+    version: ResolvedVersion
+
+    def __post_init__(self) -> None:
+        assert self.version != -1
+
+    def __repr__(self) -> str:
+        return f"{{name='{self.name}', subject='{self.subject}', version={self.version}}}"
 
     def to_dict(self) -> JsonData:
         return {
@@ -46,21 +64,23 @@ class Reference:
             "version": self.version,
         }
 
-    @classmethod
-    def from_mapping(cls, data: Mapping[str, object]) -> Self:
-        return cls(
-            name=_read_typed(data, "name", str),
-            subject=Subject(_read_typed(data, "subject", str)),
-            version=ResolvedVersion(_read_typed(data, "version", int)),
+
+def reference_from_mapping(
+    data: Mapping[str, object],
+) -> Reference | LatestVersionReference:
+    name = _read_typed(data, "name", str)
+    subject = Subject(_read_typed(data, "subject", str))
+    version = _read_typed(data, "version", int)
+    return (
+        LatestVersionReference(
+            name=name,
+            subject=subject,
         )
-
-    def __repr__(self) -> str:
-        return f"{{name='{self.name}', subject='{self.subject}', version={self.version}}}"
-
-    def __hash__(self) -> int:
-        return hash((self.name, self.subject, self.version))
-
-    def __eq__(self, other: object) -> bool:
-        if other is None or not isinstance(other, Reference):
-            return False
-        return self.name == other.name and self.subject == other.subject and self.version == other.version
+        # -1 is alias to latest version
+        if version == -1
+        else Reference(
+            name=name,
+            subject=subject,
+            version=ResolvedVersion(version),
+        )
+    )

--- a/karapace/schema_references.py
+++ b/karapace/schema_references.py
@@ -8,11 +8,10 @@ See LICENSE for details
 from __future__ import annotations
 
 from karapace.dataclasses import default_dataclass
-from karapace.typing import JsonData, ResolvedVersion, SchemaId, Subject
-from typing import List, Mapping, NewType, TypeVar
+from karapace.typing import JsonData, JsonObject, ResolvedVersion, SchemaId, Subject
+from typing import cast, List, Mapping, NewType, TypeVar
 
 Referents = NewType("Referents", List[SchemaId])
-
 
 T = TypeVar("T")
 
@@ -63,6 +62,14 @@ class Reference:
             "subject": self.subject,
             "version": self.version,
         }
+
+    @staticmethod
+    def from_dict(data: JsonObject) -> Reference:
+        return Reference(
+            name=str(data["name"]),
+            subject=Subject(str(data["subject"])),
+            version=ResolvedVersion(cast(int, data["version"])),
+        )
 
 
 def reference_from_mapping(

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -339,7 +339,7 @@ class KarapaceSchemaRegistry:
 
             all_schema_versions = self.database.find_subject_schemas(subject=subject, include_deleted=True)
             if not all_schema_versions:
-                version = 1
+                version = ResolvedVersion(1)
                 schema_id = self.database.get_schema_id(new_schema)
                 LOG.debug(
                     "Registering new subject: %r, id: %r with version: %r with schema %r, schema_id: %r",
@@ -407,7 +407,6 @@ class KarapaceSchemaRegistry:
                 # We didn't find an existing schema and the schema is compatible so go and create one
                 version = self.database.get_next_version(subject=subject)
                 schema_id = self.database.get_schema_id(new_schema)
-
                 LOG.debug(
                     "Registering subject: %r, id: %r new version: %r with schema %s, schema_id: %r",
                     subject,

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -32,7 +32,7 @@ from karapace.karapace import KarapaceBase
 from karapace.protobuf.exception import ProtobufUnresolvedDependencyException
 from karapace.rapu import HTTPRequest, JSON_CONTENT_TYPE, SERVER_NAME
 from karapace.schema_models import ParsedTypedSchema, SchemaType, SchemaVersion, TypedSchema, ValidatedTypedSchema
-from karapace.schema_references import Reference
+from karapace.schema_references import LatestVersionReference, Reference, reference_from_mapping
 from karapace.schema_registry import KarapaceSchemaRegistry, validate_version
 from karapace.typing import JsonData, JsonObject, ResolvedVersion, SchemaId
 from karapace.utils import JSONDecodeError
@@ -77,13 +77,6 @@ class SchemaErrorMessages(Enum):
     )
     SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT = "Subject '%s' does not have subject-level compatibility configured"
     REFERENCES_SUPPORT_NOT_IMPLEMENTED = "Schema references are not supported for '{schema_type}' schema type"
-
-
-def references_list(references: dict | None) -> list[Reference] | None:
-    _references: list[Reference] | None = None
-    if references:
-        _references = [Reference(reference["name"], reference["subject"], reference["version"]) for reference in references]
-    return _references
 
 
 class KarapaceSchemaRegistryController(KarapaceBase):
@@ -368,7 +361,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         schema_type = self._validate_schema_type(content_type=content_type, data=body)
         references = self._validate_references(content_type, schema_type, body)
         try:
-            new_schema_dependencies = self.schema_registry.resolve_references(references)
+            references, new_schema_dependencies = self.schema_registry.resolve_references(references)
             new_schema = ValidatedTypedSchema.parse(
                 schema_type=schema_type,
                 schema_str=body["schema"],
@@ -402,7 +395,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             old_references = old.get("references", None)
             old_dependencies = None
             if old_references:
-                old_dependencies = self.schema_registry.resolve_references(old_references)
+                old_references, old_dependencies = self.schema_registry.resolve_references(old_references)
             old_schema = ParsedTypedSchema.parse(old_schema_type, old["schema"], old_references, old_dependencies)
         except InvalidSchema:
             self.r(
@@ -996,7 +989,12 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 
-    def _validate_references(self, content_type: str, schema_type: SchemaType, body: JsonData) -> list[Reference] | None:
+    def _validate_references(
+        self,
+        content_type: str,
+        schema_type: SchemaType,
+        body: JsonData,
+    ) -> list[Reference | LatestVersionReference] | None:
         references = body.get("references", [])
         # Allow passing `null` as value for compatibility
         if references is None:
@@ -1023,12 +1021,12 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             )
 
         validated_references = []
-        for reference in references:
-            if ["name", "subject", "version"] != sorted(reference.keys()):
-                raise InvalidReferences()
-            validated_references.append(
-                Reference(name=reference["name"], subject=reference["subject"], version=reference["version"])
-            )
+        for reference_data in references:
+            try:
+                reference = reference_from_mapping(reference_data)
+            except (TypeError, KeyError) as exc:
+                raise InvalidReferences from exc
+            validated_references.append(reference)
         if validated_references:
             return validated_references
         return None
@@ -1065,7 +1063,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         schema_str = body["schema"]
         schema_type = self._validate_schema_type(content_type=content_type, data=body)
         references = self._validate_references(content_type, schema_type, body)
-        new_schema_dependencies = self.schema_registry.resolve_references(references)
+        references, new_schema_dependencies = self.schema_registry.resolve_references(references)
         try:
             # When checking if schema is already registered, allow unvalidated schema in as
             # there might be stored schemas that are non-compliant from the past.
@@ -1159,7 +1157,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         references = self._validate_references(content_type, schema_type, body)
 
         try:
-            resolved_dependencies = self.schema_registry.resolve_references(references)
+            references, resolved_dependencies = self.schema_registry.resolve_references(references)
             new_schema = ValidatedTypedSchema.parse(
                 schema_type=schema_type,
                 schema_str=body["schema"],

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -865,7 +865,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 content_type=content_type,
                 status=HTTPStatus.NOT_FOUND,
             )
-        except SubjectNotFoundException:
+        except (SchemasNotFoundException, SubjectNotFoundException):
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,

--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -472,6 +472,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.NOT_FOUND,
             )
 
+        include_subjects = request.query.get("includeSubjects", "false").lower() == "true"
         fetch_max_id = request.query.get("fetchMaxId", "false").lower() == "true"
         schema = self.schema_registry.schemas_get(parsed_schema_id, fetch_max_id=fetch_max_id)
 
@@ -505,9 +506,11 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 status=HTTPStatus.NOT_FOUND,
             )
 
-        subjects = self.schema_registry.database.subjects_for_schema(parsed_schema_id)
+        response_body = {"schema": schema.schema_str}
 
-        response_body = {"schema": schema.schema_str, "subjects": subjects}
+        if include_subjects:
+            response_body["subjects"] = self.schema_registry.database.subjects_for_schema(parsed_schema_id)
+
         if schema.schema_type is not SchemaType.AVRO:
             response_body["schemaType"] = schema.schema_type
         if schema.references:

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -115,7 +115,7 @@ class SchemaRegistryClient:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
 
     async def get_schema_for_id(self, schema_id: SchemaId) -> Tuple[TypedSchema, List[Subject]]:
-        result = await self.client.get(f"schemas/ids/{schema_id}")
+        result = await self.client.get(f"schemas/ids/{schema_id}", params={"includeSubjects": "True"})
         if not result.ok:
             raise SchemaRetrievalError(result.json()["message"])
         json_result = result.json()

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -5,17 +5,19 @@ See LICENSE for details
 from aiohttp import BasicAuth
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
 from cachetools import TTLCache
+from functools import lru_cache
 from google.protobuf.message import DecodeError
 from jsonschema import ValidationError
 from karapace.client import Client
+from karapace.dependency import Dependency
 from karapace.errors import InvalidReferences
 from karapace.protobuf.exception import ProtobufTypeException
 from karapace.protobuf.io import ProtobufDatumReader, ProtobufDatumWriter
 from karapace.schema_models import InvalidSchema, ParsedTypedSchema, SchemaType, TypedSchema, ValidatedTypedSchema
-from karapace.schema_references import Reference, reference_from_mapping
-from karapace.typing import SchemaId, Subject
+from karapace.schema_references import LatestVersionReference, Reference, reference_from_mapping
+from karapace.typing import ResolvedVersion, SchemaId, Subject
 from karapace.utils import json_decode, json_encode
-from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Set, Tuple
 from urllib.parse import quote
 
 import asyncio
@@ -101,18 +103,78 @@ class SchemaRegistryClient:
             raise SchemaRetrievalError(result.json())
         return SchemaId(result.json()["id"])
 
-    async def get_latest_schema(self, subject: str) -> Tuple[SchemaId, ParsedTypedSchema]:
-        result = await self.client.get(f"subjects/{quote(subject)}/versions/latest")
+    async def _get_schema_r(
+        self,
+        subject: Subject,
+        explored_schemas: Set[Tuple[Subject, Optional[ResolvedVersion]]],
+        version: Optional[ResolvedVersion] = None,
+    ) -> Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]:
+        if (subject, version) in explored_schemas:
+            raise InvalidSchema(
+                f"The schema has at least a cycle in dependencies, "
+                f"one path of the cycle is given by the following nodes: {explored_schemas}"
+            )
+
+        explored_schemas = explored_schemas | {(subject, version)}
+
+        version_str = str(version) if version is not None else "latest"
+        result = await self.client.get(f"subjects/{quote(subject)}/versions/{version_str}")
+
         if not result.ok:
             raise SchemaRetrievalError(result.json())
+
         json_result = result.json()
-        if "id" not in json_result or "schema" not in json_result:
+        if "id" not in json_result or "schema" not in json_result or "version" not in json_result:
             raise SchemaRetrievalError(f"Invalid result format: {json_result}")
+
+        if "references" in json_result:
+            references = [Reference.from_dict(data) for data in json_result["references"]]
+            dependencies = {}
+            for reference in references:
+                _, schema, version = await self._get_schema_r(reference.subject, explored_schemas, reference.version)
+                dependencies[reference.name] = Dependency(
+                    name=reference.name, subject=reference.subject, version=version, target_schema=schema
+                )
+        else:
+            references = None
+            dependencies = None
+
         try:
             schema_type = SchemaType(json_result.get("schemaType", "AVRO"))
-            return SchemaId(json_result["id"]), ParsedTypedSchema.parse(schema_type, json_result["schema"])
+            return (
+                SchemaId(json_result["id"]),
+                ValidatedTypedSchema.parse(
+                    schema_type,
+                    json_result["schema"],
+                    references=references,
+                    dependencies=dependencies,
+                ),
+                ResolvedVersion(json_result["version"]),
+            )
         except InvalidSchema as e:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
+
+    @lru_cache(maxsize=100)
+    async def get_schema(
+        self,
+        subject: Subject,
+        version: Optional[ResolvedVersion] = None,
+    ) -> Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]:
+        """
+        Retrieves the schema and its dependencies for the specified subject.
+
+        Args:
+            subject (Subject): The subject for which to retrieve the schema.
+            version (Optional[ResolvedVersion]): The specific version of the schema to retrieve.
+                                                    If None, the latest available schema will be returned.
+
+        Returns:
+            Tuple[SchemaId, ValidatedTypedSchema, ResolvedVersion]: A tuple containing:
+                - SchemaId: The ID of the retrieved schema.
+                - ValidatedTypedSchema: The retrieved schema, validated and typed.
+                - ResolvedVersion: The version of the schema that was retrieved.
+        """
+        return await self._get_schema_r(subject, set(), version)
 
     async def get_schema_for_id(self, schema_id: SchemaId) -> Tuple[TypedSchema, List[Subject]]:
         result = await self.client.get(f"schemas/ids/{schema_id}", params={"includeSubjects": "True"})
@@ -138,15 +200,24 @@ class SchemaRegistryClient:
                         raise InvalidReferences from exc
                     parsed_references.append(reference)
             if parsed_references:
-                return (
-                    ParsedTypedSchema.parse(
-                        schema_type,
-                        json_result["schema"],
-                        references=parsed_references,
-                    ),
-                    subjects,
-                )
-            return ParsedTypedSchema.parse(schema_type, json_result["schema"]), subjects
+                dependencies = {}
+
+                for reference in parsed_references:
+                    if isinstance(reference, LatestVersionReference):
+                        _, schema, version = await self.get_schema(reference.subject)
+                    else:
+                        _, schema, version = await self.get_schema(reference.subject, reference.version)
+
+                    dependencies[reference.name] = Dependency(reference.name, reference.subject, version, schema)
+            else:
+                dependencies = None
+
+            return (
+                ParsedTypedSchema.parse(
+                    schema_type, json_result["schema"], references=parsed_references, dependencies=dependencies
+                ),
+                subjects,
+            )
         except InvalidSchema as e:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
 
@@ -204,9 +275,9 @@ class SchemaRegistrySerializer:
 
         return Subject(f"{self.subject_name_strategy(topic_name, namespace)}-{subject_type}")
 
-    async def get_schema_for_subject(self, subject: str) -> TypedSchema:
+    async def get_schema_for_subject(self, subject: Subject) -> TypedSchema:
         assert self.registry_client, "must not call this method after the object is closed."
-        schema_id, schema = await self.registry_client.get_latest_schema(subject)
+        schema_id, schema, _ = await self.registry_client.get_schema(subject)
         async with self.state_lock:
             schema_ser = str(schema)
             self.schemas_to_ids[schema_ser] = schema_id

--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -18,4 +18,7 @@ ArgJsonData: TypeAlias = Union[JsonScalar, ArgJsonObject, ArgJsonArray]
 Subject = NewType("Subject", str)
 Version = Union[int, str]
 ResolvedVersion = NewType("ResolvedVersion", int)
+# note: the SchemaID is a unique id among all the schemas (and each version should be assigned to a different id)
+# basically the same SchemaID refer always to the same TypedSchema.
 SchemaId = NewType("SchemaId", int)
+TopicName = NewType("TopicName", str)

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 accept-types==0.4.1
     # via -r requirements.txt
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via -r requirements.txt
 aiokafka==0.8.1
     # via -r requirements.txt
@@ -55,12 +55,6 @@ commonmark==0.9.1
     #   rich
 configargparse==1.5.3
     # via locust
-exceptiongroup==1.1.1
-    # via
-    #   -r requirements.txt
-    #   anyio
-    #   hypothesis
-    #   pytest
 execnet==1.9.0
     # via pytest-xdist
 fancycompleter==0.9.1
@@ -97,12 +91,6 @@ idna==3.4
     #   anyio
     #   requests
     #   yarl
-importlib-metadata==6.7.0
-    # via flask
-importlib-resources==5.12.0
-    # via
-    #   -r requirements.txt
-    #   jsonschema
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
@@ -139,10 +127,6 @@ packaging==23.1
     #   pytest
 pdbpp==0.10.3
     # via -r requirements-dev.in
-pkgutil-resolve-name==1.3.10
-    # via
-    #   -r requirements.txt
-    #   jsonschema
 pluggy==1.2.0
     # via pytest
 protobuf==3.20.3
@@ -200,13 +184,10 @@ sortedcontainers==2.4.0
     # via hypothesis
 tenacity==8.2.2
     # via -r requirements.txt
-tomli==2.0.1
-    # via pytest
 typing-extensions==4.6.3
     # via
     #   -r requirements.txt
     #   locust
-    #   rich
 ujson==5.8.0
     # via -r requirements.txt
 urllib3==2.0.3
@@ -227,11 +208,6 @@ yarl==1.9.2
     # via
     #   -r requirements.txt
     #   aiohttp
-zipp==3.15.0
-    # via
-    #   -r requirements.txt
-    #   importlib-metadata
-    #   importlib-resources
 zope-event==5.0
     # via gevent
 zope-interface==6.0

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -29,6 +29,7 @@ attrs==23.1.0
     #   aiohttp
     #   hypothesis
     #   jsonschema
+    #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via -r requirements.txt
 blinker==1.6.2
@@ -99,8 +100,12 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-jsonschema==4.17.3
+jsonschema==4.18.4
     # via -r requirements.txt
+jsonschema-specifications==2023.7.1
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
     # via
     #   -r requirements.txt
@@ -143,10 +148,6 @@ pygments==2.15.1
     #   rich
 pyrepl==0.9.0
     # via fancycompleter
-pyrsistent==0.19.3
-    # via
-    #   -r requirements.txt
-    #   jsonschema
 pytest==7.4.0
     # via
     #   -r requirements-dev.in
@@ -160,6 +161,11 @@ python-dateutil==2.8.2
     # via -r requirements.txt
 pyzmq==25.1.0
     # via locust
+referencing==0.30.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements-dev.in
@@ -168,6 +174,11 @@ rich==12.6.0
     # via -r requirements.txt
 roundrobin==0.0.4
     # via locust
+rpds-py==0.9.2
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   referencing
 sentry-sdk==1.26.0
     # via -r requirements-dev.in
 six==1.16.0

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,7 +8,7 @@ accept-types==0.4.1
     # via -r requirements.txt
 aiohttp==3.8.4
     # via -r requirements.txt
-aiokafka==0.8.0
+aiokafka==0.8.1
     # via -r requirements.txt
 aiosignal==1.3.1
     # via
@@ -35,6 +35,8 @@ blinker==1.6.2
     # via flask
 brotli==1.0.9
     # via geventhttpclient
+cachetools==5.2.0
+    # via -r requirements.txt
 certifi==2023.5.7
     # via
     #   geventhttpclient
@@ -53,11 +55,17 @@ commonmark==0.9.1
     #   rich
 configargparse==1.5.3
     # via locust
+exceptiongroup==1.1.1
+    # via
+    #   -r requirements.txt
+    #   anyio
+    #   hypothesis
+    #   pytest
 execnet==1.9.0
     # via pytest-xdist
 fancycompleter==0.9.1
     # via pdbpp
-filelock==3.12.0
+filelock==3.12.2
     # via -r requirements-dev.in
 flask==2.3.2
     # via
@@ -66,7 +74,7 @@ flask==2.3.2
     #   locust
 flask-basicauth==0.2.0
     # via locust
-flask-cors==3.0.10
+flask-cors==4.0.0
     # via locust
 frozenlist==1.3.3
     # via
@@ -81,7 +89,7 @@ geventhttpclient==2.0.9
     # via locust
 greenlet==2.0.2
     # via gevent
-hypothesis==6.75.7
+hypothesis==6.79.3
     # via -r requirements-dev.in
 idna==3.4
     # via
@@ -89,6 +97,12 @@ idna==3.4
     #   anyio
     #   requests
     #   yarl
+importlib-metadata==6.7.0
+    # via flask
+importlib-resources==5.12.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
@@ -105,7 +119,7 @@ kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066f
     #   aiokafka
 locust==2.15.1
     # via -r requirements-dev.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -125,7 +139,11 @@ packaging==23.1
     #   pytest
 pdbpp==0.10.3
     # via -r requirements-dev.in
-pluggy==1.0.0
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+pluggy==1.2.0
     # via pytest
 protobuf==3.20.3
     # via -r requirements.txt
@@ -145,7 +163,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r requirements-dev.in
     #   pytest-timeout
@@ -166,12 +184,11 @@ rich==12.5.1
     # via -r requirements.txt
 roundrobin==0.0.4
     # via locust
-sentry-sdk==1.24.0
+sentry-sdk==1.26.0
     # via -r requirements-dev.in
 six==1.16.0
     # via
     #   -r requirements.txt
-    #   flask-cors
     #   geventhttpclient
     #   isodate
     #   python-dateutil
@@ -183,19 +200,22 @@ sortedcontainers==2.4.0
     # via hypothesis
 tenacity==8.2.2
     # via -r requirements.txt
-typing-extensions==4.6.2
+tomli==2.0.1
+    # via pytest
+typing-extensions==4.6.3
     # via
     #   -r requirements.txt
     #   locust
-ujson==5.7.0
+    #   rich
+ujson==5.8.0
     # via -r requirements.txt
-urllib3==1.26.16
+urllib3==2.0.3
     # via
     #   requests
     #   sentry-sdk
 watchfiles==0.19.0
     # via -r requirements.txt
-werkzeug==2.3.4
+werkzeug==2.3.6
     # via
     #   flask
     #   locust
@@ -207,7 +227,12 @@ yarl==1.9.2
     # via
     #   -r requirements.txt
     #   aiohttp
-zope-event==4.6
+zipp==3.15.0
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata
+    #   importlib-resources
+zope-event==5.0
     # via gevent
 zope-interface==6.0
     # via gevent

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -37,7 +37,7 @@ brotli==1.0.9
     # via geventhttpclient
 cachetools==5.2.0
     # via -r requirements.txt
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   geventhttpclient
     #   requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -164,7 +164,7 @@ requests==2.31.0
     # via
     #   -r requirements-dev.in
     #   locust
-rich==12.5.1
+rich==12.6.0
     # via -r requirements.txt
 roundrobin==0.0.4
     # via locust

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -36,7 +36,7 @@ blinker==1.6.2
     # via flask
 brotli==1.0.9
     # via geventhttpclient
-cachetools==5.2.0
+cachetools==5.3.1
     # via -r requirements.txt
 certifi==2023.7.22
     # via

--- a/requirements/requirements-typing.in
+++ b/requirements/requirements-typing.in
@@ -4,3 +4,4 @@
 mypy
 types-jsonschema
 sentry-sdk
+types-cachetools

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -4,7 +4,7 @@
 #
 #    'make requirements'
 #
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   -c requirements-dev.txt
     #   sentry-sdk
@@ -13,11 +13,9 @@ mypy==1.4.1
 mypy-extensions==1.0.0
     # via mypy
 sentry-sdk==1.26.0
-    # via -r requirements-typing.in
-tomli==2.0.1
     # via
     #   -c requirements-dev.txt
-    #   mypy
+    #   -r requirements-typing.in
 types-cachetools==5.3.0.5
     # via -r requirements-typing.in
 types-jsonschema==4.17.0.8
@@ -25,6 +23,7 @@ types-jsonschema==4.17.0.8
 typing-extensions==4.6.3
     # via
     #   -c requirements-dev.txt
+    #   -c requirements.txt
     #   mypy
 urllib3==2.0.3
     # via

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -18,7 +18,7 @@ sentry-sdk==1.26.0
     #   -r requirements-typing.in
 types-cachetools==5.3.0.5
     # via -r requirements-typing.in
-types-jsonschema==4.17.0.8
+types-jsonschema==4.17.0.10
     # via -r requirements-typing.in
 typing-extensions==4.6.3
     # via

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -16,7 +16,7 @@ sentry-sdk==1.26.0
     # via
     #   -c requirements-dev.txt
     #   -r requirements-typing.in
-types-cachetools==5.3.0.5
+types-cachetools==5.3.0.6
     # via -r requirements-typing.in
 types-jsonschema==4.17.0.10
     # via -r requirements-typing.in

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -8,23 +8,25 @@ certifi==2023.5.7
     # via
     #   -c requirements-dev.txt
     #   sentry-sdk
-mypy==1.3.0
+mypy==1.4.1
     # via -r requirements-typing.in
 mypy-extensions==1.0.0
     # via mypy
-sentry-sdk==1.24.0
+sentry-sdk==1.26.0
     # via -r requirements-typing.in
 tomli==2.0.1
     # via
     #   -c requirements-dev.txt
     #   mypy
+types-cachetools==5.3.0.5
+    # via -r requirements-typing.in
 types-jsonschema==4.17.0.8
     # via -r requirements-typing.in
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   -c requirements-dev.txt
     #   mypy
-urllib3==1.26.16
+urllib3==2.0.3
     # via
     #   -c requirements-dev.txt
     #   sentry-sdk

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,7 +12,7 @@ typing-extensions
 ujson<6
 watchfiles<1
 xxhash~=3.0
-rich~=12.5.0
+rich~=12.6.0
 cachetools==5.2.0
 
 # Patched dependencies

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,6 +13,7 @@ ujson<6
 watchfiles<1
 xxhash~=3.0
 rich~=12.5.0
+cachetools==5.2.0
 
 # Patched dependencies
 #

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -13,7 +13,7 @@ ujson<6
 watchfiles<1
 xxhash~=3.0
 rich~=12.6.0
-cachetools==5.2.0
+cachetools==5.3.1
 
 # Patched dependencies
 #

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,7 +6,7 @@
 #
 accept-types==0.4.1
     # via -r requirements.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via -r requirements.in
 aiokafka==0.8.1
     # via -r requirements.in
@@ -30,8 +30,6 @@ charset-normalizer==3.1.0
     # via aiohttp
 commonmark==0.9.1
     # via rich
-exceptiongroup==1.1.1
-    # via anyio
 frozenlist==1.3.3
     # via
     #   aiohttp
@@ -40,8 +38,6 @@ idna==3.4
     # via
     #   anyio
     #   yarl
-importlib-resources==5.12.0
-    # via jsonschema
 isodate==0.6.1
     # via -r requirements.in
 jsonschema==4.17.3
@@ -58,8 +54,6 @@ networkx==2.8.8
     # via -r requirements.in
 packaging==23.1
     # via aiokafka
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
 protobuf==3.20.3
     # via -r requirements.in
 pygments==2.15.1
@@ -79,9 +73,7 @@ sniffio==1.3.0
 tenacity==8.2.2
     # via -r requirements.in
 typing-extensions==4.6.3
-    # via
-    #   -r requirements.in
-    #   rich
+    # via -r requirements.in
 ujson==5.8.0
     # via -r requirements.in
 watchfiles==0.19.0
@@ -90,5 +82,3 @@ xxhash==3.2.0
     # via -r requirements.in
 yarl==1.9.2
     # via aiohttp
-zipp==3.15.0
-    # via importlib-resources

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,6 +22,7 @@ attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
+    #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via -r requirements.in
 cachetools==5.2.0
@@ -40,8 +41,10 @@ idna==3.4
     #   yarl
 isodate==0.6.1
     # via -r requirements.in
-jsonschema==4.17.3
+jsonschema==4.18.4
     # via -r requirements.in
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
     # via
     #   -r requirements.in
@@ -58,12 +61,18 @@ protobuf==3.20.3
     # via -r requirements.in
 pygments==2.15.1
     # via rich
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via -r requirements.in
+referencing==0.30.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 rich==12.6.0
     # via -r requirements.in
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
 six==1.16.0
     # via
     #   isodate

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,7 +25,7 @@ attrs==23.1.0
     #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via -r requirements.in
-cachetools==5.2.0
+cachetools==5.3.1
     # via -r requirements.in
 charset-normalizer==3.1.0
     # via aiohttp

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -62,7 +62,7 @@ pyrsistent==0.19.3
     # via jsonschema
 python-dateutil==2.8.2
     # via -r requirements.in
-rich==12.5.1
+rich==12.6.0
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ accept-types==0.4.1
     # via -r requirements.in
 aiohttp==3.8.4
     # via -r requirements.in
-aiokafka==0.8.0
+aiokafka==0.8.1
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
@@ -24,10 +24,14 @@ attrs==23.1.0
     #   jsonschema
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via -r requirements.in
+cachetools==5.2.0
+    # via -r requirements.in
 charset-normalizer==3.1.0
     # via aiohttp
 commonmark==0.9.1
     # via rich
+exceptiongroup==1.1.1
+    # via anyio
 frozenlist==1.3.3
     # via
     #   aiohttp
@@ -36,6 +40,8 @@ idna==3.4
     # via
     #   anyio
     #   yarl
+importlib-resources==5.12.0
+    # via jsonschema
 isodate==0.6.1
     # via -r requirements.in
 jsonschema==4.17.3
@@ -52,6 +58,8 @@ networkx==2.8.8
     # via -r requirements.in
 packaging==23.1
     # via aiokafka
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 protobuf==3.20.3
     # via -r requirements.in
 pygments==2.15.1
@@ -70,9 +78,11 @@ sniffio==1.3.0
     # via anyio
 tenacity==8.2.2
     # via -r requirements.in
-typing-extensions==4.6.2
-    # via -r requirements.in
-ujson==5.7.0
+typing-extensions==4.6.3
+    # via
+    #   -r requirements.in
+    #   rich
+ujson==5.8.0
     # via -r requirements.in
 watchfiles==0.19.0
     # via -r requirements.in
@@ -80,3 +90,5 @@ xxhash==3.2.0
     # via -r requirements.in
 yarl==1.9.2
     # via aiohttp
+zipp==3.15.0
+    # via importlib-resources

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -17,7 +17,7 @@ async def test_remote_client(registry_async_client: Client) -> None:
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro
 
@@ -31,6 +31,6 @@ async def test_remote_client_tls(registry_async_client_tls: Client) -> None:
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_avro

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -15,7 +15,7 @@ async def test_remote_client(registry_async_client: Client) -> None:
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
     assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
@@ -29,7 +29,7 @@ async def test_remote_client_tls(registry_async_client_tls: Client) -> None:
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
     assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_avro, f"stored schema {stored_schema.to_dict()} is not {schema_avro.to_dict()}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -16,7 +16,7 @@ async def test_remote_client_protobuf(registry_async_client):
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)
     assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id
@@ -31,7 +31,7 @@ async def test_remote_client_protobuf2(registry_async_client):
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)
     assert sc_id >= 0
-    stored_schema = await reg_cli.get_schema_for_id(sc_id)
+    stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
     stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
     assert stored_id == sc_id

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -18,7 +18,7 @@ async def test_remote_client_protobuf(registry_async_client):
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_protobuf
 
@@ -33,6 +33,6 @@ async def test_remote_client_protobuf2(registry_async_client):
     assert sc_id >= 0
     stored_schema, _ = await reg_cli.get_schema_for_id(sc_id)
     assert stored_schema == schema_protobuf, f"stored schema {stored_schema} is not {schema_protobuf}"
-    stored_id, stored_schema = await reg_cli.get_latest_schema(subject)
+    stored_id, stored_schema, _ = await reg_cli.get_schema(subject)
     assert stored_id == sc_id
     assert stored_schema == schema_protobuf_after

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -276,6 +276,10 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
         data = resp.json()
         assert len(data) == len(values[fmt]), f"Expected {len(values[fmt])} element in response: {resp}"
         for i in range(len(values[fmt])):
+            assert data[i]["topic"] == topic_name
+            assert data[i]["partition"] == 0
+            assert data[i]["offset"] >= 0
+            assert data[i]["timestamp"] > 0
             assert deserializers[fmt](data[i]["value"]) == values[fmt][i], (
                 f"Extracted data {deserializers[fmt](data[i]['value'])}" f" does not match {values[fmt][i]} for format {fmt}"
             )

--- a/tests/integration/test_rest_consumer_protobuf.py
+++ b/tests/integration/test_rest_consumer_protobuf.py
@@ -2,13 +2,20 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+
+from karapace.client import Client
+from karapace.kafka_rest_apis import KafkaRestAdminClient
+from karapace.protobuf.kotlin_wrapper import trim_margin
+from tests.integration.test_rest import NEW_TOPIC_TIMEOUT
 from tests.utils import (
     new_consumer,
+    new_random_name,
     new_topic,
     repeat_until_successful_request,
     REST_HEADERS,
     schema_data,
     schema_data_second,
+    wait_for_topics,
 )
 
 import pytest
@@ -74,3 +81,184 @@ async def test_publish_consume_protobuf_second(rest_async_client, admin_client, 
     data_values = [x["value"] for x in data]
     for expected, actual in zip(publish_payload, data_values):
         assert expected == actual, f"Expecting {actual} to be {expected}"
+
+
+async def test_publish_protobuf_with_references(
+    rest_async_client: Client,
+    admin_client: KafkaRestAdminClient,
+    registry_async_client: Client,
+):
+    topic_name = new_topic(admin_client)
+    subject_reference = "reference"
+    subject_topic = f"{topic_name}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    reference_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |message Reference {
+        |     string name = 1;
+        |}
+        |"""
+    )
+
+    topic_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "Reference.proto";
+        |message Example {
+        |     Reference example = 1;
+        |}
+        |"""
+    )
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_reference}/versions", json={"schemaType": "PROTOBUF", "schema": reference_schema}
+    )
+    assert "id" in res.json()
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_topic}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": topic_schema,
+            "references": [
+                {
+                    "name": "Reference.proto",
+                    "subject": subject_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    topic_schema_id = res.json()["id"]
+
+    example_message = {"value_schema_id": topic_schema_id, "records": [{"value": {"example": {"name": "myname"}}}]}
+
+    res = await rest_async_client.post(
+        f"/topics/{topic_name}",
+        json=example_message,
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+
+async def test_publish_and_consume_protobuf_with_recursive_references(
+    rest_async_client: Client,
+    admin_client: KafkaRestAdminClient,
+    registry_async_client: Client,
+):
+    topic_name = new_topic(admin_client)
+    subject_meta_reference = "meta-reference"
+    subject_inner_reference = "inner-reference"
+    subject_topic = f"{topic_name}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    meta_reference = trim_margin(
+        """
+        |syntax = "proto3";
+        |message MetaReference {
+        |     string name = 1;
+        |}
+        |"""
+    )
+
+    inner_reference = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "MetaReference.proto";
+        |message InnerReference {
+        |     MetaReference reference = 1;
+        }
+        |"""
+    )
+
+    topic_schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |import "InnerReference.proto";
+        |message Example {
+        |     InnerReference example = 1;
+        |}
+        |"""
+    )
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_meta_reference}/versions", json={"schemaType": "PROTOBUF", "schema": meta_reference}
+    )
+    assert "id" in res.json()
+    res = await registry_async_client.post(
+        f"subjects/{subject_inner_reference}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": inner_reference,
+            "references": [
+                {
+                    "name": "MetaReference.proto",
+                    "subject": subject_meta_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    assert "id" in res.json()
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_topic}/versions",
+        json={
+            "schemaType": "PROTOBUF",
+            "schema": topic_schema,
+            "references": [
+                {
+                    "name": "InnerReference.proto",
+                    "subject": subject_inner_reference,
+                    "version": 1,
+                }
+            ],
+        },
+    )
+    topic_schema_id = res.json()["id"]
+
+    produced_message = {"example": {"reference": {"name": "myname"}}}
+    example_message = {
+        "value_schema_id": topic_schema_id,
+        "records": [{"value": produced_message}],
+    }
+
+    res = await rest_async_client.post(
+        f"/topics/{topic_name}",
+        json=example_message,
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+    group = new_random_name("protobuf_recursive_reference_message")
+    instance_id = await new_consumer(rest_async_client, group)
+
+    subscribe_path = f"/consumers/{group}/instances/{instance_id}/subscription"
+
+    consume_path = f"/consumers/{group}/instances/{instance_id}/records?timeout=1000"
+
+    res = await rest_async_client.post(subscribe_path, json={"topics": [topic_name]}, headers=REST_HEADERS["binary"])
+    assert res.ok
+
+    resp = await rest_async_client.get(consume_path, headers=REST_HEADERS["avro"])
+    data = resp.json()
+
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+    msg = data[0]
+
+    assert "key" in msg
+    assert "offset" in msg
+    assert "topic" in msg
+    assert "value" in msg
+    assert "timestamp" in msg
+
+    assert msg["key"] is None, "no key defined in production"
+    assert msg["offset"] == 0 and msg["partition"] == 0, "first message of the only partition available"
+    assert msg["topic"] == topic_name
+    assert msg["value"] == produced_message

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -955,9 +955,15 @@ async def test_union_comparing_to_other_types(registry_async_client: Client) -> 
         schema = [{"type": "array", "name": "listofstrings", "items": "string"}, "string"]
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": json.dumps(schema)})
         assert res.status_code == 200
+
+        initial_schema_id = res.json()["id"]
+
         plain_schema = {"type": "string"}
         res = await registry_async_client.post(f"subjects/{subject}/versions", json={"schema": json.dumps(plain_schema)})
         assert res.status_code == status_code
+
+        res = await registry_async_client.get(f"/schemas/ids/{initial_schema_id}")
+        assert subject in res.json()["subjects"]
 
     expected_results = [("BACKWARD", 200), ("FORWARD", 409), ("FULL", 409)]
     for compatibility, status_code in expected_results:
@@ -2346,7 +2352,7 @@ async def test_malformed_kafka_message(
         sleep=1,
     )
     res_data = res.json()
-    expected_payload = {"schema": json_encode({"foo": "bar"}, compact=True)}
+    expected_payload = {"schema": json_encode({"foo": "bar"}, compact=True), "subjects": ["foo"]}
     assert res_data == expected_payload, res_data
 
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2674,6 +2674,12 @@ async def test_schema_hard_delete_whole_schema(registry_async_client: Client) ->
     assert res.json()["error_code"] == 40401
     assert res.json()["message"] == f"Subject '{subject}' not found."
 
+    # Check that fetching unescaped schema gives valid error message
+    res = await registry_async_client.get(f"subjects/{subject}/versions/latest/schema")
+    assert res.status_code == 404
+    assert res.json()["error_code"] == 40401
+    assert res.json()["message"] == f"Subject '{subject}' not found."
+
     # Soft delete cannot be done twice
     res = await registry_async_client.delete(f"subjects/{subject}")
     assert res.status_code == 404

--- a/tests/unit/protobuf/test_dependency.py
+++ b/tests/unit/protobuf/test_dependency.py
@@ -1,0 +1,114 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.protobuf.kotlin_wrapper import trim_margin
+from karapace.protobuf.schema import ProtobufSchema
+
+
+def test_nested_field_one_of_dependency():
+    """The nested field may contain nested messages that are referred with one of restriction.
+    This test is for regression when used types are added and parent name did not include correctly
+    the nested `Foo`.
+    The full used type is `.test.FooVal.Foo.Bar`.
+    """
+    proto = """
+      |syntax = "proto3";
+      |package test;
+      |
+      |option java_multiple_files = true;
+      |option java_string_check_utf8 = true;
+      |option java_outer_classname = "FooProto";
+      |option java_package = "test";
+      |
+      |// Comment
+      |message FooKey {
+      |  // Comment
+      |  string field_a = 1;
+      |
+      |}
+      |
+      |// Comment
+      |message FooVal {
+      |  // Comment
+      |  repeated Foo field_a = 1;
+      |
+      |  // Comment
+      |  string field_b = 2;
+      |
+      |  // Comment
+      |  message Foo {
+      |
+      |    // Comment
+      |    message Bar {
+      |      // Comment
+      |      string field_b = 1;
+      |    }
+      |
+      |    // Comment
+      |    message Bee {
+      |    }
+      |
+      |    // Comment
+      |    oneof packaging {
+      |      // Comment
+      |      Bar field_h = 2;
+      |
+      |      // Comment
+      |      Bee field_i = 3;
+      |    }
+      |  }
+      |}
+    """
+    proto = trim_margin(proto)
+    pbschema = ProtobufSchema(schema=proto, references=(), dependencies=())
+    deps = pbschema.verify_schema_dependencies()
+    assert deps.result, "Dependencies verification failed."
+
+
+def test_one_of_dependency():
+    proto = """
+      |syntax = "proto3";
+      |package test;
+      |
+      |option java_multiple_files = true;
+      |option java_string_check_utf8 = true;
+      |option java_outer_classname = "FooProto";
+      |option java_package = "test";
+      |
+      |// Comment
+      |message FooKey {
+      |  // Comment
+      |  string field_a = 1;
+      |
+      |}
+      |
+      |// Comment
+      |message FooVal {
+      |  // Comment
+      |  string field_b = 1;
+      |
+      |  // Comment
+      |  message Bar {
+      |    // Comment
+      |    string field_b = 1;
+      |  }
+      |
+      |  // Comment
+      |  message Bee {
+      |  }
+      |
+      |  // Comment
+      |  oneof packaging {
+      |    // Comment
+      |    Bar field_h = 2;
+      |
+      |    // Comment
+      |    Bee field_i = 3;
+      |  }
+      |}
+    """
+    proto = trim_margin(proto)
+    pbschema = ProtobufSchema(schema=proto, references=(), dependencies=())
+    deps = pbschema.verify_schema_dependencies()
+    assert deps.result, "Dependencies verification failed."

--- a/tests/unit/test_protobuf_serialization.py
+++ b/tests/unit/test_protobuf_serialization.py
@@ -14,6 +14,7 @@ from karapace.serialization import (
     SchemaRegistrySerializer,
     START_BYTE,
 )
+from karapace.typing import Subject
 from tests.utils import schema_protobuf, test_fail_objects_protobuf, test_objects_protobuf
 from unittest.mock import call, Mock
 
@@ -37,7 +38,9 @@ async def make_ser_deser(config_path: str, mock_client) -> SchemaRegistrySeriali
 async def test_happy_flow(default_config_path):
     mock_protobuf_registry_client = Mock()
     schema_for_id_one_future = asyncio.Future()
-    schema_for_id_one_future.set_result(ParsedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf)))
+    schema_for_id_one_future.set_result(
+        (ParsedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf)), [Subject("stub")])
+    )
     mock_protobuf_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
     get_latest_schema_future = asyncio.Future()
     get_latest_schema_future.set_result((1, ParsedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf))))
@@ -53,7 +56,7 @@ async def test_happy_flow(default_config_path):
     assert len(serializer.ids_to_schemas) == 1
     assert 1 in serializer.ids_to_schemas
 
-    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top")]
+    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top"), call.get_schema_for_id(1)]
 
 
 async def test_happy_flow_references(default_config_path):
@@ -105,7 +108,7 @@ async def test_happy_flow_references(default_config_path):
 
     mock_protobuf_registry_client = Mock()
     schema_for_id_one_future = asyncio.Future()
-    schema_for_id_one_future.set_result(ref_schema)
+    schema_for_id_one_future.set_result((ref_schema, [Subject("stub")]))
     mock_protobuf_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
     get_latest_schema_future = asyncio.Future()
     get_latest_schema_future.set_result((1, ref_schema))
@@ -121,7 +124,7 @@ async def test_happy_flow_references(default_config_path):
     assert len(serializer.ids_to_schemas) == 1
     assert 1 in serializer.ids_to_schemas
 
-    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top")]
+    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top"), call.get_schema_for_id(1)]
 
 
 async def test_happy_flow_references_two(default_config_path):
@@ -192,7 +195,7 @@ async def test_happy_flow_references_two(default_config_path):
 
     mock_protobuf_registry_client = Mock()
     schema_for_id_one_future = asyncio.Future()
-    schema_for_id_one_future.set_result(ref_schema_two)
+    schema_for_id_one_future.set_result((ref_schema_two, [Subject("mock")]))
     mock_protobuf_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
     get_latest_schema_future = asyncio.Future()
     get_latest_schema_future.set_result((1, ref_schema_two))
@@ -208,7 +211,7 @@ async def test_happy_flow_references_two(default_config_path):
     assert len(serializer.ids_to_schemas) == 1
     assert 1 in serializer.ids_to_schemas
 
-    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top")]
+    assert mock_protobuf_registry_client.method_calls == [call.get_latest_schema("top"), call.get_schema_for_id(1)]
 
 
 async def test_serialization_fails(default_config_path):

--- a/tests/unit/test_protobuf_serialization.py
+++ b/tests/unit/test_protobuf_serialization.py
@@ -97,7 +97,7 @@ async def test_happy_flow_references(default_config_path):
         {"query": 10, "speed": {"speed": "MIDDLE"}},
     ]
 
-    references = [Reference("Speed.proto", "speed", 1)]
+    references = [Reference(name="Speed.proto", subject="speed", version=1)]
 
     no_ref_schema = ParsedTypedSchema.parse(SchemaType.PROTOBUF, no_ref_schema_str)
     dep = Dependency("Speed.proto", "speed", 1, no_ref_schema)
@@ -179,8 +179,8 @@ async def test_happy_flow_references_two(default_config_path):
         {"index": 2, "qry": {"query": 10, "speed": {"speed": "HIGH"}}},
     ]
 
-    references = [Reference("Speed.proto", "speed", 1)]
-    references_two = [Reference("Query.proto", "msg", 1)]
+    references = [Reference(name="Speed.proto", subject="speed", version=1)]
+    references_two = [Reference(name="Query.proto", subject="msg", version=1)]
 
     no_ref_schema = ParsedTypedSchema.parse(SchemaType.PROTOBUF, no_ref_schema_str)
     dep = Dependency("Speed.proto", "speed", 1, no_ref_schema)

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -14,6 +14,7 @@ from karapace.serialization import (
     START_BYTE,
     write_value,
 )
+from karapace.typing import Subject
 from tests.utils import schema_avro_json, test_objects_avro
 from unittest.mock import call, Mock
 
@@ -43,6 +44,9 @@ async def test_happy_flow(default_config_path):
     get_latest_schema_future = asyncio.Future()
     get_latest_schema_future.set_result((1, ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)))
     mock_registry_client.get_latest_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json), [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
 
     serializer = await make_ser_deser(default_config_path, mock_registry_client)
     assert len(serializer.ids_to_schemas) == 0
@@ -52,7 +56,7 @@ async def test_happy_flow(default_config_path):
     assert len(serializer.ids_to_schemas) == 1
     assert 1 in serializer.ids_to_schemas
 
-    assert mock_registry_client.method_calls == [call.get_latest_schema("top")]
+    assert mock_registry_client.method_calls == [call.get_latest_schema("top"), call.get_schema_for_id(1)]
 
 
 def test_flatten_unions_record() -> None:
@@ -259,7 +263,7 @@ async def test_serialization_fails(default_config_path):
 async def test_deserialization_fails(default_config_path):
     mock_registry_client = Mock()
     schema_for_id_one_future = asyncio.Future()
-    schema_for_id_one_future.set_result(ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json))
+    schema_for_id_one_future.set_result((ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json), [Subject("stub")]))
     mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
 
     deserializer = await make_ser_deser(default_config_path, mock_registry_client)
@@ -277,7 +281,7 @@ async def test_deserialization_fails(default_config_path):
     mock_registry_client.reset_mock()
 
     # but we can pass in a perfectly fine doc belonging to a diff schema
-    schema = await mock_registry_client.get_schema_for_id(1)
+    schema, _ = await mock_registry_client.get_schema_for_id(1)
     schema = copy.deepcopy(schema.to_dict())
     schema["name"] = "BadUser"
     schema["fields"][0]["type"] = "int"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,6 +50,21 @@ schema_avro_json = json.dumps(
     }
 )
 
+schema_avro_json_evolution = json.dumps(
+    {
+        "namespace": "example.avro",
+        "type": "record",
+        "name": "example.avro.User",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "favorite_number", "type": "int"},
+            {"name": "favorite_color", "type": "string"},
+            {"name": "favorite_quark", "type": "string", "default": "def"},
+        ],
+    }
+)
+
+
 test_objects_jsonschema = [{"foo": 100}, {"foo": 200}]
 
 test_objects_avro = [
@@ -57,6 +72,13 @@ test_objects_avro = [
     {"name": "Second Foo", "favorite_number": 3, "favorite_color": "baz"},
     {"name": "Third Foo", "favorite_number": 5, "favorite_color": "quux"},
 ]
+
+test_objects_avro_evolution = [
+    {"name": "First Foo", "favorite_number": 2, "favorite_color": "bar", "favorite_quark": "up"},
+    {"name": "Second Foo", "favorite_number": 3, "favorite_color": "baz", "favorite_quark": "down"},
+    {"name": "Third Foo", "favorite_number": 5, "favorite_color": "quux", "favorite_quark": "charm"},
+]
+
 
 # protobuf schemas in tests must be filtered by  trim_margin() from kotlin_wrapper module
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -202,10 +202,10 @@ def create_id_factory(prefix: str) -> Callable[[], str]:
     return create_name
 
 
-def new_topic(admin_client: KafkaRestAdminClient, prefix: str = "topic") -> str:
+def new_topic(admin_client: KafkaRestAdminClient, prefix: str = "topic", *, num_partitions: int = 1) -> str:
     topic_name = f"{new_random_name(prefix)}"
     try:
-        admin_client.new_topic(topic_name)
+        admin_client.new_topic(topic_name, num_partitions=num_partitions)
     except TopicAlreadyExistsError:
         pass
     return topic_name


### PR DESCRIPTION
API requests to `/topics/<topic>/partitions/<partition_id>/offsets` often lead to `not_leader_for_partition` error as the request goes to the least loaded node. It needs to go to the leader instead.

[HH-2464]