### PR TITLE
chore: add --numprocesses to GH action pytest args

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,11 @@ jobs:
     - run: make unit-tests
       env:
         COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
-        PYTEST_ARGS: "--cov=karapace --cov-append"
+        PYTEST_ARGS: "--cov=karapace --cov-append --numprocesses 4"
     - run: make integration-tests
       env:
         COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
-        PYTEST_ARGS: "--cov=karapace --cov-append --random-order"
+        PYTEST_ARGS: "--cov=karapace --cov-append --random-order --numprocesses 4"
 
     - name: Archive logs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# About this change - What it does

Use 4 workers in GH actions. Default or `--numprocesses auto` does not use the 4 vcpus available on the Github runner.
The number of vcpus has been changed in the GH runners: https://github.blog/news-insights/product-news/github-hosted-runners-double-the-power-for-open-source/