### PR TITLE
fix: harden the order of keys that needs to be serialized

### DIFF
--- a/src/karapace/schema_registry_apis.py
+++ b/src/karapace/schema_registry_apis.py
@@ -1307,7 +1307,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         if auth_header is not None:
             headers["Authorization"] = auth_header
 
-        with async_timeout.timeout(timeout):
+        async with async_timeout.timeout(timeout):
             async with func(url, headers=headers, json=body) as response:
                 if response.headers.get("content-type", "").startswith(JSON_CONTENT_TYPE):
                     resp_content = await response.json()


### PR DESCRIPTION
# Why this way
Previously we were relying on the fact that the `.keys()` order and the `json.dumps()` order are always sync. This enforces by the `OrderedDict` a fixed order. Not sure if the same odering check should be performed also for the `is_key_in_canonical_format`, probably here we want to ensure that the current dict has exactly the same order in the `keys()`.