### PR TITLE
fix: don't send all aiokafka log.error to sentry

### DIFF
--- a/src/karapace/sentry/sentry_client.py
+++ b/src/karapace/sentry/sentry_client.py
@@ -41,6 +41,8 @@ class SentryClient(SentryClientAPI):
         # Don't send library logged errors to Sentry as there is also proper return value or raised exception to calling code
         from sentry_sdk.integrations.logging import ignore_logger
 
+        ignore_logger("aiokafka")
+        ignore_logger("aiokafka.*")
         ignore_logger("kafka")
         ignore_logger("kafka.*")
 


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
These log events are numerous and costly. When these `log.error` events are related to real error, they cause exceptions which are still properly handled and recorded by Sentry, no need to also send individual events for all the `log.error` in addition to the exceptions. 
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way
The same logic was already applied for the `kafka` library.
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
