### PR TITLE
fix: get rid of the path for fully qualified names.

### DIFF
--- a/karapace/protobuf/schema.py
+++ b/karapace/protobuf/schema.py
@@ -23,12 +23,12 @@ from karapace.protobuf.proto_file_element import ProtoFileElement
 from karapace.protobuf.proto_parser import ProtoParser
 from karapace.protobuf.serialization import deserialize, serialize
 from karapace.protobuf.type_element import TypeElement
+from karapace.protobuf.type_tree import SourceFileReference, TypeTree
 from karapace.protobuf.utils import append_documentation, append_indented
 from karapace.schema_references import Reference
-from typing import Iterable, Mapping, Sequence
+from typing import Mapping, Sequence
 
 import binascii
-import itertools
 
 
 def add_slashes(text: str) -> str:
@@ -122,88 +122,6 @@ class UsedType:
     used_attribute_type: str
 
 
-@default_dataclass
-class SourceFileReference:
-    reference: str
-    import_order: int
-
-
-@default_dataclass
-class TypeTree:
-    token: str
-    children: list[TypeTree]
-    source_reference: SourceFileReference | None
-
-    def source_reference_tree_recursive(self) -> Iterable[SourceFileReference | None]:
-        sources = [] if self.source_reference is None else [self.source_reference]
-        for child in self.children:
-            sources = itertools.chain(sources, child.source_reference_tree())
-        return sources
-
-    def source_reference_tree(self) -> Iterable[SourceFileReference]:
-        return filter(lambda x: x is not None, self.source_reference_tree_recursive())
-
-    def inserted_elements(self) -> int:
-        """
-        Returns the newest element generation accessible from that node.
-        Where with the term generation we mean the order for which a message
-        has been imported.
-        If called on the root of the tree it corresponds with the number of
-        fully specified path objects present in the tree.
-        """
-        return max(reference.import_order for reference in self.source_reference_tree())
-
-    def oldest_matching_import(self) -> int:
-        """
-        Returns the oldest element generation accessible from that node.
-        Where with the term generation we mean the order for which a message
-        has been imported.
-        """
-        return min(reference.import_order for reference in self.source_reference_tree())
-
-    def expand_missing_absolute_path_recursive(self, oldest_import: int) -> Sequence[str]:
-        """
-        Method that, once called on a node, traverse all the leaf and
-        return the oldest imported element with the common postfix.
-        This is also the current behaviour
-        of protobuf while dealing with a not fully specified path, it seeks for
-        the firstly imported message with a matching path.
-        """
-        if self.source_reference is not None:
-            if self.source_reference.import_order == oldest_import:
-                return [self.token]
-            return []
-
-        for child in self.children:
-            maybe_oldest_child = child.expand_missing_absolute_path_recursive(oldest_import)
-            if maybe_oldest_child is not None:
-                return list(maybe_oldest_child) + [self.token]
-
-        return []
-
-    def expand_missing_absolute_path(self) -> Sequence[str]:
-        oldest_import = self.oldest_matching_import()
-        expanded_missing_path = self.expand_missing_absolute_path_recursive(oldest_import)
-        assert (
-            expanded_missing_path is not None
-        ), "each node should have, by construction, at least a leaf that is a fully specified path"
-        return expanded_missing_path[:-1]  # skipping myself since I was matched
-
-    @property
-    def is_fully_qualified_type(self) -> bool:
-        return len(self.children) == 0
-
-    def represent(self, level=0) -> str:
-        spacing = " " * 3 * level
-        if self.is_fully_qualified_type:
-            return f"{spacing}>{self.token}"
-        child_repr = "\n".join(child.represent(level=level + 1) for child in self.children)
-        return f"{spacing}{self.token} ->\n{child_repr}"
-
-    def __repr__(self) -> str:
-        return self.represent()
-
-
 def _add_new_type_recursive(
     parent_tree: TypeTree,
     remaining_tokens: list[str],
@@ -258,6 +176,7 @@ class ProtobufSchema:
     ) -> None:
         if type(schema).__name__ != "str":
             raise IllegalArgumentException("Non str type of schema string")
+        self.schema = schema
         self.cache_string = ""
 
         if proto_file_element is not None:

