### PR TITLE
fix: return 422 for Avro/JSONSchema when payload does not match schema

### DIFF
--- a/karapace/kafka_rest_apis/__init__.py
+++ b/karapace/kafka_rest_apis/__init__.py
@@ -712,6 +712,13 @@ class UserRestProxy:
                 content_type=content_type,
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
+        except InvalidPayload as e:
+            cause = str(e.__cause__)
+            KafkaRest.r(
+                body={"error_code": RESTErrorCodes.INVALID_DATA.value, "message": cause},
+                content_type=content_type,
+                status=HTTPStatus.UNPROCESSABLE_ENTITY,
+            )
         except SchemaRetrievalError as e:
             KafkaRest.r(
                 body={"error_code": RESTErrorCodes.SCHEMA_RETRIEVAL_ERROR.value, "message": str(e)},


### PR DESCRIPTION
# About this change - What it does

Karapace returned 500 error for JSON payload that did not match JSON schema when serialization format was `jsonschema`.
Added an integration test which tests also Avro schema and payload.
