### PR TITLE
fix: explicitly set retries to 0

### DIFF
--- a/karapace/kafka_utils.py
+++ b/karapace/kafka_utils.py
@@ -60,6 +60,7 @@ def kafka_producer_from_config(config: Config) -> KafkaProducer:
         sasl_plain_username=config["sasl_plain_username"],
         sasl_plain_password=config["sasl_plain_password"],
         kafka_client=KarapaceKafkaClient,
+        retries=0,
     )
     try:
         yield producer


### PR DESCRIPTION
Currently in the backup tool we leave implicitly the setting about the retries.
This (if the default value change) could lead to duplication of messages in the restore of a topic.