### PR TITLE
rapu: catch `aiohttp.ClientError` with a `503` response status

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -393,11 +393,11 @@ class RestApp:
             )
             headers = {"Content-Type": "application/json"}
             resp = aiohttp.web.Response(body=body, status=status.value, headers=headers)
-        except ConnectionError as connection_error:
+        except (ConnectionError, aiohttp.ClientError) as connection_error:
             # TCP level connection errors, e.g. TCP reset, client closes connection.
             self.log.debug("Connection error.", exc_info=connection_error)
             # No response can be returned and written to client, aiohttp expects some response here.
-            resp = aiohttp.web.Response(text="Connection error", status=HTTPStatus.INTERNAL_SERVER_ERROR.value)
+            resp = aiohttp.web.Response(text="Connection error", status=HTTPStatus.SERVICE_UNAVAILABLE.value)
         except asyncio.CancelledError:
             self.log.debug("Client closed connection")
             raise


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This catches `aiohttp.ClientError` and returns `HTTPStatus<503>` rather than `HTTPStatus<500>`. 
We also catch the base `aiohttp.ClientError` rather than just `aiohttp.ClientConnectorError`, as for us, most client errors will also be TCP connection related, rather than actual invalid request data, etc and we include the exception information with the logged message, this can further aid debugging. 

References: [HH-3866](https://aiven.atlassian.net/browse/HH-3866)

# Why this way
Reflects properly the behaviour of the server via the response status. 