### PR TITLE
refactor: optimize the authorization check for get schema by id

### DIFF
--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,224 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.auth import ACLAuthorizer, ACLEntry, hash_password, HashAlgorithm, Operation, User
+
+import re
+
+
+def test_empty_acl_authorizer() -> None:
+    authorizer = ACLAuthorizer()
+    admin_password_hash = hash_password(algorithm=HashAlgorithm.SHA256, salt="salt", plaintext_password="password")
+    assert False is authorizer.check_authorization(
+        user=User(username="admin", algorithm=HashAlgorithm.SHA256, salt="salt", password_hash=admin_password_hash),
+        operation=Operation.Read,
+        resource="Subject:*",
+    )
+
+
+def test_acl_authorizer() -> None:
+    admin_password_hash = hash_password(
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        plaintext_password="admin_password",
+    )
+    read_user_password_hash = hash_password(
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        plaintext_password="read_password",
+    )
+    write_user_password_hash = hash_password(
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        plaintext_password="write_password",
+    )
+    readwrite_user_password_hash = hash_password(
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        plaintext_password="readwrite_password",
+    )
+
+    admin_user = User(
+        username="admin",
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        password_hash=admin_password_hash,
+    )
+    read_user = User(
+        username="read",
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        password_hash=read_user_password_hash,
+    )
+    write_user = User(
+        username="write",
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        password_hash=write_user_password_hash,
+    )
+    readwrite_user = User(
+        username="readwrite",
+        algorithm=HashAlgorithm.SHA256,
+        salt="salt",
+        password_hash=readwrite_user_password_hash,
+    )
+
+    authorizer = ACLAuthorizer(
+        user_db={
+            "admin": admin_user,
+            "read": read_user,
+            "write": write_user,
+            "readwrite": readwrite_user,
+        },
+        permissions=[
+            ACLEntry("admin", Operation.Read, re.compile("Subject:*")),
+            ACLEntry("admin", Operation.Write, re.compile("Subject:*")),
+            ACLEntry("admin", Operation.Read, re.compile("Config:*")),
+            ACLEntry("admin", Operation.Write, re.compile("Config:*")),
+            ACLEntry("read", Operation.Read, re.compile("Subject:read_subject")),
+            ACLEntry("write", Operation.Write, re.compile("Subject:write_subject")),
+            ACLEntry("readwrite", Operation.Read, re.compile("Subject:readwrite_subject")),
+            ACLEntry("readwrite", Operation.Write, re.compile("Subject:readwrite_subject")),
+        ],
+    )
+
+    assert True is authorizer.check_authorization(
+        user=admin_user,
+        operation=Operation.Read,
+        resource="Subject:any_subject",
+    )
+    assert True is authorizer.check_authorization(
+        user=admin_user,
+        operation=Operation.Read,
+        resource="Config:any_config",
+    )
+    assert True is authorizer.check_authorization_any(
+        user=admin_user,
+        operation=Operation.Read,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+        ],
+    )
+
+    assert True is authorizer.check_authorization(
+        user=read_user,
+        operation=Operation.Read,
+        resource="Subject:read_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=read_user,
+        operation=Operation.Read,
+        resource="Subject:any_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=read_user,
+        operation=Operation.Write,
+        resource="Subject:read_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=read_user,
+        operation=Operation.Write,
+        resource="Subject:write_subject",
+    )
+    assert False is authorizer.check_authorization_any(
+        user=read_user,
+        operation=Operation.Read,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+        ],
+    )
+    assert True is authorizer.check_authorization_any(
+        user=read_user,
+        operation=Operation.Read,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+            "Subject:read_subject",
+        ],
+    )
+
+    assert True is authorizer.check_authorization(
+        user=write_user,
+        operation=Operation.Write,
+        resource="Subject:write_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=write_user,
+        operation=Operation.Write,
+        resource="Subject:any_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=write_user,
+        operation=Operation.Write,
+        resource="Subject:read_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=write_user,
+        operation=Operation.Read,
+        resource="Subject:read_subject",
+    )
+    assert False is authorizer.check_authorization_any(
+        user=write_user,
+        operation=Operation.Write,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+        ],
+    )
+    assert True is authorizer.check_authorization_any(
+        user=write_user,
+        operation=Operation.Write,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+            "Subject:write_subject",
+        ],
+    )
+
+    assert True is authorizer.check_authorization(
+        user=readwrite_user,
+        operation=Operation.Write,
+        resource="Subject:readwrite_subject",
+    )
+    assert True is authorizer.check_authorization(
+        user=readwrite_user,
+        operation=Operation.Read,
+        resource="Subject:readwrite_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=readwrite_user,
+        operation=Operation.Write,
+        resource="Subject:any_subject",
+    )
+    assert False is authorizer.check_authorization(
+        user=readwrite_user,
+        operation=Operation.Write,
+        resource="Subject:read_subject",
+    )
+    assert False is authorizer.check_authorization_any(
+        user=readwrite_user,
+        operation=Operation.Write,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+        ],
+    )
+    assert True is authorizer.check_authorization_any(
+        user=readwrite_user,
+        operation=Operation.Write,
+        resources=[
+            "Config:any_config",
+            "Subject:any_subject",
+            "Unknown:resource",
+            "Subject:readwrite_subject",
+        ],
+    )


### PR DESCRIPTION
# About this change - What it does

Load the subjects associated with the schema id from in-memory database. This list can be used as source for subjects to match user ACLs.

The ACL authorizator is added which can operate only on the user dictionary and permission list. HTTP authorizer inherits this class and add the file loading and HTTP authorization handling on top. Unit tests for ACL authorizer are added.

# Why this way

Reduces the amount of elements iterated from the in-memory database. The returned amount of data is also greatly reduced when in-memory database collects the subjects with schema id directly instead of filtering in the `_has_subject_with_id` function.