### PR TITLE
chore, schema-coordinator: handle `aiokafka` retriable errors

### DIFF
--- a/karapace/coordinator/master_coordinator.py
+++ b/karapace/coordinator/master_coordinator.py
@@ -50,7 +50,7 @@ class MasterCoordinator:
                 await self._kafka_client.bootstrap()
                 break
             except KafkaConnectionError:
-                LOG.exception("Kafka client bootstrap failed.")
+                LOG.warning("Kafka client bootstrap failed.")
                 await asyncio.sleep(0.5)
 
         while not self._kafka_client.cluster.brokers():


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Handle `aiokafka` retriable errors, we see from [here](https://github.com/aio-libs/aiokafka/blob/master/aiokafka/consumer/consumer.py#L680) the `coordinator.check_errors()` is used in the consumer when getting the position, so this will always raise the errors that are registered with `coordinator._push_error_to_user()`, that way we do not flood application monitoring systems and instead log a warning.

# Service logs
Showing the now `warning` logs for the `GroupCoordinatorNotAvailableError`, we can also add a catch for `UnknownTopicOrPartitionError` which gets raised [here](https://github.com/Aiven-Open/karapace/blob/main/karapace/schema_reader.py#L351).

<img width="1137" alt="Screenshot 2024-08-20 at 15 23 05" src="https://github.com/user-attachments/assets/c2fe182b-b01a-4758-968a-61ae23909edd">


We also reduce the log level for the `master_coordinator` bootstrap errors as they [will be retried]
(https://github.com/Aiven-Open/karapace/blob/main/karapace/coordinator/master_coordinator.py#L54)

<img width="1126" alt="Screenshot 2024-08-20 at 15 44 23" src="https://github.com/user-attachments/assets/ad530c6c-1557-4be3-a0be-bc7794b8f528">

