### PR TITLE
Fix no-payload commit in consumer

### DIFF
--- a/karapace/kafka/consumer.py
+++ b/karapace/kafka/consumer.py
@@ -86,7 +86,10 @@ class KafkaConsumer(_KafkaConfigMixin, Consumer):
             if message is not None:
                 return super().commit(message=message, asynchronous=False)
 
-            return super().commit(offsets=offsets, asynchronous=False)
+            if offsets is not None:
+                return super().commit(offsets=offsets, asynchronous=False)
+
+            return super().commit(asynchronous=False)
         except KafkaException as exc:
             raise_from_kafkaexception(exc)
 


### PR DESCRIPTION
# About this change - What it does

Prompted by a [Sentry error](https://aiven-io.sentry.io/issues/5038513254/?notification_uuid=5af4286d-8395-4692-a22e-bdf20bd306d5&project=1219632&referrer=assigned_activity-email), the issue is "triggered" by [this line in the consumer manager](https://github.com/Aiven-Open/karapace/blob/main/karapace/kafka_rest_apis/consumer_manager.py#L279).

The confluent-kafka `Consumer.commit` method can be called with no parameters, then the current partition assignment's offsets are used (see the documentation at
https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Consumer.commit).

The previous behaviour was erroneous, raising a `TypeError`, thus an HTTP 500 when in the REST proxy's consumer manager a commit is performed with an empty payload.

