### PR TITLE
Graceful handling of broker response errors

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -1096,7 +1096,6 @@ class UserRestProxy:
                 # cancel is retriable
                 produce_results.append({"error_code": 1, "error": "Publish message cancelled"})
             elif isinstance(result, BrokerResponseError):
-                log.error("Broker error", exc_info=result)
                 resp = {"error_code": 1, "error": result.description}
                 if hasattr(result, "retriable") and result.retriable:
                     resp["error_code"] = 2


### PR DESCRIPTION
# About this change - What it does

BrokerResponseErrors include meaningful reason and message (e.g. topic authorization failed), which can be passed to caller of Kafka REST api here, so it is not an error in Karapace, and should not be logged as such.
