### PR TITLE
fix: Test Compatibility returns true when schema missing

### DIFF
--- a/src/karapace/schema_registry_apis.py
+++ b/src/karapace/schema_registry_apis.py
@@ -1354,14 +1354,8 @@ class KarapaceSchemaRegistryController(KarapaceBase):
         except InvalidVersion:
             self._invalid_version(content_type, version)
         except (VersionNotFoundException, SchemasNotFoundException, SubjectNotFoundException):
-            self.r(
-                body={
-                    "error_code": SchemaErrorCodes.VERSION_NOT_FOUND.value,
-                    "message": f"Version {version} not found.",
-                },
-                content_type=content_type,
-                status=HTTPStatus.NOT_FOUND,
-            )
+            self.r({"is_compatible": True}, content_type)
+
         old_schema_type = self._validate_schema_type(content_type=content_type, data=old)
         try:
             old_references = old.get("references", None)


### PR DESCRIPTION
To make the api compatible with Confluent Schema Registry, testing the schema compatibility should return "true" whenever the subject, schema or the version is missing

# About this change - What it does


References: #479

# Why this way
This provides the compatibility with Confluent Schema registry. So, for people switching from Confluent to Karapace it will be a smother transition.