### PR TITLE
karapace: avoid starting until topic its successfully created

### DIFF
--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -240,11 +240,12 @@ class KafkaSchemaReader(Thread):
                     # Handles also a unusual case of purged schemas topic where starting offset can be > 0
                     # and no records to process.
                     self.offset = self._get_beginning_offset()
-                try:
-                    self.handle_messages()
-                except Exception as e:  # pylint: disable=broad-except
-                    self.stats.unexpected_exception(ex=e, where="schema_reader_loop")
-                    LOG.exception("Unexpected exception in schema reader loop")
+                else:
+                    try:
+                        self.handle_messages()
+                    except Exception as e:  # pylint: disable=broad-except
+                        self.stats.unexpected_exception(ex=e, where="schema_reader_loop")
+                        LOG.exception("Unexpected exception in schema reader loop")
 
     def _get_beginning_offset(self) -> int:
         assert self.consumer is not None, "Thread must be started"


### PR DESCRIPTION
Since the underlying `create_topics` function unless the `operation_timeout` its async (the effects of this call aren't immediately visible after the call its performed), if karapace its started on a cluster that its slow enough in creating the topic, we get an unhandled exception in the startup of the service of type:
```
aiokafka.errors.UnknownTopicOrPartitionError: [Error 3] UnknownTopicOrPartitionError
```

The fix its simple, try to query from the cluster (immediately after having commanded the creation of the topic) the offsets of the topic. If the returned status its `OFFSET_UNINITIALIZED` we simply need to try again shortly later.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
