### PR TITLE
feat: enable users to disable validation only on specific topics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -464,7 +464,7 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
      - Name strategy to use when storing schemas from the kafka rest proxy service. You can opt between ``name_strategy`` , ``record_name`` and ``topic_record_name``
    * - ``name_strategy_validation``
      - ``true``
-     - If enabled, validate that given schema is registered under used name strategy when producing messages from Kafka Rest
+     - If enabled, validate that given schema is registered under the expected subjects requireds by the specified name strategy when producing messages from Kafka Rest. Otherwise no validation are performed
    * - ``master_election_strategy``
      - ``lowest``
      - Decides on what basis the Karapace cluster master is chosen (only relevant in a multi node setup)

--- a/karapace/key_format.py
+++ b/karapace/key_format.py
@@ -70,6 +70,9 @@ class KeyFormatter:
             corrected_key["subject"] = key["subject"]
         if "version" in key:
             corrected_key["version"] = key["version"]
+        if "topic" in key:
+            corrected_key["topic"] = key["topic"]
+
         # Magic is the last element
         corrected_key["magic"] = key["magic"]
         return json_encode(corrected_key, binary=True, sort_keys=False, compact=True)

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -429,9 +429,10 @@ class KafkaSchemaReader(Thread):
             LOG.info("Deleting subject: %r, value: %r", subject, value)
             self.database.delete_subject(subject=subject, version=version)
 
-    def _handle_msg_schema_validation(self, key: dict, value: dict | None) -> None:  # pylint: disable=unused-argument
+    def _handle_msg_schema_validation(self, key: dict, value: dict | None) -> None:
         assert isinstance(value, dict)
-        topic, skip_validation = TopicName(value["topic"]), bool(value["skip_validation"])
+        topic = TopicName(key["topic"])
+        skip_validation = bool(value["skip_validation"])
         self.database.override_topic_validation(topic_name=topic, skip_validation=skip_validation)
 
     def _handle_msg_schema_hard_delete(self, key: dict) -> None:

--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -476,7 +476,7 @@ class KarapaceSchemaRegistry:
         skip_validation: bool,
     ) -> None:
         key = {"topic": topic_name, "keytype": str(MessageType.schema_validation), "magic": 0}
-        value = {"skip_validation": skip_validation, "topic": topic_name}
+        value = {"skip_validation": skip_validation}
         self.producer.send_message(key=key, value=value)
 
     def send_config_message(self, compatibility_level: CompatibilityModes, subject: Subject | None = None) -> None:

--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -46,6 +46,7 @@ class NameStrategy(StrEnum, Enum):
 @unique
 class SubjectType(StrEnum, Enum):
     key = "key"
-    value = "value"
+    # value it's a property of the Enum class, avoiding the collision.
+    value_ = "value"
     # partition it's a function of `str` and StrEnum its inherits from it.
     partition_ = "partition"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,12 +7,13 @@ See LICENSE for details
 from _pytest.fixtures import SubRequest
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import TestClient
-from contextlib import closing, ExitStack
+from contextlib import asynccontextmanager, closing, ExitStack
 from dataclasses import asdict
 from filelock import FileLock
 from kafka import KafkaProducer
 from karapace.client import Client
-from karapace.config import Config, set_config_defaults, write_config
+from karapace.config import Config, ConfigDefaults, set_config_defaults, write_config
+from karapace.dataclasses import default_dataclass
 from karapace.kafka_admin import KafkaAdminClient, NewTopic
 from karapace.kafka_rest_apis import KafkaRest
 from pathlib import Path
@@ -30,7 +31,7 @@ from tests.integration.utils.process import stop_process, wait_for_port_subproce
 from tests.integration.utils.synchronization import lock_path_for
 from tests.integration.utils.zookeeper import configure_and_start_zk
 from tests.utils import repeat_until_successful_request
-from typing import AsyncIterator, Iterator, List, Optional
+from typing import AsyncContextManager, AsyncIterator, Callable, Iterator, List, Optional
 from urllib.parse import urlparse
 
 import asyncio
