### PR TITLE
Fix schema registering with ordering change

### DIFF
--- a/karapace/protobuf/compare_type_lists.py
+++ b/karapace/protobuf/compare_type_lists.py
@@ -54,20 +54,13 @@ def compare_type_lists(
             else:
                 raise IllegalStateException("Instance of element is not applicable")
         else:
-            if other_indexes[name] != self_indexes[name]:
-                if isinstance(self_types[name], MessageElement):
-                    # incompatible type
-                    result.add_modification(Modification.MESSAGE_MOVE)
-                else:
-                    raise IllegalStateException("Instance of element is not applicable")
+            if isinstance(self_types[name], MessageElement) and isinstance(other_types[name], MessageElement):
+                self_types[name].compare(other_types[name], result, compare_types)
+            elif isinstance(self_types[name], EnumElement) and isinstance(other_types[name], EnumElement):
+                self_types[name].compare(other_types[name], result, compare_types)
             else:
-                if isinstance(self_types[name], MessageElement) and isinstance(other_types[name], MessageElement):
-                    self_types[name].compare(other_types[name], result, compare_types)
-                elif isinstance(self_types[name], EnumElement) and isinstance(other_types[name], EnumElement):
-                    self_types[name].compare(other_types[name], result, compare_types)
-                else:
-                    # incompatible type
-                    result.add_modification(Modification.TYPE_ALTER)
+                # incompatible type
+                result.add_modification(Modification.TYPE_ALTER)
         result.pop_path(True)
 
     return result

--- a/karapace/protobuf/enum_element.py
+++ b/karapace/protobuf/enum_element.py
@@ -73,6 +73,6 @@ class EnumElement(TypeElement):
             elif other_tag is None:
                 result.add_modification(Modification.ENUM_CONSTANT_DROP)
             else:
-                if self_tag.name == other_tag.name:
+                if self_tag.name != other_tag.name:
                     result.add_modification(Modification.ENUM_CONSTANT_ALTER)
             result.pop_path()

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -1225,3 +1225,48 @@ message Dog {
     assert res.status_code == 200
     assert "id" in res.json()
     assert schema_id == res.json()["id"]
+
+
+async def test_protobuf_update_ordering(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_protobuf_update_ordering")()
+
+    schema_v1 = """\
+syntax = "proto3";
+package tc4;
+
+message Fred {
+  HodoCode hodecode = 1;
+}
+
+enum HodoCode {
+  HODO_CODE_UNSPECIFIED = 0;
+}
+"""
+
+    body = {"schemaType": "PROTOBUF", "schema": schema_v1}
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json=body)
+
+    assert res.status_code == 200
+    assert "id" in res.json()
+    schema_id = res.json()["id"]
+
+    schema_v2 = """\
+syntax = "proto3";
+package tc4;
+
+enum HodoCode {
+  HODO_CODE_UNSPECIFIED = 0;
+}
+
+message Fred {
+  HodoCode hodecode = 1;
+  string id = 2;
+}
+"""
+
+    body = {"schemaType": "PROTOBUF", "schema": schema_v2}
+    res = await registry_async_client.post(f"subjects/{subject}/versions", json=body)
+
+    assert res.status_code == 200
+    assert "id" in res.json()
+    assert schema_id != res.json()["id"]


### PR DESCRIPTION
# About this change - What it does

Fix schema compatibility checks if ordering of types is changed. Order of types does not affect semantical compatibility of the schemas.

Fixes #795
