### PR TITLE
test: select random free server ports with 0

### DIFF
--- a/tests/integration/backup/test_session_timeout.py
+++ b/tests/integration/backup/test_session_timeout.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from tests.integration.conftest import create_kafka_server
 from tests.integration.utils.config import KafkaDescription
 from tests.integration.utils.kafka_server import KafkaServers
-from tests.integration.utils.network import PortRangeInclusive
 
 import pytest
 
@@ -26,7 +25,6 @@ GROUP_MAX_SESSION_TIMEOUT_MS = 70000
 @pytest.fixture(scope="function", name="kafka_server_session_timeout")
 def fixture_kafka_server(
     kafka_description: KafkaDescription,
-    port_range: PortRangeInclusive,
     tmp_path_factory: pytest.TempPathFactory,
 ):
     # use custom data and log dir to avoid conflict with other kafka servers
@@ -40,7 +38,6 @@ def fixture_kafka_server(
         session_datadir,
         session_logdir,
         kafka_description,
-        port_range,
         kafka_config_extra,
     )
 

--- a/tests/integration/test_karapace.py
+++ b/tests/integration/test_karapace.py
@@ -2,11 +2,10 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-from contextlib import ExitStack
+from contextlib import closing, contextmanager, ExitStack
 from karapace.config import set_config_defaults
 from pathlib import Path
 from tests.integration.utils.kafka_server import KafkaServers
-from tests.integration.utils.network import PortRangeInclusive
 from tests.integration.utils.process import stop_process
 from tests.utils import popen_karapace_all
 from typing import Iterator
@@ -15,8 +14,15 @@ import json
 import socket
 
 
+@contextmanager
+def allocate_port_no_reuse() -> Iterator[int]:
+    """Allocate random free port and do not allow reuse."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        yield sock.getsockname()[1]
+
+
 def test_regression_server_must_exit_on_exception(
-    port_range: PortRangeInclusive,
     tmp_path: Path,
     kafka_servers: Iterator[KafkaServers],
 ) -> None:
@@ -25,10 +31,10 @@ def test_regression_server_must_exit_on_exception(
     Karapace was not closing all its background threads, so when an exception
     was raised an reached the top-level, the webserver created by asyncio would
     be stopped but the threads would keep the server running.
+    Karapace exit on exception is done by setting a reserved port as server port.
     """
     with ExitStack() as stack:
