### PR TITLE
Update schema_registry.py

### DIFF
--- a/karapace/schema_registry.py
+++ b/karapace/schema_registry.py
@@ -56,6 +56,8 @@ def validate_version(version: Version) -> Version:
         version_number = int(version)
         if version_number > 0:
             return version
+        if version_number == -1:
+            return "latest"
         raise InvalidVersion(f"Invalid version {version_number}")
     except ValueError as ex:
         if version == "latest":

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1254,7 +1254,7 @@ async def test_schema_delete_latest_version(registry_async_client: Client, trail
     await assert_schema_versions(registry_async_client, trail, schema_id_2, [])
 
     # Deleting the latest version, no schemas left
-    res = await registry_async_client.delete(f"subjects/{subject}/versions/latest")
+    res = await registry_async_client.delete(f"subjects/{subject}/versions/-1")
     assert res.status_code == 200
     assert res.json() == version_1
 


### PR DESCRIPTION
validate_version now check if version_number is equal to -1 and in case forward "latest"

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
`validate_version` check now if version is equals to -1 and in case forward "latest"
I've modifies a test that delete a version via -1 instad of latest.

This should work as intended

<!-- Provide a small sentence that summarizes the change. -->


# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

Confluent Schema Registry accept -1 as version for latest schema version