### PR TITLE
Remove aiokafka dependency

### DIFF
--- a/karapace/sentry/sentry_client.py
+++ b/karapace/sentry/sentry_client.py
@@ -41,8 +41,6 @@ class SentryClient(SentryClientAPI):
         # Don't send library logged errors to Sentry as there is also proper return value or raised exception to calling code
         from sentry_sdk.integrations.logging import ignore_logger
 
-        ignore_logger("aiokafka")
-        ignore_logger("aiokafka.*")
         ignore_logger("kafka")
         ignore_logger("kafka.*")
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -77,9 +77,6 @@ ignore_errors = True
 #   dependencies.
 # - Write your own stubs. You don't need to write stubs for the whole library,
 #   only the parts that Karapace is interacting with.
-[mypy-aiokafka.*]
-ignore_missing_imports = True
-
 [mypy-kafka.*]
 ignore_missing_imports = True
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -5,40 +5,37 @@
 #    'make requirements'
 #
 accept-types==0.4.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 aiohttp==3.9.2
-    # via -r requirements.txt
-aiokafka==0.8.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 aiosignal==1.3.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
 anyio==4.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   watchfiles
 async-timeout==4.0.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
-    #   aiokafka
 attrs==23.1.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
     #   hypothesis
     #   jsonschema
     #   referencing
     #   wmctrl
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 blinker==1.7.0
     # via flask
 brotli==1.1.0
     # via geventhttpclient
 cachetools==5.3.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 certifi==2023.11.17
     # via
     #   geventhttpclient
@@ -51,10 +48,10 @@ click==8.1.7
 configargparse==1.7
     # via locust
 confluent-kafka==2.3.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 exceptiongroup==1.2.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   anyio
     #   hypothesis
     #   pytest
@@ -63,7 +60,7 @@ execnet==2.0.2
 fancycompleter==0.9.1
     # via pdbpp
 filelock==3.13.1
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 flask==3.0.0
     # via
     #   flask-basicauth
@@ -75,7 +72,7 @@ flask-cors==4.0.0
     # via locust
 frozenlist==1.4.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
     #   aiosignal
 gevent==23.9.1
@@ -87,10 +84,10 @@ geventhttpclient==2.0.11
 greenlet==3.0.1
     # via gevent
 hypothesis==6.92.2
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 idna==3.6
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   anyio
     #   requests
     #   yarl
@@ -98,34 +95,32 @@ importlib-metadata==6.8.0
     # via flask
 importlib-resources==6.1.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   jsonschema-specifications
 iniconfig==2.0.0
     # via pytest
 isodate==0.6.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 itsdangerous==2.1.2
     # via flask
 jinja2==3.1.3
     # via flask
 jsonschema==4.21.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 jsonschema-specifications==2023.11.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
 kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
-    # via
-    #   -r requirements.txt
-    #   aiokafka
+    # via -r requirements/requirements.txt
 locust==2.19.1
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 lz4==4.3.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 markdown-it-py==3.0.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   rich
 markupsafe==2.1.3
     # via
@@ -133,109 +128,106 @@ markupsafe==2.1.3
     #   werkzeug
 mdurl==0.1.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   markdown-it-py
 msgpack==1.0.7
     # via locust
 multidict==6.0.4
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
     #   yarl
 networkx==3.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 packaging==23.2
-    # via
-    #   -r requirements.txt
-    #   aiokafka
-    #   pytest
+    # via pytest
 pdbpp==0.10.3
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 pkgutil-resolve-name==1.3.10
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
 pluggy==1.3.0
     # via pytest
 protobuf==3.20.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 psutil==5.9.6
     # via
-    #   -r requirements-dev.in
+    #   -r requirements/requirements-dev.in
     #   locust
     #   pytest-xdist
 pygments==2.17.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   pdbpp
     #   rich
 pyjwt==2.8.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyrepl==0.9.0
     # via fancycompleter
 pytest==7.4.4
     # via
-    #   -r requirements-dev.in
+    #   -r requirements/requirements-dev.in
     #   pytest-timeout
     #   pytest-xdist
 pytest-timeout==2.2.0
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 pytest-xdist[psutil]==3.5.0
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 python-dateutil==2.8.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 python-snappy==0.6.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 pyzmq==25.1.1
     # via locust
 referencing==0.31.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r requirements-dev.in
+    #   -r requirements/requirements-dev.in
     #   locust
 rich==13.7.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 roundrobin==0.0.4
     # via locust
 rpds-py==0.13.2
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   jsonschema
     #   referencing
 sentry-sdk==1.38.0
-    # via -r requirements-dev.in
+    # via -r requirements/requirements-dev.in
 six==1.16.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   geventhttpclient
     #   isodate
     #   python-dateutil
 sniffio==1.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   anyio
 sortedcontainers==2.4.0
     # via hypothesis
 tenacity==8.2.3
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 tomli==2.0.1
     # via pytest
 typing-extensions==4.8.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   rich
 ujson==5.8.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 urllib3==2.1.0
     # via
     #   requests
     #   sentry-sdk
 watchfiles==0.21.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 werkzeug==3.0.1
     # via
     #   flask
