### PR TITLE
Migrate CODEOWNERS to new GitHub organization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @aiven/team-helpful-husky @aiven/aiven-open-source
+*   @Aiven-Open/team-helpful-husky @Aiven-Open/aiven-open-source


### PR DESCRIPTION
# About this change - What it does

Migrate CODEOWNERS to new GitHub organization