### PR TITLE
feat: Update Dockerfile to add support to arbitrary user ids

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,10 +11,9 @@ ENV PIP_REQUIRE_VIRTUALENV=true
 # Install golang needed by extensions
 ENV GO_VERSION=1.21.0
 ENV PATH="/usr/local/go/bin:${PATH}"
-RUN wget --progress=dot:giga \
-    "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
-    && tar -C /usr/local -xzf "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
-    && rm "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz"
+RUN wget --progress=dot:giga "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
+ && tar -C /usr/local -xzf "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
+ && rm "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz"
 
 # Copy the requirements.txt and install dependencies in venv. Using a separate
 # command to use layer caching.
@@ -30,9 +29,9 @@ COPY . /build/karapace-repo
 WORKDIR /build/karapace-repo
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -z "${KARAPACE_VERSION}" ]; then \
-    PRETEND_VERSION="$(python -c 'from src.karapace import version; print(version.__version__)')"; \
+        PRETEND_VERSION="$(python -c 'from src.karapace import version; print(version.__version__)')"; \
     else \
-    PRETEND_VERSION=$KARAPACE_VERSION; \
+        PRETEND_VERSION=$KARAPACE_VERSION; \
     fi; \
     SETUPTOOLS_SCM_PRETEND_VERSION=$PRETEND_VERSION python3 -m pip install --no-deps .
 
@@ -40,24 +39,26 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM python:3.10.11-slim-bullseye AS karapace
 
 # Setup user and directories.
+# https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/creating-images#use-uid_create-images
 RUN useradd --system --gid 0 karapace \
-    && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
-    && chgrp -R 0  /opt/karapace /opt/karapace/runtime /var/log/karapace \
-    && chmod -R g+rwX /opt/karapace
+ && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
+ && chgrp -R 0  /opt/karapace /opt/karapace/runtime /var/log/karapace \
+ && chmod -R g+rwX /opt/karapace
 
 # Install protobuf compiler.
 ARG PROTOBUF_COMPILER_VERSION="3.12.4-1+deb11u1"
 RUN apt-get update \
-    && apt-get install --assume-yes --no-install-recommends \
+ && apt-get install --assume-yes --no-install-recommends \
     protobuf-compiler=$PROTOBUF_COMPILER_VERSION \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy virtualenv from builder and activate it.
 COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:$PATH"
 
 COPY ./container/start.sh /opt/karapace
-RUN chmod 550 /opt/karapace/start.sh
+RUN chmod 550 /opt/karapace/start.sh \
+ && chgrp -R 0  /opt/karapace/start.sh
 
 COPY ./container/healthcheck.py /opt/karapace
 
@@ -66,4 +67,3 @@ USER karapace
 
 HEALTHCHECK --interval=10s --timeout=30s --retries=3 --start-period=60s \
     CMD python3 healthcheck.py http://localhost:$KARAPACE_PORT/_health || exit 1
-

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,9 +11,10 @@ ENV PIP_REQUIRE_VIRTUALENV=true
 # Install golang needed by extensions
 ENV GO_VERSION=1.21.0
 ENV PATH="/usr/local/go/bin:${PATH}"
-RUN wget --progress=dot:giga "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
- && tar -C /usr/local -xzf "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
- && rm "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz"
+RUN wget --progress=dot:giga \
+    "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
+    && tar -C /usr/local -xzf "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
+    && rm "go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz"
 
 # Copy the requirements.txt and install dependencies in venv. Using a separate
 # command to use layer caching.
@@ -29,9 +30,9 @@ COPY . /build/karapace-repo
 WORKDIR /build/karapace-repo
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -z "${KARAPACE_VERSION}" ]; then \
-        PRETEND_VERSION="$(python -c 'from src.karapace import version; print(version.__version__)')"; \
+    PRETEND_VERSION="$(python -c 'from src.karapace import version; print(version.__version__)')"; \
     else \
-        PRETEND_VERSION=$KARAPACE_VERSION; \
+    PRETEND_VERSION=$KARAPACE_VERSION; \
     fi; \
     SETUPTOOLS_SCM_PRETEND_VERSION=$PRETEND_VERSION python3 -m pip install --no-deps .
 
@@ -39,25 +40,24 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM python:3.10.11-slim-bullseye AS karapace
 
 # Setup user and directories.
-RUN groupadd --system karapace \
- && useradd --system --gid karapace karapace \
- && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
- && chown --recursive karapace:karapace /opt/karapace /var/log/karapace
+RUN useradd --system --gid 0 karapace \
+    && mkdir /opt/karapace /opt/karapace/runtime /var/log/karapace \
+    && chgrp -R 0  /opt/karapace /opt/karapace/runtime /var/log/karapace \
+    && chmod -R g+rwX /opt/karapace
 
 # Install protobuf compiler.
 ARG PROTOBUF_COMPILER_VERSION="3.12.4-1+deb11u1"
 RUN apt-get update \
- && apt-get install --assume-yes --no-install-recommends \
+    && apt-get install --assume-yes --no-install-recommends \
     protobuf-compiler=$PROTOBUF_COMPILER_VERSION \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy virtualenv from builder and activate it.
 COPY --from=builder /venv /venv
 ENV PATH="/venv/bin:$PATH"
 
 COPY ./container/start.sh /opt/karapace
-RUN chmod 500 /opt/karapace/start.sh \
- && chown karapace:karapace /opt/karapace/start.sh
+RUN chmod 550 /opt/karapace/start.sh
 
 COPY ./container/healthcheck.py /opt/karapace
 
@@ -66,3 +66,4 @@ USER karapace
 
 HEALTHCHECK --interval=10s --timeout=30s --retries=3 --start-period=60s \
     CMD python3 healthcheck.py http://localhost:$KARAPACE_PORT/_health || exit 1
+


### PR DESCRIPTION
About this change - What it does

This change updates the Dockerfile to handle dynamic User ID (UID) allocation in compliance with OpenShift best practices. It modifies file and directory permissions to ensure compatibility with OpenShift's security requirements, allowing containers to run with arbitrary UIDs while maintaining the required access to essential directories.

References: #983 

Why this way

To solve the issue of dynamic UID handling, the proposed approach involves modifying permissions so that the container user can run with a dynamically assigned UID, which OpenShift uses for security purposes. Specifically, we change directory permissions and add the 'karapace' user to group '0', ensuring necessary access without granting root privileges. This adheres to OpenShift's recommendations for secure, multi-tenant container environments, allowing seamless and secure container operation.