### PR TITLE
Return Unauthorized on malformed OAuth token

### DIFF
--- a/karapace/kafka_rest_apis/authentication.py
+++ b/karapace/kafka_rest_apis/authentication.py
@@ -99,7 +99,11 @@ def get_expiration_time_from_header(auth_header: str) -> datetime.datetime | Non
     token_type, token = _split_auth_header(auth_header)
 
     if token_type == TokenType.BEARER.value:
-        exp_claim = jwt.decode(token, options={"verify_signature": False}).get("exp")
+        try:
+            exp_claim = jwt.decode(token, options={"verify_signature": False}).get("exp")
+        except jwt.exceptions.DecodeError:
+            raise_unauthorized()
+
         if exp_claim is not None:
             return datetime.datetime.fromtimestamp(exp_claim, datetime.timezone.utc)
 


### PR DESCRIPTION
# About this change - What it does

Handle JWT DecodeErrors when extracting the expiration timestamp from an OIDC/OAuth2 JWT token, otherwise this would result in an HTTP 500 response.

# Why this way

Catching PyJWT's `DecodeError` is sufficient, as all other exceptions from the library (see
https://pyjwt.readthedocs.io/en/stable/api.html#exceptions) are related to proper verification, which we do not do at the moment.