--- a/karapace/protobuf/type_tree.py
+++ b/karapace/protobuf/type_tree.py
@@ -1,0 +1,121 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from karapace.dataclasses import default_dataclass
+from karapace.utils import remove_prefix
+
+import itertools
+
+
+@default_dataclass
+class SourceFileReference:
+    reference: str
+    import_order: int
+
+
+@default_dataclass
+class TypeTree:
+    token: str
+    children: list[TypeTree]
+    source_reference: SourceFileReference | None
+
+    def source_reference_tree_recursive(self) -> list[SourceFileReference]:
+        return list(
+            itertools.chain(
+                [] if self.source_reference is None else [self.source_reference],
+                *[child.source_reference_tree() for child in self.children],
+            )
+        )
+
+    def source_reference_tree(self) -> Iterable[SourceFileReference]:
+        return filter(lambda x: x is not None, self.source_reference_tree_recursive())
+
+    def inserted_elements(self) -> int:
+        """
+        Returns the newest element generation accessible from that node.
+        Where with the term generation we mean the order for which a message
+        has been imported.
+        If called on the root of the tree it corresponds with the number of
+        fully specified path objects present in the tree.
+        """
+        return max(reference.import_order for reference in self.source_reference_tree())
+
+    def oldest_matching_import(self) -> int:
+        """
+        Returns the oldest element generation accessible from that node.
+        Where with the term generation we mean the order for which a message
+        has been imported.
+        """
+        return min(reference.import_order for reference in self.source_reference_tree())
+
+    def expand_missing_absolute_path_recursive(self, oldest_import: int) -> Sequence[str]:
+        """
+        Method that, once called on a node, traverse all the leaf and
+        return the oldest imported element with the common postfix.
+        This is also the current behaviour
+        of protobuf while dealing with a not fully specified path, it seeks for
+        the firstly imported message with a matching path.
+        """
+        if self.source_reference is not None:
+            if self.source_reference.import_order == oldest_import:
+                return [self.token]
+            return []
+
+        for child in self.children:
+            maybe_oldest_child = child.expand_missing_absolute_path_recursive(oldest_import)
+            if maybe_oldest_child is not None:
+                return list(maybe_oldest_child) + [self.token]
+
+        return []
+
+    @staticmethod
+    def _type_in_tree(tree: TypeTree, remaining_tokens: list[str]) -> TypeTree | None:
+        if remaining_tokens:
+            to_seek = remaining_tokens.pop()
+
+            for child in tree.children:
+                if child.token == to_seek:
+                    return TypeTree._type_in_tree(child, remaining_tokens)
+            return None
+        return tree
+
+    def type_in_tree(self, queried_type: str) -> TypeTree | None:
+        return TypeTree._type_in_tree(self, remove_prefix(queried_type, ".").split("."))
+
+    def expand_missing_absolute_path(self) -> Sequence[str]:
+        oldest_import = self.oldest_matching_import()
+        expanded_missing_path = self.expand_missing_absolute_path_recursive(oldest_import)
+        assert (
+            expanded_missing_path is not None
+        ), "each node should have, by construction, at least a leaf that is a fully specified path"
+        return expanded_missing_path[:-1]  # skipping myself since I was matched
+
+    @property
+    def is_fully_qualified_type(self) -> bool:
+        return len(self.children) == 0
+
+    @property
+    def types_with_same_scope(self) -> int:
+        # if we have the source set means that the type its defined there by a source.
+        return sum(
+            [children.types_with_same_scope for children in self.children] + [1 if self.source_reference is not None else 0]
+        )
+
+    @property
+    def is_uniquely_identifiable_type(self) -> bool:
+        # to be uniquely identifying we should find exactly 1 source that provide the current definition.
+        return self.types_with_same_scope == 1
+
+    def represent(self, level: int = 0) -> str:
+        spacing = " " * 3 * level
+        if self.is_fully_qualified_type:
+            return f"{spacing}>{self.token}"
+        child_repr = "\n".join(child.represent(level=level + 1) for child in self.children)
+        return f"{spacing}{self.token} ->\n{child_repr}"
+
+    def __repr__(self) -> str:
+        return self.represent()

