### PR TITLE
fix: remove the raise Invalid version when instantiating a version 0

### DIFF
--- a/karapace/typing.py
+++ b/karapace/typing.py
@@ -69,7 +69,7 @@ class Version:
     def __init__(self, version: int) -> None:
         if not isinstance(version, int):
             raise InvalidVersion(f"Invalid version {version}")
-        if (version < Version.MINUS_1_VERSION_TAG) or (version == 0):
+        if version < Version.MINUS_1_VERSION_TAG:
             raise InvalidVersion(f"Invalid version {version}")
         self._value = version
 

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -45,6 +45,10 @@ class TestVersion:
     def test_is_latest(self, version: Version, is_latest: bool):
         assert version.is_latest is is_latest
 
+    def version_0_its_constructable(self) -> None:
+        version_0 = Version(0)
+        assert version_0.value == 0
+
     def test_text_formating(self, version: Version):
         assert f"{version}" == "1"
         assert f"{version!r}" == "Version(1)"
@@ -159,7 +163,11 @@ class TestVersioner:
     def test_validate(self, tag: VersionTag):
         Versioner.validate_tag(tag=tag)
 
-    @pytest.mark.parametrize("tag", ["invalid_version", 0, -20, "0"])
+    @pytest.mark.parametrize("tag", ["invalid_version", "0", -20])
     def test_validate_invalid(self, tag: VersionTag):
+        """
+        Tagger should still keep invalid version 0, we are only backwards compatible, and we should
+        avoid generating 0 as a new tag for any schema.
+        """
         with pytest.raises(InvalidVersion):
             Versioner.validate_tag(tag=tag)


### PR DESCRIPTION
… This is required due to back compatibility, in the past was possible to create schema with version 0, we should deny creating new versions starting from 0 but not raising an issue if this is done during the load of the previous schema

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
