### PR TITLE
Fix references support in check schema registered endpoint

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1102,7 +1102,10 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         for schema_version in sorted(subject_data.values(), key=lambda item: item.version, reverse=True):
             try:
                 parsed_typed_schema = ParsedTypedSchema.parse(
-                    schema_version.schema.schema_type, schema_version.schema.schema_str
+                    schema_version.schema.schema_type,
+                    schema_version.schema.schema_str,
+                    references=references,
+                    dependencies=new_schema_dependencies,
                 )
             except InvalidSchema as e:
                 failed_schema_id = schema_version.schema_id

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -218,6 +218,19 @@ async def test_protobuf_schema_references(registry_async_client: Client) -> None
     assert res.status_code == 200
 
     assert "id" in res.json()
+    customer_id = res.json()["id"]
+
+    # Check if the schema has now been registered under the subject
+    res = await registry_async_client.post(
+        "subjects/customer",
+        json={"schemaType": "PROTOBUF", "schema": customer_schema, "references": customer_references},
+    )
+    assert res.status_code == 200
+    assert "subject" in res.json()
+    assert "id" in res.json()
+    assert customer_id == res.json()["id"]
+    assert "version" in res.json()
+    assert "schema" in res.json()
 
     original_schema = """
             |syntax = "proto3";


### PR DESCRIPTION
# About this change - What it does

Fix references support in parsing code that checks if a schema has been registered under the specified subject.

# Why this way

Parsing code did not pass parsed references correctly in the check code used by the endpoint.
