### PR TITLE
fix: create new schema and version on reference update

### DIFF
--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -109,7 +109,11 @@ class TypedSchema:
 
     def fingerprint(self) -> str:
         if self._fingerprint_cached is None:
-            self._fingerprint_cached = hashlib.sha1(str(self).encode("utf8")).hexdigest()
+            fingerprint_str = str(self)
+            if self.references is not None:
+                reference_str = "\n".join([repr(reference) for reference in self.references])
+                fingerprint_str = fingerprint_str + reference_str
+            self._fingerprint_cached = hashlib.sha1(fingerprint_str.encode("utf8")).hexdigest()
         return self._fingerprint_cached
 
     # This is marked @final because __init__ references this statically, hence

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -509,6 +509,16 @@ message NoReference {
 }
 """
 
+SCHEMA_NO_REF_V2 = """\
+syntax = "proto3";
+
+message NoReference {
+  string name = 1;
+  string address = 2;
+}
+"""
+
+
 SCHEMA_NO_REF_TWO = """\
 syntax = "proto3";
 
@@ -998,6 +1008,62 @@ async def test_references(testcase: ReferenceTestCase, registry_async_client: Cl
             else:
                 fetch_schema_res = await registry_async_client.get(f"/schemas/ids/{testdata.schema_id}")
                 assert fetch_schema_res.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        ReferenceTestCase(
+            test_name="With updated reference version",
+            schemas=[
+                TestCaseSchema(
+                    schema_type=SchemaType.PROTOBUF,
+                    schema_str=SCHEMA_NO_REF,
+                    subject="wr_s1",
+                    references=None,
+                    expected=200,
+                ),
+                TestCaseSchema(
+                    schema_type=SchemaType.PROTOBUF,
+                    schema_str=SCHEMA_WITH_REF,
+                    subject="wr_s2",
+                    references=[{"name": "NoReference.proto", "subject": "wr_s1", "version": 1}],
+                    expected=200,
+                ),
+                TestCaseSchema(
+                    schema_type=SchemaType.PROTOBUF,
+                    schema_str=SCHEMA_NO_REF_V2,
+                    subject="wr_s1",
+                    references=None,
+                    expected=200,
+                ),
+                TestCaseSchema(
+                    schema_type=SchemaType.PROTOBUF,
+                    schema_str=SCHEMA_WITH_REF,
+                    subject="wr_s2",
+                    references=[{"name": "NoReference.proto", "subject": "wr_s1", "version": 2}],
+                    expected=200,
+                ),
+            ],
+        ),
+    ],
+    ids=str,
+)
+async def test_reference_update_creates_new_schema_version(testcase: ReferenceTestCase, registry_async_client: Client):
+    for testdata in testcase.schemas:
+        body = {"schemaType": testdata.schema_type, "schema": testdata.schema_str}
+        if testdata.references:
+            body["references"] = testdata.references
+        res = await registry_async_client.post(f"subjects/{testdata.subject}/versions", json=body)
+        assert res.status_code == testdata.expected
+    res = await registry_async_client.get("subjects/wr_s2/versions")
+    assert len(res.json_result) == 2, "Expected two versions of schemas as reference was updated."
+    res = await registry_async_client.get("subjects/wr_s2/versions/2")
+    references = res.json_result.get("references")
+    assert len(references) == 1
+    assert references[0].get("name") == "NoReference.proto"
+    assert references[0].get("subject") == "wr_s1"
+    assert references[0].get("version") == 2
 
 
 async def test_protobuf_error(registry_async_client: Client) -> None:


### PR DESCRIPTION
# About this change - What it does

When only updating a reference to a schema a new schema and version is required to be created.
The references are also included in the schema fingerprint.

<!-- Provide the issue number below if it exists. -->
References: #783
Closes #783

# Why this way
The full protobuf schema requires also the the references. If reference is updated the schema is changed, the actual schema string  may be the same. Th
