### PR TITLE
fix: handle ConnectionError in rapu._handle_messages

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -393,6 +393,11 @@ class RestApp:
             )
             headers = {"Content-Type": "application/json"}
             resp = aiohttp.web.Response(body=body, status=status.value, headers=headers)
+        except ConnectionError as connection_error:
+            # TCP level connection errors, e.g. TCP reset, client closes connection.
+            self.log.debug("Connection error.", exc_info=connection_error)
+            # No response can be returned and written to client, aiohttp expects some response here.
+            resp = aiohttp.web.Response(text="Connection error", status=HTTPStatus.INTERNAL_SERVER_ERROR.value)
         except asyncio.CancelledError:
             self.log.debug("Client closed connection")
             raise


### PR DESCRIPTION
# About this change - What it does

If client connection is broken there is nothing the server can do. Handle the specific case and silence stats and reporting. The aiohttp expects a response object, although this is not and cannot be written to client as the connection is already broken.