-        port = stack.enter_context(port_range.allocate_port())
-        sock = stack.enter_context(socket.socket())
+        port = stack.enter_context(allocate_port_no_reuse())
 
         config = set_config_defaults(
             {
@@ -42,7 +48,6 @@ def test_regression_server_must_exit_on_exception(
         logfile = stack.enter_context((tmp_path / "karapace.log").open("w"))
         errfile = stack.enter_context((tmp_path / "karapace.err").open("w"))
         config_path.write_text(json.dumps(config))
-        sock.bind(("127.0.0.1", port))
         process = popen_karapace_all(config_path, logfile, errfile)
         stack.callback(stop_process, process)  # make sure to stop the process if the test fails
         assert process.wait(timeout=10) != 0, "Process should have exited with an error, port is already is use"

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -2,14 +2,16 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+from __future__ import annotations
+
 from contextlib import asynccontextmanager, ExitStack
 from dataclasses import dataclass
 from karapace.config import Config, set_config_defaults, write_config
 from pathlib import Path
-from tests.integration.utils.network import PortRangeInclusive
+from tests.integration.utils.network import allocate_port
 from tests.integration.utils.process import stop_process, wait_for_port_subprocess
 from tests.utils import new_random_name, popen_karapace_all
-from typing import AsyncIterator, List
+from typing import AsyncIterator
 
 
 @dataclass(frozen=True)
@@ -30,10 +32,9 @@ class RegistryDescription:
 
 @asynccontextmanager
 async def start_schema_registry_cluster(
-    config_templates: List[Config],
+    config_templates: list[Config],
     data_dir: Path,
-    port_range: PortRangeInclusive,
-) -> AsyncIterator[List[RegistryDescription]]:
+) -> AsyncIterator[list[RegistryDescription]]:
     """Start a cluster of schema registries, one process per `config_templates`."""
     for template in config_templates:
         assert "bootstrap_uri" in template, "base_config must have the value `bootstrap_uri` set"
@@ -67,7 +68,7 @@ async def start_schema_registry_cluster(
             )
             actual_group_id = config.setdefault("group_id", group_id)
 
-            port = config.setdefault("port", stack.enter_context(port_range.allocate_port()))
+            port = config.setdefault("port", stack.enter_context(allocate_port()))
             assert isinstance(port, int), "Port must be an integer"
 
             group_dir = data_dir / str(actual_group_id)

--- a/tests/integration/utils/network.py
+++ b/tests/integration/utils/network.py
@@ -2,82 +2,19 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
+from typing import Iterator
 
-import platform
-import psutil
-import random
 import socket
 
 
-def is_time_wait(port: int) -> bool:
-    """True if the port is still on TIME_WAIT state."""
-    return any(conn.laddr.port == port for conn in psutil.net_connections(kind="inet"))
-
-
-class PortRangeInclusive:
-    PRIVILEGE_END = 2**10
-    MAX_PORTS = 2**16 - 1
-
-    def __init__(
-        self,
-        start: int,
-        end: int,
-    ) -> None:
-        # Make sure the range is valid and that we don't need to be root
-        assert end > start, "there must be at least one port available"
-        assert end <= self.MAX_PORTS, f"end must be lower than {self.MAX_PORTS}"
-        assert start > self.PRIVILEGE_END, "start must not be a privileged port"
-
-        self.start = start
-        self.end = end
-        self._maybe_available = range(start, end + 1)
-        self._allocated = set()
-
-    def next_range(self, number_of_ports: int) -> "PortRangeInclusive":
-        next_start = self.end
-        next_end = next_start + number_of_ports
-        return PortRangeInclusive(next_start, next_end)
-
-    @contextmanager
-    def allocate_port(self) -> int:
-        """Find a random port in the range `PortRangeInclusive`.
-
-        Note:
-            This function is *not* aware of the ports currently open in the system,
-            the blacklist only prevents two services of the same type to randomly
-            get the same ports for *a single test run*.
-
-            Because of that, the port range should be chosen such that there is no
-            system service in the range. Also note that running two sessions of the
-            tests with the same range is not supported and will lead to flakiness.
-        """
-        if len(self._maybe_available) == 0:
-            raise RuntimeError(f"No free ports available. start: {self.start} end: {self.end}")
-
-        unallocated = [port for port in self._maybe_available if port not in self._allocated]
-
-        if platform.platform().lower().startswith("linux"):
-            filtered_ports = (port for port in unallocated if not is_time_wait(port))
-            try:
-                port = next(filtered_ports)
-            except StopIteration as e:
-                raise RuntimeError(
-                    f"No free ports available. start: {self.start} end: {self.end} time_wait: {unallocated}"
-                ) from e
-        else:
-            # psutil.net_connections requires running as privileged user on Macos, so we
-            # put our trust in entropy instead.
-            port = random.choice(unallocated)
-
-        self._allocated.add(port)
-
-        try:
-            yield port
-        finally:
-            # Remove the port at the end, this is a hack to give extra time for a TIME_WAIT socket to
-            # close, but it is not sufficient.
-            self._allocated.remove(port)
+@contextmanager
+def allocate_port() -> Iterator[int]:
+    """Allocate random free port."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        yield sock.getsockname()[1]
 
 
 def port_is_listening(hostname: str, port: int, ipv6: bool) -> bool:


### PR DESCRIPTION
# About this change - What it does

The previous port selection algorithm relied on port range. The range
was from 48700 to 49000. This is 300 ports of which some may be already
reserved in the system running tests. The free ports are allocated between
the pytest workers. With 4 workers there is 75 ports for each. This causes
flakiness in the tests as ports may not be available or are still in
wait after previous tests. In the test environment it is not necessary
to select ports from IANA dynamic port assignment range. Any free port
is ok and port 0 can be used for dynamically allocated free port.
