### PR TITLE
fix: duplicated schemas on rapid elections while continuous produce of records

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -491,6 +491,11 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
    * - ``log_format``
      - ``%(name)-20s\t%(threadName)s\t%(levelname)-8s\t%(message)s``
      - Log format
+   * - ``waiting_time_before_acting_as_master_ms``
+     - ``5000``
+     - The time that a master wait before becoming an active master if at the previous round of election wasn't the master (in that case the waiting time its skipped).
+       Should be an upper bound of the time required for a master to write a message in the kafka topic + the time required from a node in the cluster to consume the
+       Log of messages. If the value its too low there is the risk under high load of producing different schemas with the ID.
 
 
 Authentication and authorization of Karapace Schema Registry REST API

--- a/src/karapace/config.py
+++ b/src/karapace/config.py
@@ -85,6 +85,7 @@ class Config(TypedDict):
     kafka_schema_reader_strict_mode: bool
     kafka_retriable_errors_silenced: bool
     use_protobuf_formatter: bool
+    waiting_time_before_acting_as_master_ms: int
 
     sentry: NotRequired[Mapping[str, object]]
     tags: NotRequired[Mapping[str, object]]
@@ -163,6 +164,7 @@ DEFAULTS: ConfigDefaults = {
     "kafka_schema_reader_strict_mode": False,
     "kafka_retriable_errors_silenced": True,
     "use_protobuf_formatter": False,
+    "waiting_time_before_acting_as_master_ms": 5000,
 }
 SECRET_CONFIG_OPTIONS = [SASL_PLAIN_PASSWORD]
 

--- a/src/karapace/schema_registry.py
+++ b/src/karapace/schema_registry.py
@@ -58,6 +58,7 @@ class KarapaceSchemaRegistry:
             master_coordinator=self.mc,
             database=self.database,
         )
+        self.mc.set_stoppper(self.schema_reader)
 
         self.schema_lock = asyncio.Lock()
         self._master_lock = asyncio.Lock()
@@ -74,7 +75,7 @@ class KarapaceSchemaRegistry:
         return list(schema_versions.values())
 
     async def start(self) -> None:
-        await self.mc.start()
+        self.mc.start()
         self.schema_reader.start()
         self.producer.initialize_karapace_producer()
 
@@ -96,7 +97,7 @@ class KarapaceSchemaRegistry:
                 are_we_master, master_url = self.mc.get_master_info()
                 if are_we_master is None:
                     LOG.info("No master set: %r, url: %r", are_we_master, master_url)
-                elif not ignore_readiness and self.schema_reader.ready is False:
+                elif not ignore_readiness and self.schema_reader.ready() is False:
                     LOG.info("Schema reader isn't ready yet: %r", self.schema_reader.ready)
                 else:
                     return are_we_master, master_url

