### PR TITLE
Log message error on schema replay

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -317,6 +317,7 @@ class KafkaSchemaReader(Thread):
             try:
                 message_key = msg.key()
                 if message_key is None:
+                    LOG.warning("Empty message key when consuming from topic %s, error: %s", msg.topic(), msg.error())
                     continue
                 key = json_decode(message_key)
             except JSONDecodeError:


### PR DESCRIPTION
# About this change - What it does

It's a valid scenario that a message with `error()` set is consumed, however these are retriable in most cases, thus only logging for now.

Related to https://github.com/Aiven-Open/karapace/issues/812
