### PR TITLE
forwarding_client: use single session and close on shutdown

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ unit-tests: venv/.deps-dev
 	rm -fr runtime/*
 
 .PHONY: integration-tests
-unit-tests: export PYTEST_ARGS ?=
+integration-tests: export PYTEST_ARGS ?=
 integration-tests: venv/.deps-dev
 	rm -fr runtime/*
 	$(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/integration/

--- a/tests/unit/test_forwarding_client.py
+++ b/tests/unit/test_forwarding_client.py
@@ -1,7 +1,7 @@
 """
-karapace - schema registry authentication and authorization tests
+karapace - master forwarding tests
 
-Copyright (c) 2023 Aiven Ltd
+Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
 from __future__ import annotations
@@ -15,6 +15,7 @@ from starlette.datastructures import MutableHeaders
 from tests.base_testcase import BaseTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
+import aiohttp
 import pytest
 
 
@@ -26,6 +27,20 @@ class TestResponse(BaseModel):
 @dataclass
 class ContentTypeTestCase(BaseTestCase):
     content_type: str
+
+
+@pytest.fixture(name="forward_client")
+def fixture_forward_client() -> ForwardClient:
+    with patch("karapace.forward_client.aiohttp") as mocked_aiohttp:
+        mocked_aiohttp.ClientSession.return_value = Mock(
+            spec=aiohttp.ClientSession, headers={"User-Agent": ForwardClient.USER_AGENT}
+        )
+        return ForwardClient()
+
+
+async def test_forward_client_close(forward_client: ForwardClient) -> None:
+    await forward_client.close()
+    forward_client._forward_client.close.assert_awaited_once()  # pylint: disable=protected-access
 
 
 @pytest.mark.parametrize(
@@ -42,112 +57,100 @@ class ContentTypeTestCase(BaseTestCase):
     ],
     ids=str,
 )
-async def test_forward_request_with_basemodel_response(testcase: ContentTypeTestCase) -> None:
-    forward_client = ForwardClient()
-    with patch.object(forward_client, "_get_forward_client", autospec=True) as mock_get_forward_client:
-        mock_request = Mock(spec=Request)
-        mock_request.method = "GET"
-        mock_request.headers = Headers()
+async def test_forward_request_with_basemodel_response(forward_client: ForwardClient, testcase: ContentTypeTestCase) -> None:
+    mock_request = Mock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.headers = Headers()
 
-        mock_aiohttp_session = Mock()
-        mock_get_forward_client.return_value = mock_aiohttp_session
-        mock_get_func = Mock()
-        mock_response_context = AsyncMock
-        mock_response = AsyncMock()
-        mock_response_context.call_function = lambda _: mock_response
-        mock_response.text.return_value = '{"number":10,"string":"important"}'
-        headers = MutableHeaders()
-        headers["Content-Type"] = testcase.content_type
-        mock_response.headers = headers
+    mock_get_func = Mock()
+    mock_response_context = AsyncMock
+    mock_response = AsyncMock()
+    mock_response_context.call_function = lambda _: mock_response
+    mock_response.text.return_value = '{"number":10,"string":"important"}'
+    headers = MutableHeaders()
+    headers["Content-Type"] = testcase.content_type
+    mock_response.headers = headers
 
-        async def mock_aenter(_) -> Mock:
-            return mock_response
+    async def mock_aenter(_) -> Mock:
+        return mock_response
 
-        async def mock_aexit(_, __, ___, ____) -> None:
-            return
+    async def mock_aexit(_, __, ___, ____) -> None:
+        return
 
-        mock_get_func.__aenter__ = mock_aenter
-        mock_get_func.__aexit__ = mock_aexit
-        mock_aiohttp_session.get.return_value = mock_get_func
+    mock_get_func.__aenter__ = mock_aenter
+    mock_get_func.__aexit__ = mock_aexit
+    forward_client._forward_client.get.return_value = mock_get_func  # pylint: disable=protected-access
 
-        response = await forward_client.forward_request_remote(
-            request=mock_request,
-            primary_url="test-url",
-            response_type=TestResponse,
-        )
+    response = await forward_client.forward_request_remote(
+        request=mock_request,
+        primary_url="test-url",
+        response_type=TestResponse,
+    )
 
-        assert response == TestResponse(number=10, string="important")
+    assert response == TestResponse(number=10, string="important")
 
 
-async def test_forward_request_with_integer_list_response() -> None:
-    forward_client = ForwardClient()
-    with patch.object(forward_client, "_get_forward_client", autospec=True) as mock_get_forward_client:
-        mock_request = Mock(spec=Request)
-        mock_request.method = "GET"
-        mock_request.headers = Headers()
+async def test_forward_request_with_integer_list_response(forward_client: ForwardClient) -> None:
+    mock_request = Mock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.headers = Headers()
 
-        mock_aiohttp_session = Mock()
-        mock_get_forward_client.return_value = mock_aiohttp_session
-        mock_get_func = Mock()
-        mock_response_context = AsyncMock
-        mock_response = AsyncMock()
-        mock_response_context.call_function = lambda _: mock_response
-        mock_response.text.return_value = "[1, 2, 3, 10]"
-        headers = MutableHeaders()
-        headers["Content-Type"] = "application/json"
-        mock_response.headers = headers
+    mock_get_func = Mock()
+    mock_response_context = AsyncMock
+    mock_response = AsyncMock()
+    mock_response_context.call_function = lambda _: mock_response
+    mock_response.text.return_value = "[1, 2, 3, 10]"
+    headers = MutableHeaders()
+    headers["Content-Type"] = "application/json"
+    mock_response.headers = headers
 
-        async def mock_aenter(_) -> Mock:
-            return mock_response
+    async def mock_aenter(_) -> Mock:
+        return mock_response
 
-        async def mock_aexit(_, __, ___, ____) -> None:
-            return
+    async def mock_aexit(_, __, ___, ____) -> None:
+        return
 
-        mock_get_func.__aenter__ = mock_aenter
-        mock_get_func.__aexit__ = mock_aexit
-        mock_aiohttp_session.get.return_value = mock_get_func
+    mock_get_func.__aenter__ = mock_aenter
+    mock_get_func.__aexit__ = mock_aexit
+    forward_client._forward_client.get.return_value = mock_get_func  # pylint: disable=protected-access
 
-        response = await forward_client.forward_request_remote(
-            request=mock_request,
-            primary_url="test-url",
-            response_type=list[int],
-        )
+    response = await forward_client.forward_request_remote(
+        request=mock_request,
+        primary_url="test-url",
+        response_type=list[int],
+    )
 
-        assert response == [1, 2, 3, 10]
+    assert response == [1, 2, 3, 10]
 
 
-async def test_forward_request_with_integer_response() -> None:
-    forward_client = ForwardClient()
-    with patch.object(forward_client, "_get_forward_client", autospec=True) as mock_get_forward_client:
-        mock_request = Mock(spec=Request)
-        mock_request.method = "GET"
-        mock_request.headers = Headers()
+async def test_forward_request_with_integer_response(forward_client: ForwardClient) -> None:
+    mock_request = Mock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.headers = Headers()
 
-        mock_aiohttp_session = Mock()
-        mock_get_forward_client.return_value = mock_aiohttp_session
-        mock_get_func = Mock()
-        mock_response_context = AsyncMock
-        mock_response = AsyncMock()
-        mock_response_context.call_function = lambda _: mock_response
-        mock_response.text.return_value = "12"
-        headers = MutableHeaders()
-        headers["Content-Type"] = "application/json"
-        mock_response.headers = headers
+    mock_get_func = Mock()
+    mock_response_context = AsyncMock
+    mock_response = AsyncMock()
+    mock_response_context.call_function = lambda _: mock_response
+    mock_response.text.return_value = "12"
+    headers = MutableHeaders()
+    headers["Content-Type"] = "application/json"
+    mock_response.headers = headers
 
-        async def mock_aenter(_) -> Mock:
-            return mock_response
+    async def mock_aenter(_) -> Mock:
+        return mock_response
 
-        async def mock_aexit(_, __, ___, ____) -> None:
-            return
+    async def mock_aexit(_, __, ___, ____) -> None:
+        return
 
-        mock_get_func.__aenter__ = mock_aenter
-        mock_get_func.__aexit__ = mock_aexit
-        mock_aiohttp_session.get.return_value = mock_get_func
+    mock_get_func.__aenter__ = mock_aenter
+    mock_get_func.__aexit__ = mock_aexit
+    forward_client._forward_client.get.return_value = mock_get_func  # pylint: disable=protected-access
 
-        response = await forward_client.forward_request_remote(
-            request=mock_request,
-            primary_url="test-url",
-            response_type=int,
-        )
+    response = await forward_client.forward_request_remote(
+        request=mock_request,
+        primary_url="test-url",
+        response_type=int,
+    )
 
-        assert response == 12
+    assert response == 12


### PR DESCRIPTION
# About this change - What it does
We use a single client session for the forwarded requests and further close the session on application shutdown.