### PR TITLE
fix: return "messages" instead "incompatibilities" from compatibility API

### DIFF
--- a/src/karapace/schema_registry_apis.py
+++ b/src/karapace/schema_registry_apis.py
@@ -412,8 +412,7 @@ class KarapaceSchemaRegistryController(KarapaceBase):
             result = SchemaCompatibility.check_compatibility(old_schema, new_schema, compatibility_mode)
 
         if is_incompatible(result):
-            maybe_truncated_error = ", ".join(result.messages)[:300]
-            self.r({"is_compatible": False, "incompatibilities": maybe_truncated_error}, content_type)
+            self.r({"is_compatible": False, "messages": list(result.messages)}, content_type)
         self.r({"is_compatible": True}, content_type)
 
     async def schemas_list(self, content_type: str, *, request: HTTPRequest, user: User | None = None):

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -333,7 +333,7 @@ async def test_compatibility_endpoint(registry_async_client: Client, trail: str)
     )
     assert res.status_code == 200
     assert res.json().get("is_compatible") is False
-    assert res.json().get("incompatibilities") == "reader type: string not compatible with writer type: int"
+    assert res.json().get("messages") == ["reader type: string not compatible with writer type: int"]
 
 
 @pytest.mark.parametrize("trail", ["", "/"])

--- a/tests/integration/test_schema_compatibility.py
+++ b/tests/integration/test_schema_compatibility.py
@@ -44,7 +44,7 @@ class SchemaCompatibilityTestCase(BaseTestCase):
     register_baseline_schemas: SchemaRegitrationFunc
     expected_is_compatible: bool | None
     expected_status_code: int
-    expected_incompatibilities: str | None
+    expected_incompatibilities: list[str] | None
 
 
 async def _register_baseline_schemas_no_incompatibilities(registry_async_client: Client, subject: Subject) -> None:
@@ -149,7 +149,7 @@ async def _set_compatibility_mode(registry_async_client: Client, subject: Subjec
             new_schema=json.dumps(schema_int),
             expected_is_compatible=False,
             expected_status_code=200,
-            expected_incompatibilities="reader type: int not compatible with writer type: double",
+            expected_incompatibilities=["reader type: int not compatible with writer type: double"],
         ),
         # Case 3
         # Same as previous case, but in non-transitive mode
@@ -161,7 +161,7 @@ async def _set_compatibility_mode(registry_async_client: Client, subject: Subjec
             new_schema=json.dumps(schema_int),
             expected_is_compatible=False,
             expected_status_code=200,
-            expected_incompatibilities="reader type: int not compatible with writer type: string",
+            expected_incompatibilities=["reader type: int not compatible with writer type: string"],
         ),
         # Case 4
         # Same as case 2, but with a deleted schema among baseline ones
@@ -175,7 +175,7 @@ async def _set_compatibility_mode(registry_async_client: Client, subject: Subjec
             new_schema=json.dumps(schema_int),
             expected_is_compatible=False,
             expected_status_code=200,
-            expected_incompatibilities="reader type: int not compatible with writer type: double",
+            expected_incompatibilities=["reader type: int not compatible with writer type: double"],
         ),
         # Case 5
         # Same as case 3, but with a deleted schema among baseline ones
@@ -188,7 +188,7 @@ async def _set_compatibility_mode(registry_async_client: Client, subject: Subjec
             new_schema=json.dumps(schema_int),
             expected_is_compatible=False,
             expected_status_code=200,
-            expected_incompatibilities="reader type: int not compatible with writer type: string",
+            expected_incompatibilities=["reader type: int not compatible with writer type: string"],
         ),
         # Case 6
         # A new schema and no baseline schemas
@@ -232,4 +232,4 @@ async def test_schema_compatibility(test_case: SchemaCompatibilityTestCase, regi
 
     assert res.status_code == test_case.expected_status_code
     assert res.json().get("is_compatible") == test_case.expected_is_compatible
-    assert res.json().get("incompatibilities", None) == test_case.expected_incompatibilities
+    assert res.json().get("messages") == test_case.expected_incompatibilities


### PR DESCRIPTION
For Confluent Schema Registry client compatibility the response field is changed from "incompatibilities: str" to "messages: list[str]".

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