--- a/karapace/schema_models.py
+++ b/karapace/schema_models.py
@@ -74,7 +74,7 @@ def parse_protobuf_schema_definition(
     protobuf_schema = (
         ProtobufSchema(schema_definition, references, dependencies)
         if not normalize
-        else NormalizedProtobufSchema(schema_definition, references, dependencies)
+        else NormalizedProtobufSchema.from_protobuf_schema(ProtobufSchema(schema_definition, references, dependencies))
     )
     if validate_references:
         result = protobuf_schema.verify_schema_dependencies()

--- a/karapace/utils.py
+++ b/karapace/utils.py
@@ -243,3 +243,16 @@ class DebugAccessLogger(AccessLogger):
             self.logger.debug(self._log_format % tuple(values), extra=extra)
         except Exception:  # pylint: disable=broad-except
             self.logger.exception("Error in logging")
+
+
+def remove_prefix(string: str, prefix: str) -> str:
+    """
+    Not available in python 3.8.
+    """
+    i = 0
+    while i < len(string) and i < len(prefix):
+        if string[i] != prefix[i]:
+            return string
+        i += 1
+
+    return string[i:]

--- a/tests/unit/protobuf/test_protobuf_normalization.py
+++ b/tests/unit/protobuf/test_protobuf_normalization.py
@@ -2,14 +2,19 @@
 Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
+
+from karapace.dependency import Dependency
 from karapace.protobuf.compare_result import CompareResult
 from karapace.protobuf.location import Location
 from karapace.protobuf.proto_normalizations import normalize
-from karapace.protobuf.proto_parser import ProtoParser
+from karapace.schema_models import parse_protobuf_schema_definition, ValidatedTypedSchema
+from karapace.schema_type import SchemaType
+from karapace.typing import Subject, Version
+from typing import Final
 
 import pytest
 
-location: Location = Location("some/folder", "file.proto")
+LOCATION: Final[Location] = Location("somefolder", "file.proto")
 
 
 # this would be a good case for using a property based test with a well-formed message generator
@@ -511,10 +516,212 @@ service MyService {
     ),
 )
 def test_differently_ordered_options_normalizes_equally(ordered_schema: str, unordered_schema: str) -> None:
-    ordered_proto = ProtoParser.parse(location, ordered_schema)
-    unordered_proto = ProtoParser.parse(location, unordered_schema)
+    ordered_proto = parse_protobuf_schema_definition(
+        schema_definition=ordered_schema,
+        references=None,
+        dependencies=None,
+        validate_references=True,
+        normalize=True,
+    )
+    unordered_proto = parse_protobuf_schema_definition(
+        schema_definition=unordered_schema,
+        references=None,
+        dependencies=None,
+        validate_references=True,
+        normalize=True,
+    )
 
     result = CompareResult()
     normalize(ordered_proto).compare(normalize(unordered_proto), result)
     assert result.is_compatible()
     assert normalize(ordered_proto).to_schema() == normalize(unordered_proto).to_schema()
