### PR TITLE
chore: Make pytest CI runs more verbose

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -ra -q --tb=short --numprocesses auto --import-mode=importlib
+addopts = -ra --numprocesses auto --import-mode=importlib
 timeout = 60
 timeout_func_only = true


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
### About this change - What it does

Increase pytest verbosity, by removing the quiet flag as well as the `--tb=short` flag.

### Why this way

In this failing CI run, the fact that we use `--tb short` makes it impossible to tell what code path triggered the breaking call to `read_config()`.

https://github.com/Aiven-Open/karapace/actions/runs/6239301084/job/16936931606