### PR TITLE
protobuf: recognize tag alter modification

### DIFF
--- a/karapace/protobuf/compare_result.py
+++ b/karapace/protobuf/compare_result.py
@@ -26,6 +26,7 @@ class Modification(Enum):
     FIELD_NAME_ALTER = auto()
     FIELD_KIND_ALTER = auto()
     FIELD_TYPE_ALTER = auto()
+    FIELD_TAG_ALTER = auto()
     ONE_OF_ADD = auto()
     ONE_OF_DROP = auto()
     ONE_OF_MOVE = auto()
@@ -43,6 +44,7 @@ class Modification(Enum):
             self.FIELD_LABEL_ALTER,
             self.FIELD_KIND_ALTER,
             self.FIELD_TYPE_ALTER,
+            self.FIELD_TAG_ALTER,
             self.ONE_OF_FIELD_DROP,
             self.FEW_FIELDS_CONVERTED_TO_ONE_OF,
         ]  # type: ignore[comparison-overlap]

--- a/karapace/protobuf/message_element.py
+++ b/karapace/protobuf/message_element.py
@@ -94,14 +94,18 @@ class MessageElement(TypeElement):
         if types.lock_message(self):
             self_tags = {}
             other_tags = {}
+            self_names = {}
+            other_names = {}
             self_one_ofs = {}
             other_one_ofs = {}
 
             for field in self.fields:
                 self_tags[field.tag] = field
+                self_names[field.name] = field
 
             for field in other.fields:
                 other_tags[field.tag] = field
+                other_names[field.name] = field
 
             for one_of in self.one_ofs:
                 self_one_ofs[one_of.name] = one_of
@@ -125,6 +129,20 @@ class MessageElement(TypeElement):
             for tag in chain(self_tags.keys(), other_tags.keys() - self_tags.keys()):
                 result.push_path(str(tag))
 
+                if (
+                    # Check if field tag has been altered
+                    tag in self_tags
+                    and (field_name := self_tags[tag].name)
+                    and (self_field := self_names.get(field_name))
+                    and (other_field := other_names.get(field_name))
+                    and (self_field.tag != other_field.tag)
+                ):
+                    result.pop_path()
+                    result.push_path(field_name)
+                    result.add_modification(Modification.FIELD_TAG_ALTER)
+                    result.pop_path()
+                    result.push_path(str(tag))
+
                 if self_tags.get(tag) is None:
                     result.add_modification(Modification.FIELD_ADD)
                 elif other_tags.get(tag) is None:
@@ -133,6 +151,7 @@ class MessageElement(TypeElement):
                     self_tags[tag].compare(other_tags[tag], result, types)
 
                 result.pop_path()
+
             # Compare OneOfs
             for name in chain(self_one_ofs.keys(), other_one_ofs.keys() - self_one_ofs.keys()):
                 result.push_path(str(name))

--- a/tests/unit/protobuf/test_protobuf_compatibility.py
+++ b/tests/unit/protobuf/test_protobuf_compatibility.py
@@ -331,6 +331,8 @@ message Foo {
     result = CompareResult()
     self_parsed.compare(other_parsed, result)
     assert not result.is_compatible()
-    assert len(result.result) == 3  # FIELD_TAG_ALTER + FIELD_DROP + FIELD_ADD
-    assert result.result[0].modification == Modification.FIELD_TAG_ALTER
-    assert result.result[0].path == "Foo.fieldX"
+    assert {(error.modification, error.path) for error in result.result} == {
+        (Modification.FIELD_TAG_ALTER, "Foo.fieldX"),
+        (Modification.FIELD_DROP, "Foo.4"),
+        (Modification.FIELD_ADD, "Foo.5"),
+    }

--- a/tests/unit/protobuf/test_protobuf_compatibility.py
+++ b/tests/unit/protobuf/test_protobuf_compatibility.py
@@ -300,3 +300,37 @@ enum HodoCode {
     assert result.is_compatible()
     assert len(result.result) == 1
     assert result.result[0].modification == Modification.FIELD_ADD
+
+
+def test_compatibility_field_tag_change():
+    self_schema = """\
+syntax = "proto3";
+package pkg;
+message Foo {
+    string fieldA = 1;
+    string fieldB = 2;
+    string fieldC = 3;
+    string fieldX = 4;
+}
+"""
+
+    other_schema = """\
+syntax = "proto3";
+package pkg;
+message Foo {
+    string fieldA = 1;
+    string fieldB = 2;
+    string fieldC = 3;
+    string fieldX = 5;
+}
+"""
+
+    self_parsed: ProtoFileElement = ProtoParser.parse(location, self_schema)
+    other_parsed: ProtoFileElement = ProtoParser.parse(location, other_schema)
+
+    result = CompareResult()
+    self_parsed.compare(other_parsed, result)
+    assert not result.is_compatible()
+    assert len(result.result) == 3  # FIELD_TAG_ALTER + FIELD_DROP + FIELD_ADD
+    assert result.result[0].modification == Modification.FIELD_TAG_ALTER
+    assert result.result[0].path == "Foo.fieldX"


### PR DESCRIPTION
# About this change - What it does
This PR introduces a new `FIELD_TAG_ALTER` modification in order to recognize tag change of fields.

# Why this way
Changing the tag of a field is not backwards compatible but currently goes unnoticed because fields are compared by tag and not by field name. Because of this compatibility check will only recognize `FIELD_NAME_ALTER` modification which is backward compatible. This PR changes this so that if field name exists in both schemas it will compare the tags and add `FIELD_TAG_ALTER` modification if the tags don't match.