+
+
+DEPENDENCY = """\
+syntax = "proto3";
+package my.awesome.customer.v1;
+
+message NestedValue {
+    string value = 1;
+}
+\
+"""
+
+PROTO_WITH_FULLY_QUALIFIED_PATHS = """\
+syntax = "proto3";
+package my.awesome.customer.v1;
+
+import "my/awesome/customer/v1/nested_value.proto";
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "my.awesome.customer.V1";
+option go_package = "github.com/customer/api/my/awesome/customer/v1;dspv1";
+option java_multiple_files = true;
+option java_outer_classname = "EventValueProto";
+option java_package = "com.my.awesome.customer.v1";
+option objc_class_prefix = "TDD";
+option php_metadata_namespace = "My\\Awesome\\Customer\\V1";
+option php_namespace = "My\\Awesome\\Customer\\V1";
+option ruby_package = "My::Awesome::Customer::V1";
+
+message EventValue {
+  .my.awesome.customer.v1.NestedValue nested_value = 1;
+  .google.protobuf.Timestamp created_at = 2;
+}
+"""
+
+
+PROTO_WITH_SIMPLE_NAMES = """\
+syntax = "proto3";
+package my.awesome.customer.v1;
+
+import "my/awesome/customer/v1/nested_value.proto";
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "my.awesome.customer.V1";
+option go_package = "github.com/customer/api/my/awesome/customer/v1;dspv1";
+option java_multiple_files = true;
+option java_outer_classname = "EventValueProto";
+option java_package = "com.my.awesome.customer.v1";
+option objc_class_prefix = "TDD";
+option php_metadata_namespace = "My\\Awesome\\Customer\\V1";
+option php_namespace = "My\\Awesome\\Customer\\V1";
+option ruby_package = "My::Awesome::Customer::V1";
+
+message EventValue {
+  NestedValue nested_value = 1;
+  google.protobuf.Timestamp created_at = 2;
+}"""
+
+
+def test_full_path_and_simple_names_are_equal() -> None:
+    """
+    This test aims to ensure that after the normalization process the schema expressed as SimpleNames will match the same
+    schemas expressed with fully qualified references.
+    This does not consider the normalization process for the different ways a type can be expressed as a relative reference.
+
+    Long explaination below:
+
+    If we accept the specifications from buf as correct, we can look at how a type
+    reference is defined here: https://protobuf.com/docs/language-spec#type-references.
+
+    The main problem with the previous implementation is that the current parser can't tell
+    if a fully-qualified type reference in dot notation is the same as one identified by name
+    alone aka simple name notation (https://protobuf.com/docs/language-spec#fully-qualified-references).
+
+    The fix do not consider all the different ways users can define a relative reference, schemas
+     with different way of expressing a relative reference even if normalized,
+     for now will keep being considered different (https://protobuf.com/docs/language-spec#relative-references).
+
+    Right now, our logic removes the `.package_name` (+ the Message scope) part
+     before comparing field modifications (in fact it re-writes the schema using the simple name notation).
+
+    Even though the TypeTree (trie data structure) could help resolve
+    relative references (https://protobuf.com/docs/language-spec#relative-references),
+    we don't want to add this feature in the python implementation now because it might cause new bugs due to the
+    non-trivial behaviour of the protoc compiler.
+
+    We plan to properly normalize the protobuf schemas later.
+
+    We'll use protobuf descriptors (after the compilation and linking step)
+    to gather type references already resolved, and we will threaten all the protobuf
+    using always the fully qualified names.
+    Properly handling all path variations means reimplementing the protoc compiler behavior,
+     we prefer relying on the already processed proto descriptor.
+
+    So, for now, we'll only implement a normalization for the fully-qualified references
+    in dot notation and by simple name alone.
+
+    This is not changing the semantics of the message since the local scope its always the one
+    with max priority, so if you get rid of the fully-qualified reference protoc will resolve
+    the reference with the one specified in the package scope.
+    """
+    no_ref_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, DEPENDENCY, normalize=True)
+    dep = Dependency("NestedValue.proto", Subject("nested_value"), Version(1), no_ref_schema)
+    dependencies = {"NestedValue.proto": dep}
+    fully_qualitifed_simple_name_notation = parse_protobuf_schema_definition(
+        schema_definition=PROTO_WITH_SIMPLE_NAMES,
+        references=None,
+        dependencies=dependencies,
+        validate_references=True,
+        normalize=False,
+    )
+    fully_qualitifed_dot_notation = parse_protobuf_schema_definition(
+        schema_definition=PROTO_WITH_FULLY_QUALIFIED_PATHS,
+        references=None,
+        dependencies=dependencies,
+        validate_references=True,
+        normalize=True,
+    )
+    result = CompareResult()
+    fully_qualitifed_simple_name_notation.compare(normalize(fully_qualitifed_dot_notation), result)
+    assert result.is_compatible(), "normalized itn't equal to simple name"
+    assert (
+        normalize(fully_qualitifed_dot_notation).to_schema() == fully_qualitifed_simple_name_notation.to_schema()
+    ), "normalization should transform it into an equivalent simple name"
+
+    fully_qualitifed_simple_name_notation.compare(normalize(fully_qualitifed_simple_name_notation), result)
+    assert result.is_compatible(), "normalization shouldn't change a simple name notation protofile"
+    assert (
+        fully_qualitifed_simple_name_notation.to_schema() == normalize(fully_qualitifed_dot_notation).to_schema()
+    ), "also the string rendering shouldn't change a simple name notation protofile"
+
+
+TRICKY_DEPENDENCY = """\
+syntax = "proto3";
+package org.my.awesome.customer.v1;
+
+message NestedValue {
+    string value = 1;
+}\
+"""
+
+PROTO_WITH_FULLY_QUALIFIED_PATHS_AND_TRICKY_DEPENDENCY = """\
+syntax = "proto3";
+
+package my.awesome.customer.v1;
+
+import "org/my/awesome/customer/v1/nested_value.proto";
+import "my/awesome/customer/v1/nested_value.proto";
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "my.awesome.customer.V1";
+option go_package = "github.com/customer/api/my/awesome/customer/v1;dspv1";
+option java_multiple_files = true;
+option java_outer_classname = "EventValueProto";
+option java_package = "com.my.awesome.customer.v1";
+option objc_class_prefix = "TDD";
+option php_metadata_namespace = "MyAwesomeCustomerV1";
+option php_namespace = "MyAwesomeCustomerV1";
+option ruby_package = "My::Awesome::Customer::V1";
+
+message EventValue {
+  .my.awesome.customer.v1.NestedValue nested_value = 1;
+
+  google.protobuf.Timestamp created_at = 2;
+}
+"""
+
+
+def test_full_path_and_simple_names_are_not_equal_if_simple_name_is_not_unique() -> None:
+    no_ref_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, DEPENDENCY, normalize=True)
+    tricky_no_ref_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, TRICKY_DEPENDENCY, normalize=True)
+    dep = Dependency("NestedValue.proto", Subject("nested_value"), Version(1), no_ref_schema)
+    tricky_dep = Dependency("TrickyNestedValue.proto", Subject("tricky_nested_value"), Version(1), tricky_no_ref_schema)
+    dependencies = {"NestedValue.proto": dep, "TrickyNestedValue.proto": tricky_dep}
+    schema = parse_protobuf_schema_definition(
+        schema_definition=PROTO_WITH_FULLY_QUALIFIED_PATHS_AND_TRICKY_DEPENDENCY,
+        references=None,
+        dependencies=dependencies,
+        validate_references=True,
+        normalize=False,
+    ).to_schema()
+    normalized_schema = parse_protobuf_schema_definition(
+        schema_definition=PROTO_WITH_FULLY_QUALIFIED_PATHS_AND_TRICKY_DEPENDENCY,
+        references=None,
+        dependencies=dependencies,
+        validate_references=True,
+        normalize=True,
+    ).to_schema()
+
+    assert normalized_schema == schema, "Since the simple name is not unique identifying the type isn't replacing the source"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from karapace.utils import remove_prefix
+
+
+def test_remove_prefix_basic() -> None:
+    result = remove_prefix("hello world", "hello ")
+    assert result == "world"
+
+
+def test_remove_prefix_empty_prefix() -> None:
+    result = remove_prefix("hello world", "")
+    assert result == "hello world"
+
+
+def test_remove_prefix_prefix_not_in_string() -> None:
+    result = remove_prefix("hello world", "hey ")
+    assert result == "hello world"
+
+
+def test_remove_prefix_multiple_occurrences_of_prefix() -> None:
+    result = remove_prefix("hello hello world", "hello ")
+    assert result == "hello world"
+
+
+def test_remove_prefix_empty_string() -> None:
+    result = remove_prefix("", "hello ")
+    assert result == ""


