### PR TITLE
fix: handle InMemoryDatabase find_schemas latest when no versions available for subject

### DIFF
--- a/karapace/in_memory_database.py
+++ b/karapace/in_memory_database.py
@@ -174,7 +174,7 @@ class InMemoryDatabase:
             for subject, subject_data in self.subjects.items():
                 selected_schemas: list[SchemaVersion] = []
                 schemas = list(subject_data.schemas.values())
-                if latest_only:
+                if latest_only and len(schemas) > 0:
                     # TODO don't include the deleted here?
                     selected_schemas = [schemas[-1]]
                 else:

--- a/tests/unit/test_in_memory_database.py
+++ b/tests/unit/test_in_memory_database.py
@@ -1,0 +1,14 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.in_memory_database import InMemoryDatabase, Subject
+
+
+class TestFindSchemas:
+    def test_returns_empty_list_when_no_schemas(self) -> None:
+        database = InMemoryDatabase()
+        subject = Subject("hello_world")
+        database.insert_subject(subject=subject)
+        expected = {subject: []}
+        assert database.find_schemas(include_deleted=True, latest_only=True) == expected


### PR DESCRIPTION
This PR fixes an `IndexError: list index out of range` exception raised when calling `InMemoryDatabase.find_schemas` with argument `latest_only = True` and there's a schema with no versions. 