### PR TITLE
Fix logging on failed schema reader topic creation

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -212,11 +212,11 @@ class KafkaSchemaReader(Thread):
                 except InvalidReplicationFactorError:
                     LOG.info(
                         "[Schema Topic] Failed to create topic %r, not enough Kafka brokers ready yet, retrying",
-                        topic.topic,
+                        self.config["topic_name"],
                     )
                     self._stop_schema_reader.wait(timeout=SCHEMA_TOPIC_CREATION_TIMEOUT_SECONDS)
                 except:  # pylint: disable=bare-except
-                    LOG.exception("[Schema Topic] Failed to create %r, retrying", topic.topic)
+                    LOG.exception("[Schema Topic] Failed to create %r, retrying", self.config["topic_name"])
                     self._stop_schema_reader.wait(timeout=SCHEMA_TOPIC_CREATION_TIMEOUT_SECONDS)
 
             while not self._stop_schema_reader.is_set():


### PR DESCRIPTION
# About this change - What it does

Fix error logging in schema reader that would cause further exceptions.
The `topic` variable is of course nonexistent if the topic creation fails with an exception.
