### PR TITLE
Avro references poc implementation using avro lib

### DIFF
--- a/tests/integration/test_schema_avro_references.py
+++ b/tests/integration/test_schema_avro_references.py
@@ -49,7 +49,7 @@ SCHEMA_PERSON = {
     "fields": [
         {"name": "name", "type": "string"},
         {"name": "age", "type": "int"},
-        {"name": "address", "type": "Address"},
+        # {"name": "address", "type": "Address"},
         {"name": "job", "type": "Job"},
     ],
 }
@@ -61,7 +61,7 @@ SCHEMA_PERSON_AGE_INT_LONG = {
     "fields": [
         {"name": "name", "type": "string"},
         {"name": "age", "type": "long"},
-        {"name": "address", "type": "Address"},
+        # {"name": "address", "type": "Address"},
         {"name": "job", "type": "Job"},
     ],
 }
@@ -73,7 +73,7 @@ SCHEMA_PERSON_AGE_LONG_STRING = {
     "fields": [
         {"name": "name", "type": "string"},
         {"name": "age", "type": "string"},
-        {"name": "address", "type": "Address"},
+        # {"name": "address", "type": "Address"},
         {"name": "job", "type": "Job"},
     ],
 }
@@ -85,7 +85,7 @@ SCHEMA_UNION_REFERENCES = {
     "fields": [
         {"name": "name", "type": "string"},
         {"name": "age", "type": "int"},
-        {"name": "address", "type": "Address"},
+        # {"name": "address", "type": "Address"},
         {"name": "job", "type": "Job"},
         {
             "name": "children",
@@ -109,7 +109,7 @@ SCHEMA_UNION_REFERENCES2 = [
         "fields": [
             {"name": "name", "type": "string"},
             {"name": "age", "type": "int"},
-            {"name": "address", "type": "Address"},
+            # {"name": "address", "type": "Address"},
             {"name": "job", "type": "Job"},
         ],
     },
@@ -120,7 +120,7 @@ SCHEMA_UNION_REFERENCES2 = [
         "fields": [
             {"name": "name", "type": "string"},
             {"name": "age", "type": "int"},
-            {"name": "address", "type": "Address"},
+            # {"name": "address", "type": "Address"},
         ],
     },
 ]
@@ -144,7 +144,7 @@ def address_references(subject_prefix: str) -> list:
 
 def person_references(subject_prefix: str) -> list:
     return [
-        {"name": "address.avsc", "subject": f"{subject_prefix}address", "version": 1},
+        # {"name": "address.avsc", "subject": f"{subject_prefix}address", "version": 1},
         {"name": "job.avsc", "subject": f"{subject_prefix}job", "version": 1},
     ]
 
@@ -153,7 +153,7 @@ def stored_person_subject(subject_prefix: str, subject_id: int) -> dict:
     return {
         "id": subject_id,
         "references": [
-            {"name": "address.avsc", "subject": f"{subject_prefix}address", "version": 1},
+            # {"name": "address.avsc", "subject": f"{subject_prefix}address", "version": 1},
             {"name": "job.avsc", "subject": f"{subject_prefix}job", "version": 1},
         ],
         "schema": json.dumps(
@@ -161,7 +161,7 @@ def stored_person_subject(subject_prefix: str, subject_id: int) -> dict:
                 "fields": [
                     {"name": "name", "type": "string"},
                     {"name": "age", "type": "int"},
-                    {"name": "address", "type": "Address"},
+                    # {"name": "address", "type": "Address"},
                     {"name": "job", "type": "Job"},
                 ],
                 "name": "Person",


### PR DESCRIPTION
This is a proof of concept for implementing Avro reference using Avro python library.
I used the following PR (implementation using unions) as the base: https://github.com/Aiven-Open/karapace/pull/926

What works:
- Direct reference (schema1 --> schema2)
- Recursive reference (schema1 --> schema1)

What does not work:
- Indirect references (schema1 --> schema2 --> schema3) - maybe not needed, not sure Schema Registry supports this
- ... probably other things as well