### PR TITLE
fix: prevent from accepting schema that are not uniquely identifiable from the current parser

### DIFF
--- a/karapace/protobuf/dependency.py
+++ b/karapace/protobuf/dependency.py
@@ -11,13 +11,22 @@ from karapace.protobuf.one_of_element import OneOfElement
 from typing import List, Optional, Set
 
 
+class FieldNotUniquelyIdentifiableException(Exception):
+    pass
+
+
 class ProtobufDependencyVerifier:
     def __init__(self) -> None:
         self.declared_types: List[str] = []
         self.used_types: List[str] = []
         self.import_path: List[str] = []
 
-    def add_declared_type(self, full_name: str) -> None:
+    def add_declared_type(self, full_name: str, uniquely: bool = False) -> None:
+        if uniquely and full_name in self.declared_types:
+            raise FieldNotUniquelyIdentifiableException(
+                f"{full_name} is not currently identifiable from the parser, "
+                f"validating this message lead to break the schema evolution!"
+            )
         self.declared_types.append(full_name)
 
     def add_used_type(self, parent: str, element_type: str) -> None:

--- a/karapace/protobuf/dependency.py
+++ b/karapace/protobuf/dependency.py
@@ -8,7 +8,7 @@ See LICENSE for details
 from karapace.dependency import DependencyVerifierResult
 from karapace.protobuf.known_dependency import DependenciesHardcoded, KnownDependency
 from karapace.protobuf.one_of_element import OneOfElement
-from typing import List
+from typing import List, Optional, Set
 
 
 class ProtobufDependencyVerifier:
@@ -35,13 +35,31 @@ class ProtobufDependencyVerifier:
     def add_import(self, import_name: str) -> None:
         self.import_path.append(import_name)
 
+    def is_type_declared(
+        self,
+        used_type: str,
+        declared_index: Set[str],
+        father_child_type: Optional[str],
+        used_type_with_scope: Optional[str],
+    ) -> bool:
+        return (
+            used_type in declared_index
+            or (used_type_with_scope is not None and used_type_with_scope in declared_index)
+            or (father_child_type is not None and father_child_type in declared_index)
+            or "." + used_type in declared_index
+        )
+
     def verify(self) -> DependencyVerifierResult:
         declared_index = set(self.declared_types)
         for used_type in self.used_types:
             delimiter = used_type.rfind(";")
-            used_type_with_scope = ""
+            father_child_type = None
+            used_type_with_scope = None
             if delimiter != -1:
                 used_type_with_scope = used_type[:delimiter] + "." + used_type[delimiter + 1 :]
+                father_delimiter = used_type[:delimiter].find(".")
+                if father_delimiter != -1:
+                    father_child_type = used_type[:father_delimiter] + "." + used_type[delimiter + 1 :]
                 used_type = used_type[delimiter + 1 :]
 
             if used_type in DependenciesHardcoded.index:
@@ -51,11 +69,7 @@ class ProtobufDependencyVerifier:
             if known_pkg is not None and known_pkg in self.import_path:
                 continue
 
-            if (
-                used_type in declared_index
-                or (delimiter != -1 and used_type_with_scope in declared_index)
-                or "." + used_type in declared_index
-            ):
+            if self.is_type_declared(used_type, declared_index, father_child_type, used_type_with_scope):
                 continue
 
             return DependencyVerifierResult(False, f'type "{used_type}" is not defined')

--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -161,9 +161,10 @@ class ProtobufSchema:
     ):
         verifier.add_declared_type(package_name + "." + parent_name + "." + element_type.name)
         verifier.add_declared_type(parent_name + "." + element_type.name)
-        ancestor_only = parent_name.find(".")
-        if ancestor_only != -1:
-            verifier.add_declared_type(parent_name[:ancestor_only] + "." + element_type.name)
+        anchestor_only = parent_name.find(".")
+        if anchestor_only != -1:
+            # adding the first father and the type name, this should be unique to identify which is which.
+            verifier.add_declared_type(parent_name[:anchestor_only] + "." + element_type.name, uniquely=True)
 
         if isinstance(element_type, MessageElement):
             for one_of in element_type.one_ofs:


### PR DESCRIPTION
with the pr !716 it's possible to insert a schema like the following one:
```protobuf
syntax = "proto3";

package fancy.company.in.party.v1;
message AnotherMessage {
  enum BamFancyEnum {
    // Hei! This is a comment!
    MY_AWESOME_FIELD = 0;
  }
  message WowANestedMessage {
    message DeeplyNestedMsg {
      enum BamFancyEnum {
      // Hei! This is a comment!
         MY_AWESOME_FIELD = 0;
      }
      message AnotherLevelOfNesting {
         BamFancyEnum im_tricky_im_referring_to_the_previous_enum = 1;
      }
    }
  }
}
```

The problem is that currently the parser is a double pass parser that tries to expand all the types both providing the "local" name, the fully scoped name and a name composed by the first type anchestror and the type name.
We can allow types to come in but we cannot uniquely associate the type with which (resulting in a schema evolution potentially broken).
This pr is meant to avoid this situation by blocking the protobuf schemas that are not uniquely identifiable.