### PR TITLE
422 instead of 500 on subject schema error

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1104,14 +1104,14 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 schema_type=schema_type, schema_str=schema_str, references=references, dependencies=new_schema_dependencies
             )
         except InvalidSchema:
-            self.log.exception("No proper parser found")
+            self.log.warning("Invalid schema: %r", schema_str)
             self.r(
                 body={
-                    "error_code": SchemaErrorCodes.HTTP_INTERNAL_SERVER_ERROR.value,
+                    "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
                     "message": f"Error while looking up schema under subject {subject}",
                 },
                 content_type=content_type,
-                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
         except InvalidReferences:
             human_error = "Provided references is not valid"

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1461,7 +1461,7 @@ async def test_schema_subject_post_invalid(registry_async_client: Client) -> Non
         f"subjects/{subject_1}",
         json={"schema": json.dumps({"type": "invalid_type"})},
     )
-    assert res.status_code == 500, "Invalid schema for existing subject should return 500"
+    assert res.status_code == 422, "Invalid schema for existing subject should return 422"
     assert res.json()["message"] == f"Error while looking up schema under subject {subject_1}"
 
     # Subject is not found


### PR DESCRIPTION
When a user sends a bad schema, we return a 500 even though the error is handled.

Here we return a 422 instead.