### PR TITLE
Demote various exception logs to warning and info

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -307,7 +307,7 @@ class KafkaRest(KarapaceBase):
                     if self.proxies.get(key) is None:
                         self.proxies[key] = UserRestProxy(self.config, self.kafka_timeout, self.serializer)
             except (NoBrokersAvailable, AuthenticationFailedError):
-                log.exception("Failed to connect to Kafka with the credentials")
+                log.warning("Failed to connect to Kafka with the credentials")
                 self.r(body={"message": "Forbidden"}, content_type=JSON_CONTENT_TYPE, status=HTTPStatus.FORBIDDEN)
             proxy = self.proxies[key]
             proxy.mark_used()
@@ -497,9 +497,9 @@ class UserRestProxy:
                 except (NoBrokersAvailable, AuthenticationFailedError):
                     await producer.stop()
                     if retry:
-                        log.exception("Unable to connect to the bootstrap servers, retrying")
+                        log.warning("Unable to connect to the bootstrap servers, retrying")
                     else:
-                        log.exception("Giving up after trying to connect to the bootstrap servers")
+                        log.warning("Giving up after trying to connect to the bootstrap servers")
                         raise
                     await asyncio.sleep(1)
                 except Exception:
@@ -626,7 +626,7 @@ class UserRestProxy:
                 self._cluster_metadata = metadata
                 self._cluster_metadata_complete = topics is None
             except KafkaException:
-                log.exception("Could not refresh cluster metadata")
+                log.warning("Could not refresh cluster metadata")
                 KafkaRest.r(
                     body={
                         "message": "Kafka node not ready",
@@ -653,9 +653,9 @@ class UserRestProxy:
                 break
             except:  # pylint: disable=bare-except
                 if retry:
-                    log.exception("Unable to start admin client, retrying")
+                    log.warning("Unable to start admin client, retrying")
                 else:
-                    log.exception("Giving up after failing to start admin client")
+                    log.warning("Giving up after failing to start admin client")
                     raise
                 time.sleep(1)
 
@@ -858,7 +858,7 @@ class UserRestProxy:
         try:
             data[f"{subject_type}_schema_id"] = await self.get_schema_id(data, topic, subject_type, schema_type)
         except InvalidPayload:
-            log.exception("Unable to retrieve schema id")
+            log.warning("Unable to retrieve schema id")
             KafkaRest.r(
                 body={
                     "error_code": RESTErrorCodes.HTTP_BAD_REQUEST.value,

--- a/karapace/kafka_rest_apis/consumer_manager.py
+++ b/karapace/kafka_rest_apis/consumer_manager.py
@@ -228,9 +228,9 @@ class ConsumerManager:
                 return c
             except:  # pylint: disable=bare-except
                 if retry:
-                    LOG.exception("Unable to create consumer, retrying")
+                    LOG.warning("Unable to create consumer, retrying")
                 else:
-                    LOG.exception("Giving up after failing to create consumer")
+                    LOG.warning("Giving up after failing to create consumer")
                     raise
                 await asyncio.sleep(1)
 

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -129,7 +129,7 @@ class TypedSchema:
             try:
                 schema_str = json_encode(json_decode(schema_str), compact=True, sort_keys=True)
             except JSONDecodeError as e:
-                LOG.error("Schema is not valid JSON")
+                LOG.info("Schema is not valid JSON")
                 raise e
         elif schema_type == SchemaType.PROTOBUF:
             if schema:
@@ -138,7 +138,7 @@ class TypedSchema:
                 try:
                     schema_str = str(parse_protobuf_schema_definition(schema_str, None, None, False))
                 except InvalidSchema as e:
-                    LOG.exception("Schema is not valid ProtoBuf definition")
+                    LOG.info("Schema is not valid ProtoBuf definition")
                     raise e
 
         else:

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -165,7 +165,7 @@ class KafkaSchemaReader(Thread):
                     LOG.warning("[Admin Client] No Brokers available yet. Retrying")
                     self._stop_schema_reader.wait(timeout=KAFKA_CLIENT_CREATION_TIMEOUT_SECONDS)
                 except KafkaConfigurationError:
-                    LOG.exception("[Admin Client] Invalid configuration. Bailing")
+                    LOG.info("[Admin Client] Invalid configuration. Bailing")
                     raise
                 except Exception as e:  # pylint: disable=broad-except
                     LOG.exception("[Admin Client] Unexpected exception. Retrying")
@@ -182,7 +182,7 @@ class KafkaSchemaReader(Thread):
                     LOG.warning("[Consumer] No Brokers available yet. Retrying")
                     self._stop_schema_reader.wait(timeout=2.0)
                 except KafkaConfigurationError:
-                    LOG.exception("[Consumer] Invalid configuration. Bailing")
+                    LOG.info("[Consumer] Invalid configuration. Bailing")
                     raise
                 except Exception as e:  # pylint: disable=broad-except
                     LOG.exception("[Consumer] Unexpected exception. Retrying")
@@ -239,7 +239,7 @@ class KafkaSchemaReader(Thread):
             # * See `OFFSET_EMPTY` and `OFFSET_UNINITIALIZED`
             return beginning_offset - 1
         except KafkaTimeoutError:
-            LOG.exception("Reading begin offsets timed out.")
+            LOG.warning("Reading begin offsets timed out.")
         except Exception as e:  # pylint: disable=broad-except
             self.stats.unexpected_exception(ex=e, where="_get_beginning_offset")
             LOG.exception("Unexpected exception when reading begin offsets.")
@@ -254,7 +254,7 @@ class KafkaSchemaReader(Thread):
         try:
             _, end_offset = self.consumer.get_watermark_offsets(TopicPartition(self.config["topic_name"], 0))
         except KafkaTimeoutError:
-            LOG.exception("Reading end offsets timed out.")
+            LOG.warning("Reading end offsets timed out.")
             return False
         except Exception as e:  # pylint: disable=broad-except
             self.stats.unexpected_exception(ex=e, where="_is_ready")


### PR DESCRIPTION
Exception level logging should only be used for cases where there's an actual application error, but in many cases was being used for recoverable situations and during normal operations and user errors. The right place to use exception level logging is when the exception is unknown, not just when any Python exception has occurred.

In some situations exceptions were logged before being re-raised, those were demoted to info logs since there's no value in having duplicated logging.

Overall, exception handling is not structured throughout Karapace and we at some point need to do a deep inventory. In many places we catch broad exceptions where we really should not, and this is likely having bad effects on behavior during memory constrained operations and similar.