### PR TITLE
tests,schema_reader: kafka message handling error tests

### DIFF
--- a/karapace/protobuf/exception.py
+++ b/karapace/protobuf/exception.py
@@ -12,14 +12,6 @@ if TYPE_CHECKING:
     from karapace.protobuf.schema import ProtobufSchema
 
 
-class IllegalStateException(Exception):
-    pass
-
-
-class IllegalArgumentException(Exception):
-    pass
-
-
 class Error(Exception):
     """Base class for errors in this module."""
 
@@ -28,8 +20,16 @@ class ProtobufException(Error):
     """Generic Protobuf schema error."""
 
 
-class ProtobufTypeException(Error):
+class ProtobufTypeException(ProtobufException):
     """Generic Protobuf type error."""
+
+
+class IllegalStateException(ProtobufException):
+    pass
+
+
+class IllegalArgumentException(ProtobufException):
+    pass
 
 
 class ProtobufUnresolvedDependencyException(ProtobufException):

--- a/karapace/schema_reader.py
+++ b/karapace/schema_reader.py
@@ -28,7 +28,7 @@ from karapace import constants
 from karapace.config import Config
 from karapace.coordinator.master_coordinator import MasterCoordinator
 from karapace.dependency import Dependency
-from karapace.errors import InvalidReferences, InvalidSchema, ShutdownException
+from karapace.errors import InvalidReferences, InvalidSchema, InvalidVersion, ShutdownException
 from karapace.in_memory_database import InMemoryDatabase
 from karapace.kafka.admin import KafkaAdminClient
 from karapace.kafka.common import translate_from_kafkaerror
@@ -399,7 +399,7 @@ class KafkaSchemaReader(Thread):
 
             try:
                 self.handle_msg(key, value)
-            except (InvalidSchema, TypeError) as exc:
+            except (InvalidSchema, InvalidVersion, TypeError) as exc:
                 self.kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_READER, error=exc)
                 continue
             finally:
@@ -486,8 +486,8 @@ class KafkaSchemaReader(Thread):
 
     def _handle_msg_delete_subject(self, key: dict, value: dict | None) -> None:  # pylint: disable=unused-argument
         if value is None:
-            LOG.warning("DELETE_SUBJECT record doesnt have a value, should have")
-            return
+            LOG.warning("DELETE_SUBJECT record does not have a value, should have")
+            raise ValueError("DELETE_SUBJECT record does not have a value, should have")
 
         subject = value["subject"]
         version = Version(value["version"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,6 +148,22 @@ test_objects_protobuf_second = [
     {"q": 3, "sensor_type": "L1", "nums": [3, 4], "order": {"item": "ABC01223"}},
 ]
 
+schema_protobuf_invalid = """
+|o3"
+|
+|opti  --  om.codingharbour.protobuf";
+|option java_outer_classname = "TestEnumOrder";
+|
+|message Message {
+|  int32
+|  speed =;
+|}
+|Enum
+|  HIGH = 0
+|  MIDDLE = ;
+"""
+schema_protobuf_invalid = trim_margin(schema_protobuf_invalid)
+
 schema_data_second = {"protobuf": (schema_protobuf_second, test_objects_protobuf_second)}
 
 second_schema_json = json.dumps(


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
We add tests to validate the possible error cases while parsing the message key:
- we test for invalid JSON for key
- missing `keytype` in the key data
- we test for invalid `keytype`
- we test for invalid config value
- we test for invalid subject delete value
- we test for invalid version number within schema value
- we test for generic invalid protobuf schema

# Why this way
This is not added via the integration tests as we are verifying the side-effects which are then handled by other components and thus the unit tests are fine just to add. 

The work requires the work currently done in #936 and thus was tested locally with a rebase on that branch, some linting and added tests might fail until we merge the other PR.