### PR TITLE
fix: Restore pip-compile invocation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,6 @@ MAKEFLAGS     += --warn-undefined-variables
 MAKEFLAGS     += --no-builtin-rules
 SHELL         := bash
 .SHELLFLAGS   := -euxo pipefail -O globstar -c
-.ONESHELL:
 .SILENT:
 .SUFFIXES:
 
@@ -86,9 +85,9 @@ cleanest: cleaner
 requirements: export CUSTOM_COMPILE_COMMAND='make requirements'
 requirements:
 	pip install --upgrade pip setuptools pip-tools
-	pip-compile --upgrade --resolver=backtracking requirements/requirements.in -o requirements/requirements.txt
-	pip-compile --upgrade --resolver=backtracking requirements/requirements-dev.in -o requirements/requirements-dev.txt
-	pip-compile --upgrade --resolver=backtracking requirements/requirements-typing.in -o requirements/requirements-typing.txt
+	cd requirements && pip-compile --upgrade --resolver=backtracking requirements.in -o requirements.txt
+	cd requirements && pip-compile --upgrade --resolver=backtracking requirements-dev.in -o requirements-dev.txt
+	cd requirements && pip-compile --upgrade --resolver=backtracking requirements-typing.in -o requirements-typing.txt
 
 .PHONY: schema
 schema: against := origin/main


### PR DESCRIPTION
In eb9ee31b3ff5879546d70737903cd6941562fb2d, pip-compile was changed to no longer cd into the requirements directory. The reason for this change was because of the use of `ONESHELL` which causes diverging behavior in environments with make versions that don't yet support this mode.

This commit reverts the removal of the `cd` invocations, and additionally removes the `ONESHELL` option which should make behavior aligned across dev envs.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