@@ -243,14 +235,14 @@ werkzeug==3.0.1
 wmctrl==0.5
     # via pdbpp
 xxhash==3.4.1
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 yarl==1.9.3
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   aiohttp
 zipp==3.17.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   importlib-metadata
     #   importlib-resources
 zope-event==5.0
@@ -258,7 +250,7 @@ zope-event==5.0
 zope-interface==6.1
     # via gevent
 zstandard==0.22.0
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -6,47 +6,47 @@
 #
 attrs==23.1.0
     # via
-    #   -c requirements-dev.txt
-    #   -c requirements.txt
+    #   -c requirements/requirements-dev.txt
+    #   -c requirements/requirements.txt
     #   referencing
 certifi==2023.11.17
     # via
-    #   -c requirements-dev.txt
+    #   -c requirements/requirements-dev.txt
     #   sentry-sdk
 mypy==1.8.0
-    # via -r requirements-typing.in
+    # via -r requirements/requirements-typing.in
 mypy-extensions==1.0.0
     # via mypy
 referencing==0.31.1
     # via
-    #   -c requirements-dev.txt
-    #   -c requirements.txt
+    #   -c requirements/requirements-dev.txt
+    #   -c requirements/requirements.txt
     #   types-jsonschema
 rpds-py==0.13.2
     # via
-    #   -c requirements-dev.txt
-    #   -c requirements.txt
+    #   -c requirements/requirements-dev.txt
+    #   -c requirements/requirements.txt
     #   referencing
 sentry-sdk==1.38.0
     # via
-    #   -c requirements-dev.txt
-    #   -r requirements-typing.in
+    #   -c requirements/requirements-dev.txt
+    #   -r requirements/requirements-typing.in
 tomli==2.0.1
     # via
-    #   -c requirements-dev.txt
+    #   -c requirements/requirements-dev.txt
     #   mypy
 types-cachetools==5.3.0.7
-    # via -r requirements-typing.in
+    # via -r requirements/requirements-typing.in
 types-jsonschema==4.21.0.20240118
-    # via -r requirements-typing.in
+    # via -r requirements/requirements-typing.in
 types-protobuf==3.20.4.6
-    # via -r requirements-typing.in
+    # via -r requirements/requirements-typing.in
 typing-extensions==4.8.0
     # via
-    #   -c requirements-dev.txt
-    #   -c requirements.txt
+    #   -c requirements/requirements-dev.txt
+    #   -c requirements/requirements.txt
     #   mypy
 urllib3==2.1.0
     # via
-    #   -c requirements-dev.txt
+    #   -c requirements/requirements-dev.txt
     #   sentry-sdk

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,6 @@
 # PyPI dependencies
 accept-types<1
 aiohttp<4
-aiokafka<1
 confluent-kafka==2.3.0
 isodate<1
 jsonschema<5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,30 +5,26 @@
 #    'make requirements'
 #
 accept-types==0.4.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 aiohttp==3.9.2
-    # via -r requirements.in
-aiokafka==0.8.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 aiosignal==1.3.1
     # via aiohttp
 anyio==4.1.0
     # via watchfiles
 async-timeout==4.0.3
-    # via
-    #   aiohttp
-    #   aiokafka
+    # via aiohttp
 attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 cachetools==5.3.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 confluent-kafka==2.3.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 exceptiongroup==1.2.0
     # via anyio
 frozenlist==1.4.0
@@ -44,17 +40,15 @@ importlib-resources==6.1.1
     #   jsonschema
     #   jsonschema-specifications
 isodate==0.6.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 jsonschema==4.21.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 jsonschema-specifications==2023.11.2
     # via jsonschema
 kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
-    # via
-    #   -r requirements.in
-    #   aiokafka
+    # via -r requirements/requirements.in
 lz4==4.3.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -64,27 +58,25 @@ multidict==6.0.4
     #   aiohttp
     #   yarl
 networkx==3.1
-    # via -r requirements.in
-packaging==23.2
-    # via aiokafka
+    # via -r requirements/requirements.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 protobuf==3.20.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 pygments==2.17.2
     # via rich
 pyjwt==2.8.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 python-dateutil==2.8.2
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 python-snappy==0.6.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 referencing==0.31.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 rpds-py==0.13.2
     # via
     #   jsonschema
@@ -96,20 +88,20 @@ six==1.16.0
 sniffio==1.3.0
     # via anyio
 tenacity==8.2.3
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 typing-extensions==4.8.0
     # via
-    #   -r requirements.in
+    #   -r requirements/requirements.in
     #   rich
 ujson==5.8.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 watchfiles==0.21.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 xxhash==3.4.1
-    # via -r requirements.in
+    # via -r requirements/requirements.in
 yarl==1.9.3
     # via aiohttp
 zipp==3.17.0
     # via importlib-resources
 zstandard==0.22.0
-    # via -r requirements.in
+    # via -r requirements/requirements.in

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "protobuf",
         "pyjwt",
         "python-dateutil",
-        # compression algorithms supported by AioKafka and KafkaConsumer
+        # compression algorithms supported by confluent-kafka-python
         "lz4",
         "python-snappy",
         "zstandard",


### PR DESCRIPTION
# About this change - What it does

Remove `aiokafka` as a dependency and regenerate the requirements files, as well as removing it from the mypy configuration.

`kafka-python` remains, as it is still used in the schema registry's coordinator and for translating error codes to human readable exceptions.
