### PR TITLE
chore: bump kafka-python:2.0.2 to kafka-python-ng:2.2.2

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,6 +4,7 @@ aiohttp<4
 confluent-kafka==2.3.0
 isodate<1
 jsonschema<5
+kafka-python-ng==2.2.2
 lz4
 networkx<4
 protobuf<4
@@ -27,5 +28,4 @@ zstandard
 # - The contents of the file change, which invalidates the existing docker
 #   images and forces a new image generation.
 #
-https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
 https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -45,7 +45,7 @@ jsonschema==4.21.1
     # via -r requirements.in
 jsonschema-specifications==2023.11.2
     # via jsonschema
-kafka-python @ https://github.com/aiven/kafka-python/archive/1b95333c9628152066fb8b1092de9da0433401fd.tar.gz
+kafka-python-ng==2.2.2
     # via -r requirements.in
 lz4==4.3.3
     # via -r requirements.in


### PR DESCRIPTION
# About this change - What it does

The `kafka-python` is unmaintained. Fork of it has been created as `kafka-python-ng`: https://github.com/wbarnha/kafka-python-ng
See note at `kafka-python`: https://github.com/dpkp/kafka-python/issues/2431