--- a/src/karapace/typing.py
+++ b/src/karapace/typing.py
@@ -4,6 +4,7 @@ See LICENSE for details
 """
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from enum import Enum, unique
 from karapace.errors import InvalidVersion
@@ -102,3 +103,13 @@ class Version:
     @property
     def is_latest(self) -> bool:
         return self.value == self.MINUS_1_VERSION_TAG
+
+
+class SchemaReaderStoppper(ABC):
+    @abstractmethod
+    def ready(self) -> bool:
+        pass
+
+    @abstractmethod
+    def set_not_ready(self) -> None:
+        pass

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -15,6 +15,7 @@ from karapace.offset_watcher import OffsetWatcher
 from karapace.schema_reader import KafkaSchemaReader
 from karapace.utils import json_encode
 from tests.base_testcase import BaseTestCase
+from tests.integration.test_master_coordinator import AlwaysAvailableSchemaReaderStoppper
 from tests.integration.utils.kafka_server import KafkaServers
 from tests.schemas.json_schemas import FALSE_SCHEMA, TRUE_SCHEMA
 from tests.utils import create_group_name_factory, create_subject_name_factory, new_random_name, new_topic
@@ -70,8 +71,9 @@ async def test_regression_soft_delete_schemas_should_be_registered(
         }
     )
     master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
     try:
-        await master_coordinator.start()
+        master_coordinator.start()
         database = InMemoryDatabase()
         offset_watcher = OffsetWatcher()
         schema_reader = KafkaSchemaReader(
@@ -162,8 +164,9 @@ async def test_regression_config_for_inexisting_object_should_not_throw(
         }
     )
     master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
     try:
-        await master_coordinator.start()
+        master_coordinator.start()
         database = InMemoryDatabase()
         offset_watcher = OffsetWatcher()
         schema_reader = KafkaSchemaReader(
@@ -266,8 +269,9 @@ async def test_key_format_detection(
         }
     )
     master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
     try:
-        await master_coordinator.start()
+        master_coordinator.start()
         key_formatter = KeyFormatter()
         database = InMemoryDatabase()
         offset_watcher = OffsetWatcher()

--- a/tests/unit/test_schema_reader.py
+++ b/tests/unit/test_schema_reader.py
@@ -173,7 +173,7 @@ def test_readiness_check(testcase: ReadinessTestCase) -> None:
     schema_reader.offset = testcase.cur_offset
 
     schema_reader.handle_messages()
-    assert schema_reader.ready is testcase.expected
+    assert schema_reader.ready() is testcase.expected
 
 
 def test_num_max_messages_to_consume_moved_to_one_after_ready() -> None:
@@ -196,7 +196,7 @@ def test_num_max_messages_to_consume_moved_to_one_after_ready() -> None:
     assert schema_reader.max_messages_to_process == MAX_MESSAGES_TO_CONSUME_ON_STARTUP
 
     schema_reader.handle_messages()
-    assert schema_reader.ready is True
+    assert schema_reader.ready() is True
     assert schema_reader.max_messages_to_process == MAX_MESSAGES_TO_CONSUME_AFTER_STARTUP
 
 
@@ -242,16 +242,16 @@ def test_schema_reader_can_end_to_ready_state_if_last_message_is_invalid_in_sche
 
     schema_reader.handle_messages()
     assert schema_reader.offset == 1
-    assert schema_reader.ready is False
+    assert schema_reader.ready() is False
     schema_reader.handle_messages()
     assert schema_reader.offset == 2
-    assert schema_reader.ready is False
+    assert schema_reader.ready() is False
     schema_reader.handle_messages()
     assert schema_reader.offset == 3
-    assert schema_reader.ready is False
+    assert schema_reader.ready() is False
     schema_reader.handle_messages()  # call last time to call _is_ready()
     assert schema_reader.offset == 3
-    assert schema_reader.ready is True
+    assert schema_reader.ready() is True
     assert schema_reader.max_messages_to_process == MAX_MESSAGES_TO_CONSUME_AFTER_STARTUP
 
 
@@ -598,7 +598,7 @@ def test_message_error_handling(
             schema_reader.handle_messages()
 
         assert schema_reader.offset == 1
-        assert not schema_reader.ready
+        assert not schema_reader.ready()
         for log in caplog.records:
             assert log.name == "karapace.schema_reader"
             assert log.levelname == "WARNING"
@@ -640,7 +640,7 @@ def test_message_error_handling_with_invalid_reference_schema_protobuf(
             schema_reader.handle_messages()
 
             assert schema_reader.offset == 1
-            assert not schema_reader.ready
+            assert not schema_reader.ready()
 
         # When handling the schema
         schema_reader.consumer.consume.side_effect = ([message_using_ref],)
@@ -650,7 +650,7 @@ def test_message_error_handling_with_invalid_reference_schema_protobuf(
             schema_reader.handle_messages()
 
             assert schema_reader.offset == 1
-            assert not schema_reader.ready
+            assert not schema_reader.ready()
 
         warn_records = [r for r in caplog.records if r.levelname == "WARNING"]
 

--- a/tests/unit/test_schema_registry_api.py
+++ b/tests/unit/test_schema_registry_api.py
@@ -33,7 +33,7 @@ async def test_validate_schema_request_body() -> None:
 async def test_forward_when_not_ready() -> None:
     with patch("karapace.schema_registry_apis.KarapaceSchemaRegistry") as schema_registry_class:
         schema_reader_mock = Mock(spec=KafkaSchemaReader)
-        ready_property_mock = PropertyMock(return_value=False)
+        ready_property_mock = PropertyMock(return_value=lambda: False)
         schema_registry = AsyncMock(spec=KarapaceSchemaRegistry)
         type(schema_reader_mock).ready = ready_property_mock
         schema_registry.schema_reader = schema_reader_mock

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,7 @@ import json
 import os
 import ssl
 import sys
+import time
 import uuid
 
 consumer_valid_payload = {
@@ -317,6 +318,15 @@ async def repeat_until_successful_request(
             ok = res.ok
 
     return res
+
+
+async def repeat_until_master_is_available(client: Client) -> None:
+    while True:
+        res = await client.get("/master_available", json={})
+        reply = res.json()
+        if reply is not None and "master_available" in reply and reply["master_available"] is True:
+            break
+        time.sleep(1)
 
 
 def write_ini(file_path: Path, ini_data: dict) -> None:


### PR DESCRIPTION
coordinator rewrite
1. moving the coordinator in a separate thread
2. adding a waiting time between when the master its elected and the master can act. This has been done to avoid rapid elections of master that may produce schemas with different ids.

Example of what could happpen without the delay:

```md
|--------------------------------------|
|Node | Node1    | Node2    | Node3    |
|Role | Master   | Follower | Follower |
|--------------------------------------|


Node1 -> Send Message A{id=max(current_ids)} to kafka

where the max(current_ids) = 10

---------------------------------------

Node1 its disconnected, the message its still in the producer queue of Node1

---------------------------------------

Node2 its elected master

|--------------------------------------|
|Node | Node1    | Node2    | Node3    |
|Role | Follower | Master   | Follower |
|--------------------------------------|

----------------------------------------


Node2 produces a message B{id=max(current_ids)} to kafka

Because the message A isn't yet delivered to Node2, the max(current_ids) returns still 10.
And we have an ID clash.
```

The solution its simple, each master should wait a reasonable high number of milliseconds before acting as a master.
So that all the in-flight messages are delivered to kafka + the reasonable delay of the consumer for the master node before noticing that a message has been produced