### PR TITLE
config: Dropped `kafka` prefix from shutdown flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -468,10 +468,10 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
    * - ``master_election_strategy``
      - ``lowest``
      - Decides on what basis the Karapace cluster master is chosen (only relevant in a multi node setup)
-   * - ``kafka_schema_reader_strict_mode``
+   * - ``schema_reader_strict_mode``
      - ``false``
      - If enabled, causes the Karapace schema-registry service to shutdown when there are invalid schema records in the `_schemas` topic
-   * - ``kafka_retriable_errors_silenced``
+   * - ``retriable_errors_silenced``
      - ``true``
      - If enabled, kafka errors which can be retried or custom errors specififed for the service will not be raised,
        instead, a warning log is emitted. This will denoise issue tracking systems, i.e. sentry

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -80,8 +80,8 @@ services:
       KARAPACE_COMPATIBILITY: FULL
       KARAPACE_STATSD_HOST: statsd-exporter
       KARAPACE_STATSD_PORT: 8125
-      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
-      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_RETRIABLE_ERRORS_SILENCED: true
 
   karapace-rest:
     image: ghcr.io/aiven-open/karapace:develop
@@ -108,8 +108,8 @@ services:
       KARAPACE_LOG_LEVEL: WARNING
       KARAPACE_STATSD_HOST: statsd-exporter
       KARAPACE_STATSD_PORT: 8125
-      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
-      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_RETRIABLE_ERRORS_SILENCED: true
 
   prometheus:
     image: prom/prometheus

--- a/karapace/config.py
+++ b/karapace/config.py
@@ -80,8 +80,8 @@ class Config(TypedDict):
     protobuf_runtime_directory: str
     statsd_host: str
     statsd_port: int
-    kafka_schema_reader_strict_mode: bool
-    kafka_retriable_errors_silenced: bool
+    schema_reader_strict_mode: bool
+    retriable_errors_silenced: bool
 
     sentry: NotRequired[Mapping[str, object]]
     tags: NotRequired[Mapping[str, object]]
@@ -156,8 +156,8 @@ DEFAULTS: ConfigDefaults = {
     "protobuf_runtime_directory": "runtime",
     "statsd_host": "127.0.0.1",
     "statsd_port": 8125,
-    "kafka_schema_reader_strict_mode": False,
-    "kafka_retriable_errors_silenced": True,
+    "schema_reader_strict_mode": False,
+    "retriable_errors_silenced": True,
 }
 SECRET_CONFIG_OPTIONS = [SASL_PLAIN_PASSWORD]
 

--- a/karapace/kafka_error_handler.py
+++ b/karapace/kafka_error_handler.py
@@ -25,8 +25,8 @@ class KafkaRetriableErrors(enum.Enum):
 
 class KafkaErrorHandler:
     def __init__(self, config: Config) -> None:
-        self.schema_reader_strict_mode: bool = config["kafka_schema_reader_strict_mode"]
-        self.retriable_errors_silenced: bool = config["kafka_retriable_errors_silenced"]
+        self.schema_reader_strict_mode: bool = config["schema_reader_strict_mode"]
+        self.retriable_errors_silenced: bool = config["retriable_errors_silenced"]
 
     def log(self, location: KafkaErrorLocation, error: BaseException) -> None:
         LOG.warning("%s encountered error - %s", location, error)

--- a/tests/unit/test_kafka_error_handler.py
+++ b/tests/unit/test_kafka_error_handler.py
@@ -14,8 +14,8 @@ import pytest
 @pytest.fixture(name="kafka_error_handler")
 def fixture_kafka_error_handler() -> KafkaErrorHandler:
     config = {
-        "kafka_schema_reader_strict_mode": False,
-        "kafka_retriable_errors_silenced": True,
+        "schema_reader_strict_mode": False,
+        "retriable_errors_silenced": True,
     }
     return KafkaErrorHandler(config=config)
 
@@ -42,7 +42,7 @@ def test_handle_error_retriable_schema_coordinator(
             assert log.levelname == "WARNING"
             assert log.message == f"SCHEMA_COORDINATOR encountered error - {retriable_error}"
 
-    # Check that the config flag - `kafka_retriable_errors_silenced` switches the behaviour
+    # Check that the config flag - `retriable_errors_silenced` switches the behaviour
     kafka_error_handler.retriable_errors_silenced = False
     with pytest.raises(retriable_error.__class__):
         kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_COORDINATOR, error=retriable_error)
@@ -63,7 +63,7 @@ def test_handle_error_nonretriable_schema_coordinator(
     with pytest.raises(nonretriable_error.__class__):
         kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_COORDINATOR, error=nonretriable_error)
 
-    # Check that the config flag - `kafka_retriable_errors_silenced` switches the behaviour
+    # Check that the config flag - `retriable_errors_silenced` switches the behaviour
     kafka_error_handler.retriable_errors_silenced = True
     kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_COORDINATOR, error=nonretriable_error)
 
@@ -73,6 +73,6 @@ def test_handle_error_schema_reader(kafka_error_handler: KafkaErrorHandler) -> N
     with pytest.raises(CorruptKafkaRecordException):
         kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_READER, error=Exception)
 
-    # Check that the config flag - `kafka_schema_reader_strict_mode` switches the behaviour
+    # Check that the config flag - `schema_reader_strict_mode` switches the behaviour
     kafka_error_handler.schema_reader_strict_mode = False
     kafka_error_handler.handle_error(location=KafkaErrorLocation.SCHEMA_READER, error=Exception)

--- a/tests/unit/test_schema_reader.py
+++ b/tests/unit/test_schema_reader.py
@@ -347,7 +347,7 @@ def fixture_schema_reader_with_consumer_messages_factory() -> Callable[[Tuple[Li
 
         # Update the config to run the schema reader in strict mode so errors can be raised
         config = DEFAULTS.copy()
-        config["kafka_schema_reader_strict_mode"] = True
+        config["schema_reader_strict_mode"] = True
 
         offset_watcher = OffsetWatcher()
         schema_reader = KafkaSchemaReader(


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
We remove the `kafka_` prefix from the config values: `kafka_schema_reader_strict_mode` and `kafka_retriable_errors_silenced`.
