### PR TITLE
fix: fixed various stuff that were blocking a new out of the box installation only using the `GNUmakefile`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -86,9 +86,9 @@ cleanest: cleaner
 requirements: export CUSTOM_COMPILE_COMMAND='make requirements'
 requirements:
 	pip install --upgrade pip setuptools pip-tools
-	cd requirements && pip-compile --upgrade --resolver=backtracking requirements.in
-	cd requirements && pip-compile --upgrade --resolver=backtracking requirements-dev.in
-	cd requirements && pip-compile --upgrade --resolver=backtracking requirements-typing.in
+	pip-compile --upgrade --resolver=backtracking requirements/requirements.in -o requirements/requirements.txt
+	pip-compile --upgrade --resolver=backtracking requirements/requirements-dev.in -o requirements/requirements-dev.txt
+	pip-compile --upgrade --resolver=backtracking requirements/requirements-typing.in -o requirements/requirements-typing.txt
 
 .PHONY: schema
 schema: against := origin/main

--- a/tests/integration/utils/config.py
+++ b/tests/integration/utils/config.py
@@ -24,7 +24,7 @@ class ZKConfig:
 @dataclass(frozen=True)
 class KafkaDescription:
     version: str
-    kafka_tgz: str
+    kafka_tgz: Path
     install_dir: Path
     download_url: str
     protocol_version: str

--- a/tests/integration/utils/kafka_server.py
+++ b/tests/integration/utils/kafka_server.py
@@ -63,6 +63,7 @@ def maybe_download_kafka(kafka_description: KafkaDescription) -> None:
     if not os.path.exists(kafka_description.install_dir):
         log.info("Downloading Kafka '%s'", kafka_description.download_url)
         download = requests.get(kafka_description.download_url, stream=True)
+        kafka_description.kafka_tgz.parent.mkdir(parents=True, exist_ok=True)
         with open(kafka_description.kafka_tgz, "wb") as fd:
             for chunk in download.iter_content(chunk_size=None):
                 fd.write(chunk)


### PR DESCRIPTION
fixed errors that I've encountered by cloning the project from scratch in a new folder and using the `GNUmakefile` to set it up and running.