### PR TITLE
feat: GET /mode and GET /mode/<subject:path> endpoints

### DIFF
--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -29,7 +29,7 @@ from karapace.offset_watcher import OffsetWatcher
 from karapace.schema_models import ParsedTypedSchema, SchemaType, SchemaVersion, TypedSchema, ValidatedTypedSchema
 from karapace.schema_reader import KafkaSchemaReader
 from karapace.schema_references import LatestVersionReference, Reference
-from karapace.typing import JsonObject, ResolvedVersion, SchemaId, Subject, Version
+from karapace.typing import JsonObject, Mode, ResolvedVersion, SchemaId, Subject, Version
 from typing import Mapping, Sequence
 
 import asyncio
@@ -438,6 +438,12 @@ class KarapaceSchemaRegistry:
             subject_versions.append({"subject": schema_version.subject, "version": schema_version.version})
         subject_versions = sorted(subject_versions, key=lambda s: (s["subject"], s["version"]))
         return subject_versions
+
+    def get_global_mode(self) -> Mode:
+        return Mode.readwrite
+
+    def get_subject_mode(self) -> Mode:
+        return Mode.readwrite
 
     def send_schema_message(
         self,

--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -49,3 +49,8 @@ class SubjectType(StrEnum, Enum):
     value = "value"
     # partition it's a function of `str` and StrEnum its inherits from it.
     partition_ = "partition"
+
+
+@unique
+class Mode(StrEnum):
+    readwrite = "READWRITE"

--- a/tests/integration/test_schema_registry_auth.py
+++ b/tests/integration/test_schema_registry_auth.py
@@ -100,6 +100,12 @@ async def test_sr_auth_endpoints(registry_async_client_auth: Client) -> None:
     res = await registry_async_client_auth.delete(f"subjects/{quote(subject)}")
     assert res.status_code == 401
 
+    res = await registry_async_client_auth.get("mode")
+    assert res.status_code == 401
+
+    res = await registry_async_client_auth.get(f"mode/{quote(subject)}")
+    assert res.status_code == 401
+
 
 async def test_sr_list_subjects(registry_async_client_auth: Client) -> None:
     cavesubject = new_random_name("cave-")

--- a/tests/integration/test_schema_registry_mode.py
+++ b/tests/integration/test_schema_registry_mode.py
@@ -1,0 +1,53 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.client import Client
+from karapace.typing import Mode
+from tests.utils import create_schema_name_factory, create_subject_name_factory
+
+import json
+import pytest
+
+
+@pytest.mark.parametrize("trail", ["", "/"])
+async def test_global_mode(registry_async_client: Client, trail: str) -> None:
+    res = await registry_async_client.get(f"/mode{trail}")
+    assert res.status_code == 200
+    json_res = res.json()
+    assert json_res == {"mode": str(Mode.readwrite)}
+
+
+@pytest.mark.parametrize("trail", ["", "/"])
+async def test_subject_mode(registry_async_client: Client, trail: str) -> None:
+    subject_name_factory = create_subject_name_factory(f"test_schema_same_subject_{trail}")
+    schema_name = create_schema_name_factory(f"test_schema_same_subject_{trail}")()
+
+    schema_str = json.dumps(
+        {
+            "type": "record",
+            "name": schema_name,
+            "fields": [
+                {
+                    "name": "f",
+                    "type": "string",
+                }
+            ],
+        }
+    )
+    subject = subject_name_factory()
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schema": schema_str},
+    )
+    assert res.status_code == 200
+
+    res = await registry_async_client.get(f"/mode/{subject}{trail}")
+    assert res.status_code == 200
+    json_res = res.json()
+    assert json_res == {"mode": str(Mode.readwrite)}
+
+    res = await registry_async_client.get(f"/mode/unknown_subject{trail}")
+    assert res.status_code == 404
+    json_res = res.json()
+    assert json_res == {"error_code": 40401, "message": "Subject 'unknown_subject' not found."}


### PR DESCRIPTION
# About this change - What it does

Add mode GET support to Karapace. The mode is always READWRITE and response contains static `{"mode": "READWRITE"}` mode for global and subject modes.