@@ -215,13 +216,14 @@ def fixture_admin(kafka_servers: KafkaServers) -> Iterator[KafkaAdminClient]:
     yield KafkaAdminClient(bootstrap_servers=kafka_servers.bootstrap_servers)
 
 
-@pytest.fixture(scope="function", name="rest_async")
-async def fixture_rest_async(
+@asynccontextmanager
+async def _kafka_rest_async(
     request: SubRequest,
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     tmp_path: Path,
     kafka_servers: KafkaServers,
     registry_async_client: Client,
+    custom_values: Optional[ConfigDefaults] = None,
 ) -> AsyncIterator[Optional[KafkaRest]]:
     # Do not start a REST api when the user provided an external service. Doing
     # so would cause this node to join the existing group and participate in
@@ -234,14 +236,17 @@ async def fixture_rest_async(
 
     config_path = tmp_path / "karapace_config.json"
 
-    config = set_config_defaults(
-        {
-            "admin_metadata_max_age": 2,
-            "bootstrap_uri": kafka_servers.bootstrap_servers,
-            # Use non-default max request size for REST producer.
-            "producer_max_request_size": REST_PRODUCER_MAX_REQUEST_BYTES,
-        }
-    )
+    override_values = {
+        "admin_metadata_max_age": 2,
+        "bootstrap_uri": kafka_servers.bootstrap_servers,
+        # Use non-default max request size for REST producer.
+        "producer_max_request_size": REST_PRODUCER_MAX_REQUEST_BYTES,
+    }
+
+    if custom_values is not None:
+        override_values.update(custom_values)
+
+    config = set_config_defaults(override_values)
     write_config(config_path, config)
     rest = KafkaRest(config=config)
 
@@ -253,8 +258,49 @@ async def fixture_rest_async(
         await rest.close()
 
 
-@pytest.fixture(scope="function", name="rest_async_client")
-async def fixture_rest_async_client(
+@pytest.fixture(scope="function", name="rest_async")
+async def fixture_rest_async(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    tmp_path: Path,
+    kafka_servers: KafkaServers,
+    registry_async_client: Client,
+) -> AsyncIterator[Optional[KafkaRest]]:
+    async with _kafka_rest_async(
+        request,
+        loop,
+        tmp_path,
+        kafka_servers,
+        registry_async_client,
+    ) as kafka_rest_async:
+        yield kafka_rest_async
+
+
+@pytest.fixture(scope="function", name="rest_async_from_config")
+def fixture_rest_async_from_config(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    tmp_path: Path,
+    kafka_servers: KafkaServers,
+    registry_async_client_from_config: Callable[[ConfigDefaults], AsyncIterator[RegistryDescription]],
+) -> Callable[[ConfigDefaults], AsyncContextManager[Optional[KafkaRest]]]:
+    @asynccontextmanager
+    async def async_kafka_from_custom_config(config: ConfigDefaults) -> KafkaRest:
+        async with registry_async_client_from_config(config) as registry_async_client:
+            async with _kafka_rest_async(
+                request,
+                loop,
+                tmp_path,
+                kafka_servers,
+                registry_async_client,
+            ) as kafka_rest_async:
+                yield kafka_rest_async
+
+    return async_kafka_from_custom_config
+
+
+@asynccontextmanager
+async def _rest_async_client(
     request: SubRequest,
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     rest_async: KafkaRest,
@@ -286,6 +332,43 @@ async def fixture_rest_async_client(
         yield client
     finally:
         await client.close()
+
+
+@pytest.fixture(scope="function", name="rest_async_client")
+async def fixture_rest_async_client(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    rest_async: KafkaRest,
+    aiohttp_client: AiohttpClient,
+) -> AsyncIterator[Client]:
+    async with _rest_async_client(
+        request,
+        loop,
+        rest_async,
+        aiohttp_client,
+    ) as rest_async_client:
+        yield rest_async_client
+
+
+@pytest.fixture(scope="function", name="rest_async_client_from_config")
+async def fixture_rest_async_client_from_config(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    rest_async_from_config: Callable[[ConfigDefaults], AsyncContextManager[Optional[KafkaRest]]],
+    aiohttp_client: AiohttpClient,
+) -> Callable[[ConfigDefaults], AsyncContextManager[Client]]:
+    @asynccontextmanager
+    async def async_client_from_custom_config(config: ConfigDefaults) -> Client:
+        async with rest_async_from_config(config) as rest_async:
+            async with _rest_async_client(
+                request,
+                loop,
+                rest_async,
+                aiohttp_client,
+            ) as rest_async_client:
+                yield rest_async_client
+
+    return async_client_from_custom_config
 
 
 @pytest.fixture(scope="function", name="rest_async_novalidation")
@@ -453,13 +536,14 @@ async def fixture_registry_async_pair(
         yield [server.endpoint.to_url() for server in endpoints]
 
 
-@pytest.fixture(scope="function", name="registry_cluster")
-async def fixture_registry_cluster(
+@asynccontextmanager
+async def _registry_cluster(
     request: SubRequest,
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
     session_logdir: Path,
     kafka_servers: KafkaServers,
     port_range: PortRangeInclusive,
+    custom_values: Optional[ConfigDefaults] = None,
 ) -> AsyncIterator[RegistryDescription]:
     # Do not start a registry when the user provided an external service. Doing
     # so would cause this node to join the existing group and participate in
@@ -477,12 +561,56 @@ async def fixture_registry_cluster(
         config_templates=[config],
         data_dir=session_logdir / _clear_test_name(request.node.name),
         port_range=port_range,
+        custom_values=custom_values,
     ) as servers:
         yield servers[0]
 
 
-@pytest.fixture(scope="function", name="registry_async_client")
-async def fixture_registry_async_client(
+@pytest.fixture(scope="function", name="registry_cluster")
+async def fixture_registry_cluster(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    session_logdir: Path,
+    kafka_servers: KafkaServers,
+    port_range: PortRangeInclusive,
+    custom_values: Optional[ConfigDefaults] = None,
+) -> AsyncIterator[RegistryDescription]:
+    async with _registry_cluster(
+        request,
+        loop,
+        session_logdir,
+        kafka_servers,
+        port_range,
+        custom_values,
+    ) as registry_description:
+        yield registry_description
+
+
+@pytest.fixture(scope="function", name="registry_cluster_from_custom_config")
+def fixture_registry_cluster_with_custom_config(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    session_logdir: Path,
+    kafka_servers: KafkaServers,
+    port_range: PortRangeInclusive,
+) -> Callable[[ConfigDefaults], AsyncContextManager[RegistryDescription]]:
+    @asynccontextmanager
+    async def registry_from_custom_config(config: ConfigDefaults) -> RegistryDescription:
+        async with _registry_cluster(
+            request,
+            loop,
+            session_logdir,
+            kafka_servers,
+            port_range,
+            config,
+        ) as registry_description:
+            yield registry_description
+
+    return registry_from_custom_config
+
+
+@asynccontextmanager
+async def _registry_async_client(
     request: SubRequest,
     registry_cluster: RegistryDescription,
     loop: asyncio.AbstractEventLoop,  # pylint: disable=unused-argument
@@ -506,6 +634,80 @@ async def fixture_registry_async_client(
         yield client
     finally:
         await client.close()
+
+
+@pytest.fixture(scope="function", name="registry_async_client")
+async def fixture_registry_async_client(
+    request: SubRequest,
+    registry_cluster: RegistryDescription,
+    loop: asyncio.AbstractEventLoop,
+) -> Client:
+    async with _registry_async_client(
+        request,
+        registry_cluster,
+        loop,
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="function", name="registry_async_client_from_config")
+def fixture_registry_async_client_custom_config(
+    request: SubRequest,
+    registry_cluster_from_custom_config: Callable[[ConfigDefaults], AsyncIterator[RegistryDescription]],
+    loop: asyncio.AbstractEventLoop,
+) -> Callable[[ConfigDefaults], AsyncContextManager[Client]]:
+    @asynccontextmanager
+    async def client_from_custom_config(config: ConfigDefaults) -> Client:
+        async with registry_cluster_from_custom_config(config) as registry_description:
+            async with _registry_async_client(request, registry_description, loop) as client:
+                yield client
+
+    return client_from_custom_config
+
+
+@default_dataclass
+class RestClientAndRegistryClient:
+    registry_client: Client
+    rest_client: Client
+
+
+@pytest.fixture(scope="function", name="rest_async_client_and_rest_async_client_from_config")
+def fixture_rest_async_client_and_rest_async_client_from_config(
+    request: SubRequest,
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    session_logdir: Path,
+    kafka_servers: KafkaServers,
+    tmp_path: Path,
+    port_range: PortRangeInclusive,
+) -> Callable[[ConfigDefaults], AsyncContextManager[RestClientAndRegistryClient]]:
+    @asynccontextmanager
+    async def client_from_custom_config(config: ConfigDefaults) -> RestClientAndRegistryClient:
+        # ugly but without python 3.9 we cannot join those :(
+        async with _registry_cluster(
+            request,
+            loop,
+            session_logdir,
+            kafka_servers,
+            port_range,
+            config,
+        ) as registry_description:
+            async with _registry_async_client(request, registry_description, loop) as registry_async_client:
+                async with _kafka_rest_async(
+                    request, loop, tmp_path, kafka_servers, registry_async_client, config
+                ) as kafka_rest_async:
+                    async with _rest_async_client(
+                        request,
+                        loop,
+                        kafka_rest_async,
+                        aiohttp_client,
+                    ) as rest_async_client:
+                        yield RestClientAndRegistryClient(
+                            registry_client=registry_async_client,
+                            rest_client=rest_async_client,
+                        )
+
+    return client_from_custom_config
 
 
 @pytest.fixture(scope="function", name="credentials_folder")

--- a/tests/integration/test_rest_consumer.py
+++ b/tests/integration/test_rest_consumer.py
@@ -2,6 +2,7 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+from karapace.client import Client
 from karapace.kafka_rest_apis.consumer_manager import KNOWN_FORMATS
 from tests.utils import (
     consumer_valid_payload,
@@ -22,7 +23,7 @@ import time
 
 
 @pytest.mark.parametrize("trail", ["", "/"])
-async def test_create_and_delete(rest_async_client, trail):
+async def test_create_and_delete(rest_async_client: Client, trail: str):
     header = REST_HEADERS["json"]
     group_name = "test_group"
     resp = await rest_async_client.post(f"/consumers/{group_name}{trail}", json=consumer_valid_payload, headers=header)

--- a/tests/integration/test_rest_consumer_protobuf.py
+++ b/tests/integration/test_rest_consumer_protobuf.py
@@ -23,7 +23,12 @@ import pytest
 
 @pytest.mark.parametrize("schema_type", ["protobuf"])
 @pytest.mark.parametrize("trail", ["", "/"])
-async def test_publish_consume_protobuf(rest_async_client, admin_client, trail, schema_type):
+async def test_publish_consume_protobuf(
+    rest_async_client: Client,
+    admin_client: KafkaAdminClient,
+    trail: str,
+    schema_type: str,
+):
     header = REST_HEADERS[schema_type]
     group_name = "e2e_protobuf_group"
     instance_id = await new_consumer(rest_async_client, group_name, fmt=schema_type, trail=trail)
@@ -54,7 +59,12 @@ async def test_publish_consume_protobuf(rest_async_client, admin_client, trail, 
 
 @pytest.mark.parametrize("schema_type", ["protobuf"])
 @pytest.mark.parametrize("trail", ["", "/"])
-async def test_publish_consume_protobuf_second(rest_async_client, admin_client, trail, schema_type):
+async def test_publish_consume_protobuf_second(
+    rest_async_client: Client,
+    admin_client: KafkaAdminClient,
+    trail: str,
+    schema_type: str,
+):
     header = REST_HEADERS[schema_type]
     group_name = "e2e_proto_second"
     instance_id = await new_consumer(rest_async_client, group_name, fmt=schema_type, trail=trail)

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -2,14 +2,16 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+from __future__ import annotations
+
 from contextlib import asynccontextmanager, ExitStack
 from dataclasses import dataclass
-from karapace.config import Config, set_config_defaults, write_config
+from karapace.config import Config, ConfigDefaults, set_config_defaults, write_config
 from pathlib import Path
 from tests.integration.utils.network import PortRangeInclusive
 from tests.integration.utils.process import stop_process, wait_for_port_subprocess
 from tests.utils import new_random_name, popen_karapace_all
-from typing import AsyncIterator, List
+from typing import AsyncIterator
 
 
 @dataclass(frozen=True)
@@ -30,10 +32,11 @@ class RegistryDescription:
 
 @asynccontextmanager
 async def start_schema_registry_cluster(
-    config_templates: List[Config],
+    config_templates: list[Config],
     data_dir: Path,
     port_range: PortRangeInclusive,
-) -> AsyncIterator[List[RegistryDescription]]:
+    custom_values: ConfigDefaults | None = None,
+) -> AsyncIterator[list[RegistryDescription]]:
     """Start a cluster of schema registries, one process per `config_templates`."""
     for template in config_templates:
         assert "bootstrap_uri" in template, "base_config must have the value `bootstrap_uri` set"
@@ -75,6 +78,9 @@ async def start_schema_registry_cluster(
             config_path = group_dir / f"{pos}.config.json"
             log_path = group_dir / f"{pos}.log"
             error_path = group_dir / f"{pos}.error"
+
+            if custom_values is not None:
+                config.update(custom_values)
 
             config = set_config_defaults(config)
             write_config(config_path, config)

--- a/tests/unit/test_schema_registry_api.py
+++ b/tests/unit/test_schema_registry_api.py
@@ -5,7 +5,7 @@ See LICENSE for details
 from aiohttp.test_utils import TestClient, TestServer
 from karapace.config import DEFAULTS, set_config_defaults
 from karapace.rapu import HTTPResponse
-from karapace.schema_registry_apis import KarapaceSchemaRegistryController
+from karapace.schema_registry_apis import compute_forwarded_url, KarapaceSchemaRegistryController
 from unittest.mock import ANY, Mock, patch, PropertyMock
 
 import asyncio
@@ -52,3 +52,13 @@ async def test_forward_when_not_ready():
             mock_forward_func.assert_called_once_with(
                 request=ANY, body=None, url="http://primary-url/schemas/ids/1", content_type="application/json", method="GET"
             )
+
+
+def test_compute_forwarded_url() -> None:
+    assert (
+        compute_forwarded_url(
+            master_url="http://localhost:8081/another/fancy/path",
+            request_url="https://docs.python.org/3/library/urllib.parse.html",
+        )
+        == "http://localhost:8081/3/library/urllib.parse.html"
+    )

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -365,9 +365,9 @@ async def test_deserialization_fails(default_config_path: Path):
         (Subject("foo-key"), NameStrategy.topic_name, SubjectType.key),
         (Subject("io.aiven.data.Test"), NameStrategy.record_name, SubjectType.key),
         (Subject("foo-io.aiven.data.Test"), NameStrategy.topic_record_name, SubjectType.key),
-        (Subject("foo-value"), NameStrategy.topic_name, SubjectType.value),
-        (Subject("io.aiven.data.Test"), NameStrategy.record_name, SubjectType.value),
-        (Subject("foo-io.aiven.data.Test"), NameStrategy.topic_record_name, SubjectType.value),
+        (Subject("foo-value"), NameStrategy.topic_name, SubjectType.value_),
+        (Subject("io.aiven.data.Test"), NameStrategy.record_name, SubjectType.value_),
+        (Subject("foo-io.aiven.data.Test"), NameStrategy.topic_record_name, SubjectType.value_),
     ),
 )
 def test_name_strategy_for_avro(expected_subject: Subject, strategy: NameStrategy, subject_type: SubjectType):
@@ -382,8 +382,8 @@ def test_name_strategy_for_avro(expected_subject: Subject, strategy: NameStrateg
     (
         (Subject("Test"), NameStrategy.record_name, SubjectType.key),
         (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.key),
-        (Subject("Test"), NameStrategy.record_name, SubjectType.value),
-        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value),
+        (Subject("Test"), NameStrategy.record_name, SubjectType.value_),
+        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value_),
     ),
 )
 def test_name_strategy_for_json_schema(expected_subject: Subject, strategy: NameStrategy, subject_type: SubjectType):
@@ -398,8 +398,8 @@ def test_name_strategy_for_json_schema(expected_subject: Subject, strategy: Name
     (
         (Subject("Test"), NameStrategy.record_name, SubjectType.key),
         (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.key),
-        (Subject("Test"), NameStrategy.record_name, SubjectType.value),
-        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value),
+        (Subject("Test"), NameStrategy.record_name, SubjectType.value_),
+        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value_),
     ),
 )
 def test_name_strategy_for_avro_without_namespace(
@@ -418,8 +418,8 @@ def test_name_strategy_for_avro_without_namespace(
     (
         (Subject("Test"), NameStrategy.record_name, SubjectType.key),
         (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.key),
-        (Subject("Test"), NameStrategy.record_name, SubjectType.value),
-        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value),
+        (Subject("Test"), NameStrategy.record_name, SubjectType.value_),
+        (Subject("foo-Test"), NameStrategy.topic_record_name, SubjectType.value_),
     ),
 )
 def test_name_strategy_for_protobuf(expected_subject: Subject, strategy: NameStrategy, subject_type: SubjectType):

--- a/tests/unit/test_validation_check_wrapper.py
+++ b/tests/unit/test_validation_check_wrapper.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.kafka_rest_apis import ValidationCheckWrapper
+from karapace.typing import TopicName
+from unittest import mock
+from unittest.mock import AsyncMock
+
+
+async def test_validation_test_wrapper_elapse_works():
+    with mock.patch("time.monotonic_ns") as mock_time:
+        mock_time.return_value = 0
+
+        mock_registry_client = AsyncMock()
+        mock_registry_client.topic_require_validation.return_value = True
+
+        wrapper = await ValidationCheckWrapper.construct_new(
+            mock_registry_client,
+            TopicName("test_topic"),
+            cache_interval_ns=300,
+        )
+
+        result_1 = await wrapper.require_validation()
+        mock_time.return_value = 200
+        result_2 = await wrapper.require_validation()
+
+        assert result_1 is True
+        assert result_2 is True
+
+        mock_registry_client.topic_require_validation.assert_called_once()
+
+
+async def test_result_queried_twice_because_cache_evicted():
+    with mock.patch("time.monotonic_ns") as mock_time:
+        mock_time.return_value = 0
+
+        mock_registry_client = AsyncMock()
+        mock_registry_client.topic_require_validation.return_value = True
+
+        wrapper = await ValidationCheckWrapper.construct_new(
+            mock_registry_client,
+            TopicName("test_topic"),
+            cache_interval_ns=300,
+        )
+
+        result_1 = await wrapper.require_validation()
+        mock_time.return_value = 301
+        mock_registry_client.topic_require_validation.return_value = False
+        result_2 = await wrapper.require_validation()
+
+        assert result_1 is True
+        assert result_2 is False
+
+        assert mock_registry_client.topic_require_validation.call_count == 2


### PR DESCRIPTION
This PR enables users to avoid validation only on specific topics. It is necessary because, prior to [this commit](ca65ddde04b1dd49cf4324ede66e2f5d827d3c51) it was possible to create messages with incorrect or missing subjects. By fixing the validation of subject flows that were previously functioning (but shouldn't have been) now no longer work due to the added validation.

With this PR, users can migrate their flows one by one while adding new validated flows, rather than opting out of validation completely if they wish to retain the functionality of old flows without refactoring them.