### PR TITLE
Fix error message formatting variable expansion

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -75,7 +75,9 @@ class SchemaErrorMessages(Enum):
         "forward, full, backward_transitive, forward_transitive, and "
         "full_transitive"
     )
-    SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT = "Subject '%s' does not have subject-level compatibility configured"
+    SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT = (
+        "Subject '{subject}' does not have subject-level compatibility configured"
+    )
     REFERENCES_SUPPORT_NOT_IMPLEMENTED = "Schema references are not supported for '{schema_type}' schema type"
 
 

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -2103,9 +2103,7 @@ async def test_config(registry_async_client: Client, trail: str) -> None:
     res = await registry_async_client.get(f"config/{subject_1}{trail}")
     assert res.status_code == 404
     assert res.json()["error_code"] == 40408
-    assert res.json()["message"] == SchemaErrorMessages.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT.value.format(
-        subject=subject_1
-    )
+    assert res.json()["message"] == f"Subject '{subject_1}' does not have subject-level compatibility configured"
 
     res = await registry_async_client.put(f"config/{subject_1}{trail}", json={"compatibility": "FULL"})
     assert res.status_code == 200
@@ -2125,9 +2123,7 @@ async def test_config(registry_async_client: Client, trail: str) -> None:
     res = await registry_async_client.get(f"config/{subject_1}{trail}")
     assert res.status_code == 404
     assert res.json()["error_code"] == 40408
-    assert res.json()["message"] == SchemaErrorMessages.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_FMT.value.format(
-        subject=subject_1
-    )
+    assert res.json()["message"] == f"Subject '{subject_1}' does not have subject-level compatibility configured"
 
     # It's possible to add a config to a subject that doesn't exist yet
     subject_2 = subject_name_factory()


### PR DESCRIPTION
# About this change - What it does

Fix formatting of error message variable expansion if subject level compatibility mode is not configured.

# Why this way

Old code was literally asserting that error message was `Subject '%s' does not have subject-level compatibility configured`
