### PR TITLE
AVRO references support

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1043,7 +1043,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 content_type=content_type,
                 status=HTTPStatus.BAD_REQUEST,
             )
-        if references and schema_type != SchemaType.PROTOBUF:
+        if references and schema_type != SchemaType.PROTOBUF and schema_type != SchemaType.AVRO:
             self.r(
                 body={
                     "error_code": SchemaErrorCodes.REFERENCES_SUPPORT_NOT_IMPLEMENTED.value,

--- a/tests/integration/test_schema_avro_references.py
+++ b/tests/integration/test_schema_avro_references.py
@@ -4,9 +4,9 @@ karapace - schema tests
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-import json
-
 from karapace.client import Client
+
+import json
 
 baseurl = "http://localhost:8081"
 
@@ -16,10 +16,7 @@ async def test_avro_references(registry_async_client: Client) -> None:
         "type": "record",
         "name": "Country",
         "namespace": "com.netapp",
-        "fields": [
-            {"name": "name", "type": "string"},
-            {"name": "code", "type": "string"}
-        ]
+        "fields": [{"name": "name", "type": "string"}, {"name": "code", "type": "string"}],
     }
 
     schema_address = {
@@ -30,14 +27,11 @@ async def test_avro_references(registry_async_client: Client) -> None:
             {"name": "street", "type": "string"},
             {"name": "city", "type": "string"},
             {"name": "postalCode", "type": "string"},
-            {"name": "country", "type": "Country"}
-        ]
-
+            {"name": "country", "type": "Country"},
+        ],
     }
 
-    res = await registry_async_client.post(
-        f"subjects/country/versions", json={"schema": json.dumps(schema_country)}
-    )
+    res = await registry_async_client.post("subjects/country/versions", json={"schema": json.dumps(schema_country)})
     assert res.status_code == 200
     assert "id" in res.json()
     country_references = [{"name": "country.proto", "subject": "country", "version": 1}]

--- a/tests/integration/test_schema_avro_references.py
+++ b/tests/integration/test_schema_avro_references.py
@@ -1,0 +1,64 @@
+"""
+karapace - schema tests
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+import json
+
+from karapace.client import Client
+
+baseurl = "http://localhost:8081"
+
+
+async def test_avro_references(registry_async_client: Client) -> None:
+    schema_country = {
+        "type": "record",
+        "name": "Country",
+        "namespace": "com.netapp",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "code", "type": "string"}
+        ]
+    }
+
+    schema_address = {
+        "type": "record",
+        "name": "Address",
+        "namespace": "com.netapp",
+        "fields": [
+            {"name": "street", "type": "string"},
+            {"name": "city", "type": "string"},
+            {"name": "postalCode", "type": "string"},
+            {"name": "country", "type": "Country"}
+        ]
+
+    }
+
+    res = await registry_async_client.post(
+        f"subjects/country/versions", json={"schema": json.dumps(schema_country)}
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    country_references = [{"name": "country.proto", "subject": "country", "version": 1}]
+
+    res = await registry_async_client.post(
+        "subjects/address/versions",
+        json={"schemaType": "AVRO", "schema": json.dumps(schema_address), "references": country_references},
+    )
+    assert res.status_code == 200
+    assert "id" in res.json()
+    address_id = res.json()["id"]
+
+    # Check if the schema has now been registered under the subject
+
+    res = await registry_async_client.post(
+        "subjects/address",
+        json={"schemaType": "AVRO", "schema": json.dumps(schema_address), "references": country_references},
+    )
+    assert res.status_code == 200
+    assert "subject" in res.json()
+    assert "id" in res.json()
+    assert address_id == res.json()["id"]
+    assert "version" in res.json()
+    assert "schema" in res.json()


### PR DESCRIPTION
Support for AVRO references has been added. The AVRO parser now receives an AVRO schema containing references, and all referenced schemas are merged on top of the original schema. A simple integration test is added.  I am looking for additional test cases to assess its capabilities.