### PR TITLE
Add tests for empty payload consumer commit

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -180,9 +180,11 @@ REST_HEADERS = {
 }
 
 
-async def new_consumer(c, group, fmt="avro", trail=""):
+async def new_consumer(c, group, fmt="avro", trail="", payload_override=None):
     payload = copy.copy(consumer_valid_payload)
     payload["format"] = fmt
+    if payload_override:
+        payload.update(payload_override)
     resp = await c.post(f"/consumers/{group}{trail}", json=payload, headers=REST_HEADERS[fmt])
     assert resp.ok
     return resp.json()["instance_id"]


### PR DESCRIPTION
# About this change - What it does

Following up on #833, adding tests around the fix that was hastily implemented there.
