### PR TITLE
fix: log InvalidSchema exception on INFO level

### DIFF
--- a/karapace/schema_registry_apis.py
+++ b/karapace/schema_registry_apis.py
@@ -1212,7 +1212,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
                 normalize=normalize,
             )
         except (InvalidReferences, InvalidSchema, InvalidSchemaType) as e:
-            self.log.warning("Invalid schema: %r", body["schema"], exc_info=True)
+            self.log.info("Invalid schema: %r", body["schema"], exc_info=True)
             if isinstance(e.__cause__, (SchemaParseException, JSONDecodeError, ProtobufUnresolvedDependencyException)):
                 human_error = f"{e.__cause__.args[0]}"  # pylint: disable=no-member
             else:


### PR DESCRIPTION
# About this change - What it does

The Sentry SDK integration by default sends the warning level logs to Sentry backend. Posted input data is handled and correct 422 response is sent back to client and there is no need to create entry for this to Sentry.
