### PR TITLE
Fix subject name strategy config and add validation flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -462,6 +462,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
    * - ``name_strategy``
      - ``topic_name``
      - Name strategy to use when storing schemas from the kafka rest proxy service
+   * - ``name_strategy_validation``
+     - ``true``
+     - If enabled, validate that given schema is registered under used name strategy when producing messages from Kafka Rest
    * - ``master_election_strategy``
      - ``lowest``
      - Decides on what basis the Karapace cluster master is chosen (only relevant in a multi node setup)

--- a/README.rst
+++ b/README.rst
@@ -460,7 +460,7 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - ``runtime``
      - Runtime directory for the ``protoc`` protobuf schema parser and code generator
    * - ``name_strategy``
-     - ``subject_name``
+     - ``topic_name``
      - Name strategy to use when storing schemas from the kafka rest proxy service
    * - ``master_election_strategy``
      - ``lowest``

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -32,7 +32,7 @@ RUN groupadd --system karapace \
  && chown --recursive karapace:karapace /opt/karapace /var/log/karapace
 
 # Install protobuf compiler.
-ARG PROTOBUF_COMPILER_VERSION="3.12.4-1"
+ARG PROTOBUF_COMPILER_VERSION="3.12.4-1+deb11u1"
 RUN apt-get update \
  && apt-get install --assume-yes --no-install-recommends \
     protobuf-compiler=$PROTOBUF_COMPILER_VERSION \

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -74,6 +74,7 @@ class Config(TypedDict):
     karapace_rest: bool
     karapace_registry: bool
     name_strategy: str
+    name_strategy_validation: bool
     master_election_strategy: str
     protobuf_runtime_directory: str
 
@@ -144,6 +145,7 @@ DEFAULTS: ConfigDefaults = {
     "karapace_rest": False,
     "karapace_registry": False,
     "name_strategy": "topic_name",
+    "name_strategy_validation": True,
     "master_election_strategy": "lowest",
     "protobuf_runtime_directory": "runtime",
 }

--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -779,7 +779,7 @@ class UserRestProxy:
                 need_new_call=subject_not_included,
             )
 
-            if subject_not_included(parsed_schema, valid_subjects):
+            if self.config["name_strategy_validation"] and subject_not_included(parsed_schema, valid_subjects):
                 raise InvalidSchema()
 
         return schema_id

--- a/karapace/serialization.py
+++ b/karapace/serialization.py
@@ -229,8 +229,6 @@ class SchemaRegistrySerializer:
     def __init__(
         self,
         config: dict,
-        name_strategy: str = "topic_name",
-        **cfg,  # pylint: disable=unused-argument
     ) -> None:
         self.config = config
         self.state_lock = asyncio.Lock()
@@ -245,7 +243,8 @@ class SchemaRegistrySerializer:
         else:
             registry_url = f"http://{self.config['registry_host']}:{self.config['registry_port']}"
             registry_client = SchemaRegistryClient(registry_url, session_auth=session_auth)
-        self.subject_name_strategy = NAME_STRATEGIES[name_strategy]
+        name_strategy = config.get("name_strategy", "topic_name")
+        self.subject_name_strategy = NAME_STRATEGIES.get(name_strategy, topic_name_strategy)
         self.registry_client: Optional[SchemaRegistryClient] = registry_client
         self.ids_to_schemas: Dict[int, TypedSchema] = {}
         self.ids_to_subjects: MutableMapping[int, List[Subject]] = TTLCache(maxsize=10000, ttl=600)

--- a/tests/integration/test_rest.py
+++ b/tests/integration/test_rest.py
@@ -559,6 +559,70 @@ async def test_publish_with_schema_id_of_another_subject(rest_async_client, regi
     assert res.status_code == 200
 
 
+async def test_publish_with_schema_id_of_another_subject_novalidation(
+    rest_async_novalidation_client, registry_async_client, admin_client
+):
+    """
+    Same as above but with name_strategy_validation disabled as config
+    """
+    topic_name = new_topic(admin_client)
+    subject_1 = f"{topic_name}-value"
+    subject_2 = "some-other-subject-value"
+
+    await wait_for_topics(rest_async_novalidation_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+    url = f"/topics/{topic_name}"
+
+    schema_1 = {
+        "type": "record",
+        "name": "Schema1",
+        "fields": [
+            {
+                "name": "name",
+                "type": "string",
+            },
+        ],
+    }
+    schema_2 = {
+        "type": "record",
+        "name": "Schema2",
+        "fields": [
+            {
+                "name": "temperature",
+                "type": "int",
+            },
+        ],
+    }
+
+    # Register schemas to get the ids
+    res = await registry_async_client.post(
+        f"subjects/{subject_1}/versions",
+        json={"schema": json.dumps(schema_1)},
+    )
+    assert res.status_code == 200
+    schema_1_id = res.json()["id"]
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_2}/versions",
+        json={"schema": json.dumps(schema_2)},
+    )
+    assert res.status_code == 200
+    schema_2_id = res.json()["id"]
+
+    res = await rest_async_novalidation_client.post(
+        url,
+        json={"value_schema_id": schema_2_id, "records": [{"value": {"temperature": 25}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200  # This is fine if name_strategy_validation is disabled
+
+    res = await rest_async_novalidation_client.post(
+        url,
+        json={"value_schema_id": schema_1_id, "records": [{"value": {"name": "Mr. Mustache"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+
+
 async def test_brokers(rest_async_client):
     res = await rest_async_client.get("/brokers")
     assert res.ok

--- a/tests/unit/test_protobuf_serialization.py
+++ b/tests/unit/test_protobuf_serialization.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 async def make_ser_deser(config_path: str, mock_client) -> SchemaRegistrySerializer:
     with open(config_path, encoding="utf8") as handler:
         config = read_config(handler)
-    serializer = SchemaRegistrySerializer(config_path=config_path, config=config)
+    serializer = SchemaRegistrySerializer(config=config)
     await serializer.registry_client.close()
     serializer.registry_client = mock_client
     return serializer

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 async def make_ser_deser(config_path: str, mock_client) -> SchemaRegistrySerializer:
     with open(config_path, encoding="utf8") as handler:
         config = read_config(handler)
-    serializer = SchemaRegistrySerializer(config_path=config_path, config=config)
+    serializer = SchemaRegistrySerializer(config=config)
     await serializer.registry_client.close()
     serializer.registry_client = mock_client
     return serializer


### PR DESCRIPTION
# About this change - What it does

Fix subject `name_strategy` configuration setting, which we have had kind of documented but not working. Now it is possible to set it, and use it. Also fixes documentation to match what has been the default in the implementation.

Add new configuration option `name_strategy_validation` (true by default) which allows skipping subject name strategy validation when producing messages with Kafka REST calls. 

References: #664 and #724

# Why this way

This enables easy backward compatible behaviour of producing with REST using any schema.
