### PR TITLE
rapu: fire shutdown metric on app shutdown

### DIFF
--- a/karapace/rapu.py
+++ b/karapace/rapu.py
@@ -164,6 +164,7 @@ class RestApp:
         self.app_name = app_name
         self.config = config
         self.app_request_metric = f"{app_name}_request"
+        self.app_shutdown_count_metric = f"{app_name}_shutdown_count"
         self.app = self._create_aiohttp_application(config=config)
         self.log = logging.getLogger(self.app_name)
         self.stats = StatsClient(config=config)
@@ -183,6 +184,8 @@ class RestApp:
         set as hook because the awaitables have to run inside the event loop
         created by the aiohttp library.
         """
+        self.log.warning("=======> Received shutdown signal, closing Application <=======")
+        self.stats.increase(self.app_shutdown_count_metric)
         self.stats.close()
 
     @staticmethod


### PR DESCRIPTION
# About this change - What it does
- we add the `karapace_shutdown_count` metric, to the base app and fire the metric on app shutdown
- the `close_by_app()` is added to the app shutdown hooks and thus is called on app shutdown

### Shutdown logs
<img width="1027" alt="Screenshot 2024-08-26 at 16 18 22" src="https://github.com/user-attachments/assets/953a9b09-3798-43c1-866a-3b5e2721dd67">

### Active shutdown alert after 2 manual shutdowns
<img width="1494" alt="Screenshot 2024-08-26 at 16 20 37" src="https://github.com/user-attachments/assets/19a5094f-468d-4e8d-8e4b-1b11954b4494">

### Firing shutdown alert after 2 manual shutdowns
<img width="1485" alt="Screenshot 2024-08-26 at 16 27 31" src="https://github.com/user-attachments/assets/02bdccdc-59a1-4d3a-b661-e787d62f8417">

# Why this way
This way we have a metric to count the app shutdown ands this is handled on the app server level, rather than in application code. 