### PR TITLE
fix: enable self-referencing schemas

### DIFF
--- a/karapace/protobuf/dependency.py
+++ b/karapace/protobuf/dependency.py
@@ -8,7 +8,7 @@ See LICENSE for details
 from karapace.dependency import DependencyVerifierResult
 from karapace.protobuf.known_dependency import DependenciesHardcoded, KnownDependency
 from karapace.protobuf.one_of_element import OneOfElement
-from typing import List
+from typing import List, Optional, Set
 
 
 class ProtobufDependencyVerifier:
@@ -35,13 +35,31 @@ class ProtobufDependencyVerifier:
     def add_import(self, import_name: str) -> None:
         self.import_path.append(import_name)
 
+    def is_type_declared(
+        self,
+        used_type: str,
+        declared_index: Set[str],
+        father_child_type: Optional[str],
+        used_type_with_scope: Optional[str],
+    ) -> bool:
+        return (
+            used_type in declared_index
+            or (used_type_with_scope is not None and used_type_with_scope in declared_index)
+            or (father_child_type is not None and father_child_type in declared_index)
+            or "." + used_type in declared_index
+        )
+
     def verify(self) -> DependencyVerifierResult:
         declared_index = set(self.declared_types)
         for used_type in self.used_types:
             delimiter = used_type.rfind(";")
-            used_type_with_scope = ""
+            father_child_type = None
+            used_type_with_scope = None
             if delimiter != -1:
                 used_type_with_scope = used_type[:delimiter] + "." + used_type[delimiter + 1 :]
+                father_delimiter = used_type[:delimiter].find(".")
+                if father_delimiter != -1:
+                    father_child_type = used_type[:father_delimiter] + "." + used_type[delimiter + 1 :]
                 used_type = used_type[delimiter + 1 :]
 
             if used_type in DependenciesHardcoded.index:
@@ -51,11 +69,7 @@ class ProtobufDependencyVerifier:
             if known_pkg is not None and known_pkg in self.import_path:
                 continue
 
-            if (
-                used_type in declared_index
-                or (delimiter != -1 and used_type_with_scope in declared_index)
-                or "." + used_type in declared_index
-            ):
+            if self.is_type_declared(used_type, declared_index, father_child_type, used_type_with_scope):
                 continue
 
             return DependencyVerifierResult(False, f'type "{used_type}" is not defined')


### PR DESCRIPTION
Before this PR the protobuf schema was able to refer only to fully qualified names or names defined in an higher leaf of the parsing tree.
This commit enable a schema to refer the same scope level if at the same leaf level there is defined exactly the field required after.

In an example:
```protobuf
enum FancyEnum {
  ...
}
message FancyMessage1 {
   FancyEnum field ...
}
```
 `FancyMessage1` is allowed to call `FancyEnum` because his scope is `/FancyMessage1` while the scope of `FancyEnum` it's `/` (the name itself doesn't count in the declarations, but take part only in field assignment inside the declarations, we could say that `field` has the scope set to `/FancyMessage1` but the type `FancyEnum` has also the scope `/`, only when referring to a type you enter in it's scope during the parsing procedure).

This was a valid declaration in the previous status.


Instead, in this example:

```protobuf
message FancyMessage1 {
   enum FancyEnum {
     ...
   }
   FancyEnum field ...
}
```

In the previous state was an invalid schema.

With this pr, since `FancyEnum field ...` it's declared inside the scope `/FancyMessage1` but also the requested type `FancyEnum` it's declared in the same scope, `/FancyMessage1` it's considered valid


Fixes #713