### PR DESCRIPTION
This is not complete normalization feature but rather more a fix for the fully qualified paths vs simple name references. This fix not manage the various way a type can be expressed with a partial path.

Long explanation below:

If we accept the specifications from buf as correct, we can look at how a type reference is defined [here](https://protobuf.com/docs/language-spec#type-references).

The main problem with the previous implementation is that the current parser can't tell if a fully-qualified type reference in dot notation is the same as one identified by name alone aka simple name notation ([fully qualified reference](https://protobuf.com/docs/language-spec#fully-qualified-references)).

The fix do not consider all the different ways users can define a relative reference, schemas
 with different way of expressing a [relative reference](https://protobuf.com/docs/language-spec#relative-references) even if normalized,
 for now will keep being considered different.

Right now, our logic removes the `.package_name` (+ the Message scope) part
 before comparing field modifications (in fact it re-writes the schema using the simple name notation).

Even though the TypeTree (trie data structure) could help resolve [relative references](https://protobuf.com/docs/language-spec#relative-references), we don't want to add this feature in the python implementation now because it might cause new bugs due to the non-trivial behaviour of the protoc compiler.

We plan to properly normalize the protobuf schemas later.

We'll use protobuf descriptors (after the compilation and linking step) to gather type references already resolved, and we will threaten all the protobuf using always the fully qualified names.
Properly handling all path variations means reimplementing the protoc compiler behavior, we prefer relying on the already processed proto descriptor.

So, for now, we'll only implement a normalization for the fully-qualified references in dot notation and by simple name alone.

**NB:** This is not changing the semantics of the message since the local scope its always the one
 with max priority, so if you get rid of the fully-qualified reference protoc will resolve
 the reference with the one specified in the package scope.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
