### PR TITLE
feat: OTel metrics & metering

### DIFF
--- a/container/compose.yml
+++ b/container/compose.yml
@@ -154,6 +154,11 @@ services:
 
   prometheus:
     image: prom/prometheus
+    command:
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=1d
+      - --enable-feature=otlp-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus/rules.yml:/etc/prometheus/rules.yml

--- a/container/opentelemetry/collector-config.yaml
+++ b/container/opentelemetry/collector-config.yaml
@@ -15,7 +15,7 @@ exporters:
     tls:
       insecure: true
   otlphttp/prometheus:
-    endpoint: prometheus:9090/api/v1/otlp
+    endpoint: http://prometheus:9090/api/v1/otlp
     tls:
       insecure: true
 

--- a/container/prometheus/prometheus.yml
+++ b/container/prometheus/prometheus.yml
@@ -3,6 +3,10 @@ global:
   scrape_timeout: 5s # How long until a scrape request times out.
   evaluation_interval: 10s # How frequently to evaluate rules.
 
+storage:
+  tsdb:
+    out_of_order_time_window: 30m
+
 rule_files:
  - /etc/prometheus/rules.yml
 

--- a/src/karapace/config.py
+++ b/src/karapace/config.py
@@ -24,6 +24,7 @@ import ssl
 
 HOSTNAME = socket.gethostname()
 
+
 try:
     from opentelemetry import version as otel_version
 

--- a/src/karapace/config.py
+++ b/src/karapace/config.py
@@ -45,6 +45,7 @@ class KarapaceTelemetryOTelExporter(str, enum.Enum):
 class KarapaceTelemetry(BaseModel):
     otel_endpoint_url: str | None = None
     otel_exporter: KarapaceTelemetryOTelExporter = KarapaceTelemetryOTelExporter.NOOP
+    metrics_export_interval_milliseconds: int = 10000
     resource_service_name: str = "karapace"
     resource_service_instance_id: str = "karapace"
     resource_telemetry_sdk_name: str = "opentelemetry"

--- a/src/schema_registry/__main__.py
+++ b/src/schema_registry/__main__.py
@@ -18,6 +18,7 @@ import schema_registry.routers.metrics
 import schema_registry.routers.mode
 import schema_registry.routers.schemas
 import schema_registry.routers.subjects
+import schema_registry.telemetry.meter
 import schema_registry.telemetry.middleware
 import schema_registry.telemetry.setup
 import schema_registry.telemetry.tracer
@@ -31,6 +32,7 @@ if __name__ == "__main__":
             __name__,
             schema_registry.controller,
             schema_registry.telemetry.tracer,
+            schema_registry.telemetry.meter,
         ]
     )
 

--- a/src/schema_registry/factory.py
+++ b/src/schema_registry/factory.py
@@ -18,7 +18,7 @@ from schema_registry.http_handlers import setup_exception_handlers
 from schema_registry.middlewares import setup_middlewares
 from schema_registry.registry import KarapaceSchemaRegistry
 from schema_registry.routers.setup import setup_routers
-from schema_registry.telemetry.setup import setup_tracing
+from schema_registry.telemetry.setup import setup_metering, setup_tracing
 from typing import AsyncContextManager
 
 import logging
@@ -59,6 +59,7 @@ def create_karapace_application(
     app = FastAPI(lifespan=lifespan)  # type: ignore[arg-type]
 
     setup_tracing()
+    setup_metering()
     setup_routers(app=app)
     setup_exception_handlers(app=app)
     setup_middlewares(app=app)

--- a/src/schema_registry/telemetry/container.py
+++ b/src/schema_registry/telemetry/container.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.semconv.attributes import telemetry_attributes as T
 from schema_registry.telemetry.meter import Meter
+from schema_registry.telemetry.metrics import Metrics
 from schema_registry.telemetry.tracer import Tracer
 
 
@@ -31,5 +32,6 @@ class TelemetryContainer(containers.DeclarativeContainer):
     telemetry_resource = providers.Factory(create_telemetry_resource, config=karapace_container.config)
 
     meter = providers.Singleton(Meter)
+    metrics = providers.Singleton(Metrics, meter=meter)
     tracer = providers.Singleton(Tracer)
     tracer_provider = providers.Singleton(TracerProvider, resource=telemetry_resource)

--- a/src/schema_registry/telemetry/container.py
+++ b/src/schema_registry/telemetry/container.py
@@ -10,7 +10,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.semconv.attributes import telemetry_attributes as T
 from schema_registry.telemetry.meter import Meter
-from schema_registry.telemetry.metrics import Metrics
+from schema_registry.telemetry.metrics import HTTPRequestMetrics
 from schema_registry.telemetry.tracer import Tracer
 
 
@@ -32,6 +32,6 @@ class TelemetryContainer(containers.DeclarativeContainer):
     telemetry_resource = providers.Factory(create_telemetry_resource, config=karapace_container.config)
 
     meter = providers.Singleton(Meter)
-    metrics = providers.Singleton(Metrics, meter=meter)
+    http_request_metrics = providers.Singleton(HTTPRequestMetrics, meter=meter)
     tracer = providers.Singleton(Tracer)
     tracer_provider = providers.Singleton(TracerProvider, resource=telemetry_resource)

--- a/src/schema_registry/telemetry/container.py
+++ b/src/schema_registry/telemetry/container.py
@@ -9,10 +9,11 @@ from karapace.container import KarapaceContainer
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.semconv.attributes import telemetry_attributes as T
+from schema_registry.telemetry.meter import Meter
 from schema_registry.telemetry.tracer import Tracer
 
 
-def create_tracing_resource(config: Config) -> Resource:
+def create_telemetry_resource(config: Config) -> Resource:
     return Resource.create(
         {
             "service.name": config.telemetry.resource_service_name,
@@ -26,6 +27,9 @@ def create_tracing_resource(config: Config) -> Resource:
 
 class TelemetryContainer(containers.DeclarativeContainer):
     karapace_container = providers.Container(KarapaceContainer)
-    tracing_resource = providers.Factory(create_tracing_resource, config=karapace_container.config)
-    tracer_provider = providers.Singleton(TracerProvider, resource=tracing_resource)
+
+    telemetry_resource = providers.Factory(create_telemetry_resource, config=karapace_container.config)
+
+    meter = providers.Singleton(Meter)
     tracer = providers.Singleton(Tracer)
+    tracer_provider = providers.Singleton(TracerProvider, resource=telemetry_resource)

--- a/src/schema_registry/telemetry/meter.py
+++ b/src/schema_registry/telemetry/meter.py
@@ -8,7 +8,12 @@ from karapace.config import Config
 from karapace.container import KarapaceContainer
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, MetricReader, PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    MetricExporter,
+    MetricReader,
+    PeriodicExportingMetricReader,
+)
 from typing import Final
 
 
@@ -23,7 +28,7 @@ class Meter:
     @staticmethod
     @inject
     def get_metric_reader(config: Config = Provide[KarapaceContainer.config]) -> MetricReader:
-        exporter = ConsoleMetricExporter()
+        exporter: MetricExporter = ConsoleMetricExporter()
         if config.telemetry.otel_endpoint_url:
             exporter = OTLPMetricExporter(endpoint=config.telemetry.otel_endpoint_url)
         return PeriodicExportingMetricReader(

--- a/src/schema_registry/telemetry/meter.py
+++ b/src/schema_registry/telemetry/meter.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 
 from dependency_injector.wiring import inject, Provide
-from karapace.config import Config
+from karapace.config import Config, KarapaceTelemetryOTelExporter
 from karapace.container import KarapaceContainer
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
@@ -13,7 +13,32 @@ from opentelemetry.sdk.metrics.export import (
     MetricExporter,
     MetricReader,
     PeriodicExportingMetricReader,
+    MetricsData,
+    MetricExportResult,
 )
+from typing import Any
+
+
+class NOOPMetricExporter(MetricExporter):
+    """Implementation of :class:`MetricExporter` that does nothing.
+
+    This class is intended to be used when metrics exporting to an OTel backend is disabled
+    and the ConsoleExporter is too verbose to be used.
+    """
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 0,
+        **kwargs: Any,
+    ) -> MetricExportResult:
+        return MetricExportResult.SUCCESS
+
+    def shutdown(self, timeout_millis: float = 0, **kwargs: Any) -> None:
+        pass
+
+    def force_flush(self, _: float = 0) -> bool:
+        return True
 
 
 class Meter:
@@ -23,11 +48,19 @@ class Meter:
         return metrics.get_meter_provider().get_meter(f"{config.tags.app}.meter")
 
     @staticmethod
+    def get_metric_exporter(config: Config) -> MetricExporter:
+        match config.telemetry.otel_exporter:
+            case KarapaceTelemetryOTelExporter.NOOP:
+                return NOOPMetricExporter()
+            case KarapaceTelemetryOTelExporter.CONSOLE:
+                return ConsoleMetricExporter()
+            case KarapaceTelemetryOTelExporter.OTLP:
+                return OTLPMetricExporter(endpoint=config.telemetry.otel_endpoint_url)
+
+    @staticmethod
     @inject
     def get_metric_reader(config: Config = Provide[KarapaceContainer.config]) -> MetricReader:
-        exporter: MetricExporter = ConsoleMetricExporter()
-        if config.telemetry.otel_endpoint_url:
-            exporter = OTLPMetricExporter(endpoint=config.telemetry.otel_endpoint_url)
+        exporter: MetricExporter = Meter.get_metric_exporter(config)
         return PeriodicExportingMetricReader(
             exporter=exporter,
             export_interval_millis=config.telemetry.metrics_export_interval_milliseconds,

--- a/src/schema_registry/telemetry/meter.py
+++ b/src/schema_registry/telemetry/meter.py
@@ -1,0 +1,32 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+from dependency_injector.wiring import inject, Provide
+from karapace.config import Config
+from karapace.container import KarapaceContainer
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, MetricReader, PeriodicExportingMetricReader
+from typing import Final
+
+
+class Meter:
+    START_TIME_KEY: Final = "start_time"
+
+    @staticmethod
+    @inject
+    def get_meter(config: Config = Provide[KarapaceContainer.config]) -> metrics.Meter:
+        return metrics.get_meter_provider().get_meter(f"{config.tags.app}.meter")
+
+    @staticmethod
+    @inject
+    def get_metric_reader(config: Config = Provide[KarapaceContainer.config]) -> MetricReader:
+        exporter = ConsoleMetricExporter()
+        if config.telemetry.otel_endpoint_url:
+            exporter = OTLPMetricExporter(endpoint=config.telemetry.otel_endpoint_url)
+        return PeriodicExportingMetricReader(
+            exporter=exporter,
+            export_interval_millis=config.telemetry.metrics_export_interval_milliseconds,
+        )

--- a/src/schema_registry/telemetry/meter.py
+++ b/src/schema_registry/telemetry/meter.py
@@ -14,12 +14,9 @@ from opentelemetry.sdk.metrics.export import (
     MetricReader,
     PeriodicExportingMetricReader,
 )
-from typing import Final
 
 
 class Meter:
-    START_TIME_KEY: Final = "start_time"
-
     @staticmethod
     @inject
     def get_meter(config: Config = Provide[KarapaceContainer.config]) -> metrics.Meter:

--- a/src/schema_registry/telemetry/metrics.py
+++ b/src/schema_registry/telemetry/metrics.py
@@ -1,0 +1,27 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+from opentelemetry.metrics import Counter, Histogram, UpDownCounter
+from schema_registry.telemetry.meter import Meter
+from typing import Final
+
+
+class Metrics:
+    START_TIME_KEY: Final = "start_time"
+
+    def __init__(self, meter: Meter):
+        self.karapace_http_requests_in_progress: UpDownCounter = meter.get_meter().create_up_down_counter(
+            name="karapace_http_requests_in_progress",
+            description="In-progress requests for HTTP/TCP Protocol",
+        )
+        self.karapace_http_requests_duration_seconds: Histogram = meter.get_meter().create_histogram(
+            unit="seconds",
+            name="karapace_http_requests_duration_seconds",
+            description="Request Duration for HTTP/TCP Protocol",
+        )
+        self.karapace_http_requests_total: Counter = meter.get_meter().create_counter(
+            name="karapace_http_requests_total",
+            description="Total Request Count for HTTP/TCP Protocol",
+        )

--- a/src/schema_registry/telemetry/metrics.py
+++ b/src/schema_registry/telemetry/metrics.py
@@ -3,25 +3,57 @@ Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
 
+from fastapi import Request, Response, HTTPException
 from opentelemetry.metrics import Counter, Histogram, UpDownCounter
 from schema_registry.telemetry.meter import Meter
 from typing import Final
+from collections.abc import Mapping
+
+import time
 
 
-class Metrics:
+class HTTPRequestMetrics:
     START_TIME_KEY: Final = "start_time"
 
     def __init__(self, meter: Meter):
-        self.karapace_http_requests_in_progress: UpDownCounter = meter.get_meter().create_up_down_counter(
+        self.meter = meter
+        self.karapace_http_requests_in_progress: Final[UpDownCounter] = self.meter.get_meter().create_up_down_counter(
             name="karapace_http_requests_in_progress",
             description="In-progress requests for HTTP/TCP Protocol",
         )
-        self.karapace_http_requests_duration_seconds: Histogram = meter.get_meter().create_histogram(
+        self.karapace_http_requests_duration_seconds: Final[Histogram] = self.meter.get_meter().create_histogram(
             unit="seconds",
             name="karapace_http_requests_duration_seconds",
             description="Request Duration for HTTP/TCP Protocol",
         )
-        self.karapace_http_requests_total: Counter = meter.get_meter().create_counter(
+        self.karapace_http_requests_total: Final[Counter] = self.meter.get_meter().create_counter(
             name="karapace_http_requests_total",
             description="Total Request Count for HTTP/TCP Protocol",
         )
+
+    def get_resource_from_request(self, request: Request) -> str:
+        return request.url.path.split("/")[1]
+
+    def start_request(self, request: Request) -> Mapping[str, str | int]:
+        # Set start time for request
+        setattr(request.state, self.START_TIME_KEY, time.monotonic())
+
+        PATH = request.url.path
+        METHOD = request.method
+        ATTRIBUTES = {"method": METHOD, "path": PATH, "resource": self.get_resource_from_request(request=request)}
+
+        self.karapace_http_requests_in_progress.add(amount=1, attributes=ATTRIBUTES)
+        return ATTRIBUTES
+
+    def finish_request(self, ATTRIBUTES: Mapping[str, str | int], request: Request, response: Response | None) -> None:
+        status = response.status_code if response else 0
+        self.karapace_http_requests_total.add(amount=1, attributes={**ATTRIBUTES, "status": status})
+        self.karapace_http_requests_duration_seconds.record(
+            amount=(time.monotonic() - getattr(request.state, self.START_TIME_KEY)),
+            attributes=ATTRIBUTES,
+        )
+        self.karapace_http_requests_in_progress.add(amount=-1, attributes=ATTRIBUTES)
+
+    def record_request_exception(self, ATTRIBUTES: Mapping[str, str | int], exc: Exception) -> None:
+        status = exc.status_code if isinstance(exc, HTTPException) else 0
+        self.karapace_http_requests_total.add(amount=1, attributes={**ATTRIBUTES, "status": status})

--- a/src/schema_registry/telemetry/middleware.py
+++ b/src/schema_registry/telemetry/middleware.py
@@ -5,14 +5,13 @@ See LICENSE for details
 
 from collections.abc import Awaitable, Callable
 from dependency_injector.wiring import inject, Provide
-from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi import FastAPI, Request, Response
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from schema_registry.telemetry.container import TelemetryContainer
-from schema_registry.telemetry.metrics import Metrics
+from schema_registry.telemetry.metrics import HTTPRequestMetrics
 from schema_registry.telemetry.tracer import Tracer
 
 import logging
-import time
 
 LOG = logging.getLogger(__name__)
 
@@ -22,47 +21,28 @@ async def telemetry_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
     tracer: Tracer = Provide[TelemetryContainer.tracer],
-    metrics: Metrics = Provide[TelemetryContainer.metrics],
+    http_request_metrics: HTTPRequestMetrics = Provide[TelemetryContainer.http_request_metrics],
 ) -> Response | None:
-    RESOURCE = request.url.path.split("/")[1]
+    RESOURCE = http_request_metrics.get_resource_from_request(request=request)
     with tracer.get_tracer().start_as_current_span(name=f"{request.method}: /{RESOURCE}", kind=SpanKind.SERVER) as SPAN:
-        SPAN.add_event("Creating metering resources")
-
-        # Set start time for request
-        setattr(request.state, metrics.START_TIME_KEY, time.monotonic())
+        ATTRIBUTES = http_request_metrics.start_request(request=request)
         tracer.update_span_with_request(request=request, span=SPAN)
 
-        PATH = request.url.path
-        METHOD = request.method
-        ATTRIBUTES = {"method": METHOD, "path": PATH, "resource": RESOURCE}
-
-        SPAN.add_event("Metering requests in progress (increase)")
-        metrics.karapace_http_requests_in_progress.add(amount=1, attributes=ATTRIBUTES)
-
         try:
-            SPAN.add_event("Calling request handler")
             response: Response = await call_next(request)
             SPAN.set_status(Status(StatusCode.OK))
         except Exception as exc:
-            status = exc.status_code if isinstance(exc, HTTPException) else 0
-            SPAN.add_event("Metering total requests on exception")
-            metrics.karapace_http_requests_total.add(amount=1, attributes={**ATTRIBUTES, "status": status})
+            http_request_metrics.record_request_exception(ATTRIBUTES=ATTRIBUTES, exc=exc)
             SPAN.set_status(Status(StatusCode.ERROR))
             SPAN.record_exception(exc)
         else:
-            SPAN.add_event("Metering total requests")
-            metrics.karapace_http_requests_total.add(amount=1, attributes={**ATTRIBUTES, "status": response.status_code})
-            SPAN.add_event("Update span with response details")
             tracer.update_span_with_response(response=response, span=SPAN)
             return response
         finally:
-            SPAN.add_event("Metering request duration")
-            metrics.karapace_http_requests_duration_seconds.record(
-                amount=(time.monotonic() - getattr(request.state, metrics.START_TIME_KEY)),
-                attributes=ATTRIBUTES,
+            http_request_metrics.finish_request(
+                ATTRIBUTES=ATTRIBUTES, request=request, response=response if "response" in locals() else None
             )
-            SPAN.add_event("Metering requests in progress (decrease)")
-            metrics.karapace_http_requests_in_progress.add(amount=-1, attributes=ATTRIBUTES)
+
     return None
 
 

--- a/src/schema_registry/telemetry/middleware.py
+++ b/src/schema_registry/telemetry/middleware.py
@@ -6,13 +6,16 @@ See LICENSE for details
 from collections.abc import Awaitable, Callable
 from dependency_injector.wiring import inject, Provide
 from fastapi import FastAPI, Request, Response
+from opentelemetry.metrics import Counter, Histogram, UpDownCounter
 from opentelemetry.trace import SpanKind
 from karapace.config import Config
 from karapace.container import KarapaceContainer
 from schema_registry.telemetry.container import TelemetryContainer
+from schema_registry.telemetry.meter import Meter
 from schema_registry.telemetry.tracer import Tracer
 
 import logging
+import time
 
 LOG = logging.getLogger(__name__)
 
@@ -22,13 +25,60 @@ async def telemetry_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
     tracer: Tracer = Provide[TelemetryContainer.tracer],
+    meter: Meter = Provide[TelemetryContainer.meter],
     config: Config = Provide[KarapaceContainer.config],
 ) -> Response:
     resource = request.url.path.split("/")[1]
     with tracer.get_tracer().start_as_current_span(name=f"{request.method}: /{resource}", kind=SpanKind.SERVER) as span:
-        tracer.update_span_with_request(request=request, span=span, config=config)
+        span.add_event("Creating metering resources")
+        karapace_http_requests_in_progress: UpDownCounter = meter.get_meter().create_up_down_counter(
+            name="karapace_http_requests_in_progress",
+            description="In-progress requests for HTTP/TCP Protocol",
+        )
+        karapace_http_requests_duration_seconds: Histogram = meter.get_meter().create_histogram(
+            unit="seconds",
+            name="karapace_http_requests_duration_seconds",
+            description="Request Duration for HTTP/TCP Protocol",
+        )
+        karapace_http_requests_total: Counter = meter.get_meter().create_counter(
+            name="karapace_http_requests_total",
+            description="Total Request Count for HTTP/TCP Protocol",
+        )
+
+        # Set start time for request
+        setattr(request.state, meter.START_TIME_KEY, time.monotonic())
+
+        # Extract request labels
+        path = request.url.path
+        method = request.method
+
+        # Increment requests in progress before response handler
+        span.add_event("Metering requests in progress (increase)")
+        karapace_http_requests_in_progress.add(amount=1, attributes={"method": method, "path": path})
+
+        # Call request handler
+        tracer.update_span_with_request(request=request, span=span)
+        span.add_event("Calling request handler")
         response: Response = await call_next(request)
         tracer.update_span_with_response(response=response, span=span)
+
+        # Instrument request duration
+        span.add_event("Metering request duration")
+        karapace_http_requests_duration_seconds.record(
+            amount=(time.monotonic() - getattr(request.state, meter.START_TIME_KEY)),
+            attributes={"method": method, "path": path},
+        )
+
+        # Instrument total requests
+        span.add_event("Metering total requests")
+        karapace_http_requests_total.add(
+            amount=1, attributes={"method": method, "path": path, "status": response.status_code}
+        )
+
+        # Decrement requests in progress after response handler
+        span.add_event("Metering requests in progress (decrease)")
+        karapace_http_requests_in_progress.add(amount=-1, attributes={"method": method, "path": path})
+
         return response
 
 

--- a/src/schema_registry/telemetry/setup.py
+++ b/src/schema_registry/telemetry/setup.py
@@ -4,9 +4,12 @@ See LICENSE for details
 """
 
 from dependency_injector.wiring import inject, Provide
-from opentelemetry import trace
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from schema_registry.telemetry.container import TelemetryContainer
+from schema_registry.telemetry.meter import Meter
 from schema_registry.telemetry.tracer import Tracer
 
 import logging
@@ -22,3 +25,12 @@ def setup_tracing(
     LOG.info("Setting OTel tracing provider")
     tracer_provider.add_span_processor(tracer.get_span_processor())
     trace.set_tracer_provider(tracer_provider)
+
+
+@inject
+def setup_metering(
+    meter: Meter = Provide[TelemetryContainer.meter],
+    telemetry_resource: Resource = Provide[TelemetryContainer.telemetry_resource],
+) -> None:
+    LOG.info("Setting OTel meter provider")
+    metrics.set_meter_provider(MeterProvider(resource=telemetry_resource, metric_readers=[meter.get_metric_reader()]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import os
 import pytest
 import re
 import schema_registry.controller
+import schema_registry.telemetry.meter
 import schema_registry.telemetry.middleware
 import schema_registry.telemetry.setup
 import schema_registry.telemetry.tracer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,7 @@ def fixture_karapace_container() -> KarapaceContainer:
         modules=[
             schema_registry.controller,
             schema_registry.telemetry.tracer,
+            schema_registry.telemetry.meter,
         ]
     )
     return karapace_container

--- a/tests/unit/schema_registry/telemetry/test_meter.py
+++ b/tests/unit/schema_registry/telemetry/test_meter.py
@@ -5,6 +5,7 @@ Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
 
+from karapace.config import KarapaceTelemetry
 from karapace.container import KarapaceContainer
 from schema_registry.telemetry.meter import Meter
 from unittest.mock import patch
@@ -16,30 +17,35 @@ def test_meter(karapace_container: KarapaceContainer):
         mock_metrics.get_meter_provider.return_value.get_meter.assert_called_once_with("Karapace.meter")
 
 
-def test_get_metric_reader_with_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+def test_get_metric_reader_without_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+    config = karapace_container.config().set_config_defaults(
+        new_config={"telemetry": KarapaceTelemetry(otel_endpoint_url=None)}
+    )
     with (
-        patch("schema_registry.telemetry.meter.OTLPMetricExporter") as mock_otlp_exporter,
+        patch("schema_registry.telemetry.meter.ConsoleMetricExporter") as mock_console_exporter,
         patch("schema_registry.telemetry.meter.PeriodicExportingMetricReader") as mock_periodic_exporting_metric_reader,
     ):
-        karapace_container.config().telemetry.otel_endpoint_url = "http://otel:4317"
-        reader = Meter.get_metric_reader(config=karapace_container.config())
-        mock_otlp_exporter.assert_called_once_with(endpoint="http://otel:4317")
+        reader = Meter.get_metric_reader(config=config)
+        mock_console_exporter.assert_called_once()
         mock_periodic_exporting_metric_reader.assert_called_once_with(
-            exporter=mock_otlp_exporter.return_value,
+            exporter=mock_console_exporter.return_value,
             export_interval_millis=10000,
         )
         assert reader is mock_periodic_exporting_metric_reader.return_value
 
 
-def test_get_metric_reader_without_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+def test_get_metric_reader_with_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+    config = karapace_container.config().set_config_defaults(
+        new_config={"telemetry": KarapaceTelemetry(otel_endpoint_url="http://otel:4317")}
+    )
     with (
-        patch("schema_registry.telemetry.meter.ConsoleMetricExporter") as mock_console_exporter,
+        patch("schema_registry.telemetry.meter.OTLPMetricExporter") as mock_otlp_exporter,
         patch("schema_registry.telemetry.meter.PeriodicExportingMetricReader") as mock_periodic_exporting_metric_reader,
     ):
-        reader = Meter.get_metric_reader(config=karapace_container.config())
-        mock_console_exporter.assert_called_once()
+        reader = Meter.get_metric_reader(config=config)
+        mock_otlp_exporter.assert_called_once_with(endpoint="http://otel:4317")
         mock_periodic_exporting_metric_reader.assert_called_once_with(
-            exporter=mock_console_exporter.return_value,
+            exporter=mock_otlp_exporter.return_value,
             export_interval_millis=10000,
         )
         assert reader is mock_periodic_exporting_metric_reader.return_value

--- a/tests/unit/schema_registry/telemetry/test_meter.py
+++ b/tests/unit/schema_registry/telemetry/test_meter.py
@@ -7,8 +7,9 @@ See LICENSE for details
 
 from karapace.config import KarapaceTelemetry
 from karapace.container import KarapaceContainer
-from schema_registry.telemetry.meter import Meter
+from schema_registry.telemetry.meter import Meter, NOOPMetricExporter
 from unittest.mock import patch
+from opentelemetry.sdk.metrics.export import ConsoleMetricExporter, MetricExporter
 
 
 def test_meter(karapace_container: KarapaceContainer):
@@ -17,18 +18,59 @@ def test_meter(karapace_container: KarapaceContainer):
         mock_metrics.get_meter_provider.return_value.get_meter.assert_called_once_with("Karapace.meter")
 
 
+def test_get_metric_exporter_noop(karapace_container: KarapaceContainer) -> None:
+    config = karapace_container.config().set_config_defaults(
+        new_config={
+            "telemetry": KarapaceTelemetry(
+                otel_endpoint_url="http://otel:4317",
+                otel_exporter="NOOP",
+            )
+        }
+    )
+    exporter: MetricExporter = Meter.get_metric_exporter(config=config)
+    assert isinstance(exporter, NOOPMetricExporter)
+
+
+def test_get_metric_exporter_console(karapace_container: KarapaceContainer) -> None:
+    config = karapace_container.config().set_config_defaults(
+        new_config={
+            "telemetry": KarapaceTelemetry(
+                otel_endpoint_url="http://otel:4317",
+                otel_exporter="CONSOLE",
+            )
+        }
+    )
+    exporter: MetricExporter = Meter.get_metric_exporter(config=config)
+    assert isinstance(exporter, ConsoleMetricExporter)
+
+
+def test_get_metric_exporter_otlp(karapace_container: KarapaceContainer) -> None:
+    config = karapace_container.config().set_config_defaults(
+        new_config={
+            "telemetry": KarapaceTelemetry(
+                otel_endpoint_url="http://otel:4317",
+                otel_exporter="OTLP",
+            )
+        }
+    )
+    with patch("schema_registry.telemetry.meter.OTLPMetricExporter") as mock_otlp_exporter:
+        exporter: MetricExporter = Meter.get_metric_exporter(config=config)
+        mock_otlp_exporter.assert_called_once_with(endpoint="http://otel:4317")
+        assert exporter is mock_otlp_exporter.return_value
+
+
 def test_get_metric_reader_without_otel_endpoint(karapace_container: KarapaceContainer) -> None:
     config = karapace_container.config().set_config_defaults(
         new_config={"telemetry": KarapaceTelemetry(otel_endpoint_url=None)}
     )
     with (
-        patch("schema_registry.telemetry.meter.ConsoleMetricExporter") as mock_console_exporter,
+        patch("schema_registry.telemetry.meter.NOOPMetricExporter") as mock_noop_exporter,
         patch("schema_registry.telemetry.meter.PeriodicExportingMetricReader") as mock_periodic_exporting_metric_reader,
     ):
         reader = Meter.get_metric_reader(config=config)
-        mock_console_exporter.assert_called_once()
+        mock_noop_exporter.assert_called_once()
         mock_periodic_exporting_metric_reader.assert_called_once_with(
-            exporter=mock_console_exporter.return_value,
+            exporter=mock_noop_exporter.return_value,
             export_interval_millis=10000,
         )
         assert reader is mock_periodic_exporting_metric_reader.return_value
@@ -36,7 +78,12 @@ def test_get_metric_reader_without_otel_endpoint(karapace_container: KarapaceCon
 
 def test_get_metric_reader_with_otel_endpoint(karapace_container: KarapaceContainer) -> None:
     config = karapace_container.config().set_config_defaults(
-        new_config={"telemetry": KarapaceTelemetry(otel_endpoint_url="http://otel:4317")}
+        new_config={
+            "telemetry": KarapaceTelemetry(
+                otel_endpoint_url="http://otel:4317",
+                otel_exporter="OTLP",
+            )
+        }
     )
     with (
         patch("schema_registry.telemetry.meter.OTLPMetricExporter") as mock_otlp_exporter,

--- a/tests/unit/schema_registry/telemetry/test_meter.py
+++ b/tests/unit/schema_registry/telemetry/test_meter.py
@@ -1,0 +1,45 @@
+"""
+schema_registry - telemetry meter tests
+
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+from karapace.container import KarapaceContainer
+from schema_registry.telemetry.meter import Meter
+from unittest.mock import patch
+
+
+def test_meter(karapace_container: KarapaceContainer):
+    with patch("schema_registry.telemetry.meter.metrics") as mock_metrics:
+        Meter.get_meter(config=karapace_container.config())
+        mock_metrics.get_meter_provider.return_value.get_meter.assert_called_once_with("Karapace.meter")
+
+
+def test_get_metric_reader_with_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+    with (
+        patch("schema_registry.telemetry.meter.OTLPMetricExporter") as mock_otlp_exporter,
+        patch("schema_registry.telemetry.meter.PeriodicExportingMetricReader") as mock_periodic_exporting_metric_reader,
+    ):
+        karapace_container.config().telemetry.otel_endpoint_url = "http://otel:4317"
+        reader = Meter.get_metric_reader(config=karapace_container.config())
+        mock_otlp_exporter.assert_called_once_with(endpoint="http://otel:4317")
+        mock_periodic_exporting_metric_reader.assert_called_once_with(
+            exporter=mock_otlp_exporter.return_value,
+            export_interval_millis=10000,
+        )
+        assert reader is mock_periodic_exporting_metric_reader.return_value
+
+
+def test_get_metric_reader_without_otel_endpoint(karapace_container: KarapaceContainer) -> None:
+    with (
+        patch("schema_registry.telemetry.meter.ConsoleMetricExporter") as mock_console_exporter,
+        patch("schema_registry.telemetry.meter.PeriodicExportingMetricReader") as mock_periodic_exporting_metric_reader,
+    ):
+        reader = Meter.get_metric_reader(config=karapace_container.config())
+        mock_console_exporter.assert_called_once()
+        mock_periodic_exporting_metric_reader.assert_called_once_with(
+            exporter=mock_console_exporter.return_value,
+            export_interval_millis=10000,
+        )
+        assert reader is mock_periodic_exporting_metric_reader.return_value

--- a/tests/unit/schema_registry/telemetry/test_metrics.py
+++ b/tests/unit/schema_registry/telemetry/test_metrics.py
@@ -1,0 +1,40 @@
+"""
+schema_registry - telemetry metrics tests
+
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+from schema_registry.telemetry.metrics import Metrics
+from schema_registry.telemetry.meter import Meter
+from unittest.mock import call, MagicMock
+
+
+def test_metrics():
+    meter = MagicMock(spec=Meter)
+    metrics = Metrics(meter=meter)
+
+    assert hasattr(metrics, "karapace_http_requests_in_progress")
+    assert hasattr(metrics, "karapace_http_requests_duration_seconds")
+    assert hasattr(metrics, "karapace_http_requests_total")
+    assert hasattr(metrics, "START_TIME_KEY")
+    assert metrics.START_TIME_KEY == "start_time"
+
+    meter.assert_has_calls(
+        [
+            call.get_meter(),
+            call.get_meter().create_up_down_counter(
+                name="karapace_http_requests_in_progress", description="In-progress requests for HTTP/TCP Protocol"
+            ),
+            call.get_meter(),
+            call.get_meter().create_histogram(
+                unit="seconds",
+                name="karapace_http_requests_duration_seconds",
+                description="Request Duration for HTTP/TCP Protocol",
+            ),
+            call.get_meter(),
+            call.get_meter().create_counter(
+                name="karapace_http_requests_total", description="Total Request Count for HTTP/TCP Protocol"
+            ),
+        ]
+    )

--- a/tests/unit/schema_registry/telemetry/test_metrics.py
+++ b/tests/unit/schema_registry/telemetry/test_metrics.py
@@ -5,22 +5,37 @@ Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
 
-from schema_registry.telemetry.metrics import Metrics
+from fastapi import Request, Response, HTTPException
+from schema_registry.telemetry.metrics import HTTPRequestMetrics
 from schema_registry.telemetry.meter import Meter
 from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 
-def test_metrics():
+@pytest.fixture
+def http_request_metrics() -> HTTPRequestMetrics:
     meter = MagicMock(spec=Meter)
-    metrics = Metrics(meter=meter)
+    return HTTPRequestMetrics(meter=meter)
 
-    assert hasattr(metrics, "karapace_http_requests_in_progress")
-    assert hasattr(metrics, "karapace_http_requests_duration_seconds")
-    assert hasattr(metrics, "karapace_http_requests_total")
-    assert hasattr(metrics, "START_TIME_KEY")
-    assert metrics.START_TIME_KEY == "start_time"
 
-    meter.assert_has_calls(
+@pytest.fixture
+def request_mock() -> AsyncMock:
+    request_mock = AsyncMock(spec=Request)
+    request_mock.method = "GET"
+    request_mock.url.path = "/test/inner-path"
+    return request_mock
+
+
+def test_http_request_metrics_objects(http_request_metrics: HTTPRequestMetrics):
+    assert hasattr(http_request_metrics, "karapace_http_requests_in_progress")
+    assert hasattr(http_request_metrics, "karapace_http_requests_duration_seconds")
+    assert hasattr(http_request_metrics, "karapace_http_requests_total")
+    assert hasattr(http_request_metrics, "START_TIME_KEY")
+    assert http_request_metrics.START_TIME_KEY == "start_time"
+
+    http_request_metrics.meter.assert_has_calls(
         [
             call.get_meter(),
             call.get_meter().create_up_down_counter(
@@ -37,4 +52,74 @@ def test_metrics():
                 name="karapace_http_requests_total", description="Total Request Count for HTTP/TCP Protocol"
             ),
         ]
+    )
+
+
+def test_get_resource_from_request(http_request_metrics: HTTPRequestMetrics, request_mock: AsyncMock) -> None:
+    assert http_request_metrics.get_resource_from_request(request=request_mock) == "test"
+
+
+def test_start_request(http_request_metrics: HTTPRequestMetrics, request_mock: AsyncMock) -> None:
+    http_request_metrics.karapace_http_requests_in_progress = MagicMock()
+
+    with patch("schema_registry.telemetry.metrics.time.monotonic", return_value=1):
+        ATTRIBUTES = http_request_metrics.start_request(request=request_mock)
+        http_request_metrics.karapace_http_requests_in_progress.add.assert_called_with(amount=1, attributes=ATTRIBUTES)
+        assert ATTRIBUTES == {"method": "GET", "path": "/test/inner-path", "resource": "test"}
+
+
+def test_finish_request(http_request_metrics: HTTPRequestMetrics, request_mock: AsyncMock) -> None:
+    ATTRIBUTES = {"method": "GET", "path": "/test/inner-path", "resource": "test"}
+    response_mock = AsyncMock(spec=Response)
+    response_mock.status_code = 200
+    http_request_metrics.karapace_http_requests_duration_seconds = MagicMock()
+    http_request_metrics.karapace_http_requests_in_progress = MagicMock()
+    http_request_metrics.karapace_http_requests_total = MagicMock()
+
+    with patch("schema_registry.telemetry.metrics.time.monotonic", return_value=3):
+        http_request_metrics.finish_request(ATTRIBUTES=ATTRIBUTES, request=request_mock, response=response_mock)
+        http_request_metrics.karapace_http_requests_duration_seconds.record.assert_called_with(
+            amount=3 - request_mock.state.start_time, attributes=ATTRIBUTES
+        )
+        http_request_metrics.karapace_http_requests_in_progress.add.assert_called_with(amount=-1, attributes=ATTRIBUTES)
+        http_request_metrics.karapace_http_requests_total.add.assert_called_with(
+            amount=1, attributes={**ATTRIBUTES, "status": 200}
+        )
+
+
+def test_finish_request_without_response(http_request_metrics: HTTPRequestMetrics, request_mock: AsyncMock) -> None:
+    ATTRIBUTES = {"method": "GET", "path": "/test/inner-path", "resource": "test"}
+    http_request_metrics.karapace_http_requests_duration_seconds = MagicMock()
+    http_request_metrics.karapace_http_requests_in_progress = MagicMock()
+    http_request_metrics.karapace_http_requests_total = MagicMock()
+
+    with patch("schema_registry.telemetry.metrics.time.monotonic", return_value=3):
+        http_request_metrics.finish_request(ATTRIBUTES=ATTRIBUTES, request=request_mock, response=None)
+        http_request_metrics.karapace_http_requests_duration_seconds.record.assert_called_with(
+            amount=3 - request_mock.state.start_time, attributes=ATTRIBUTES
+        )
+        http_request_metrics.karapace_http_requests_in_progress.add.assert_called_with(amount=-1, attributes=ATTRIBUTES)
+        http_request_metrics.karapace_http_requests_total.add.assert_called_with(
+            amount=1, attributes={**ATTRIBUTES, "status": 0}
+        )
+
+
+def test_record_request_exception_http_exception(http_request_metrics: HTTPRequestMetrics) -> None:
+    exception = HTTPException(status_code=404)
+    ATTRIBUTES = {"method": "GET", "path": "/test/inner-path", "resource": "test"}
+    http_request_metrics.karapace_http_requests_total = MagicMock()
+
+    http_request_metrics.record_request_exception(ATTRIBUTES=ATTRIBUTES, exc=exception)
+    http_request_metrics.karapace_http_requests_total.add.assert_called_with(
+        amount=1, attributes={**ATTRIBUTES, "status": 404}
+    )
+
+
+def test_record_request_exception_uncaught_exception(http_request_metrics: HTTPRequestMetrics) -> None:
+    ATTRIBUTES = {"method": "GET", "path": "/test/inner-path", "resource": "test"}
+    http_request_metrics.karapace_http_requests_total = MagicMock()
+
+    http_request_metrics.record_request_exception(ATTRIBUTES=ATTRIBUTES, exc=Exception())
+    http_request_metrics.karapace_http_requests_total.add.assert_called_with(
+        amount=1, attributes={**ATTRIBUTES, "status": 0}
     )

--- a/tests/unit/schema_registry/telemetry/test_middleware.py
+++ b/tests/unit/schema_registry/telemetry/test_middleware.py
@@ -9,9 +9,10 @@ from _pytest.logging import LogCaptureFixture
 from fastapi import FastAPI, Request, Response
 from opentelemetry.trace import SpanKind
 from karapace.config import Config
+from schema_registry.telemetry.meter import Meter
 from schema_registry.telemetry.middleware import setup_telemetry_middleware, telemetry_middleware
 from schema_registry.telemetry.tracer import Tracer
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock, patch
 
 import logging
 
@@ -32,10 +33,11 @@ def test_setup_telemetry_middleware(caplog: LogCaptureFixture) -> None:
 
 async def test_telemetry_middleware() -> None:
     tracer = MagicMock(spec=Tracer)
+    meter = MagicMock(spec=Meter, START_TIME_KEY="start_time")
 
     request_mock = AsyncMock(spec=Request)
     request_mock.method = "GET"
-    request_mock.url.path = "/test"
+    request_mock.url.path = "/test/inner-path"
 
     response_mock = AsyncMock(spec=Response)
     response_mock.status_code = 200
@@ -45,15 +47,52 @@ async def test_telemetry_middleware() -> None:
     call_next = AsyncMock()
     call_next.return_value = response_mock
 
-    response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, config=config_mock)
-    span = tracer.get_tracer.return_value.start_as_current_span.return_value.__enter__.return_value
+    with patch("schema_registry.telemetry.middleware.time.monotonic", return_value=1):
+        response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, meter=meter)
+        span = tracer.get_tracer.return_value.start_as_current_span.return_value.__enter__.return_value
 
-    tracer.get_tracer.assert_called_once()
-    tracer.get_tracer.return_value.start_as_current_span.assert_called_once_with(name="GET: /test", kind=SpanKind.SERVER)
-    tracer.update_span_with_request.assert_called_once_with(request=request_mock, span=span, config=config_mock)
-    tracer.update_span_with_response.assert_called_once_with(response=response_mock, span=span)
+        tracer.get_tracer.assert_called_once()
+        tracer.get_tracer.return_value.start_as_current_span.assert_called_once_with(name="GET: /test", kind=SpanKind.SERVER)
+        tracer.update_span_with_request.assert_called_once_with(request=request_mock, span=span)
+        tracer.update_span_with_response.assert_called_once_with(response=response_mock, span=span)
 
-    # Check that the request handler is called
-    call_next.assert_awaited_once_with(request_mock)
+        # Check that the request handler is called
+        call_next.assert_awaited_once_with(request_mock)
 
-    assert response == response_mock
+        span.add_event.assert_has_calls(
+            [
+                call("Creating metering resources"),
+                call("Metering requests in progress (increase)"),
+                call("Calling request handler"),
+                call("Metering request duration"),
+                call("Metering total requests"),
+                call("Metering requests in progress (decrease)"),
+            ]
+        )
+
+        meter.get_meter.assert_has_calls(
+            [
+                call(),
+                call().create_up_down_counter(
+                    name="karapace_http_requests_in_progress", description="In-progress requests for HTTP/TCP Protocol"
+                ),
+                call(),
+                call().create_histogram(
+                    unit="seconds",
+                    name="karapace_http_requests_duration_seconds",
+                    description="Request Duration for HTTP/TCP Protocol",
+                ),
+                call(),
+                call().create_counter(
+                    name="karapace_http_requests_total", description="Total Request Count for HTTP/TCP Protocol"
+                ),
+                call().create_up_down_counter().add(amount=1, attributes={"method": "GET", "path": "/test/inner-path"}),
+                call().create_histogram().record(amount=0, attributes={"method": "GET", "path": "/test/inner-path"}),
+                call()
+                .create_counter()
+                .add(amount=1, attributes={"method": "GET", "path": "/test/inner-path", "status": 200}),
+                call().create_up_down_counter().add(amount=-1, attributes={"method": "GET", "path": "/test/inner-path"}),
+            ]
+        )
+
+        assert response == response_mock

--- a/tests/unit/schema_registry/telemetry/test_middleware.py
+++ b/tests/unit/schema_registry/telemetry/test_middleware.py
@@ -6,15 +6,28 @@ See LICENSE for details
 """
 
 from _pytest.logging import LogCaptureFixture
-from fastapi import FastAPI, Request, Response
-from opentelemetry.trace import SpanKind
-from karapace.config import Config
+from fastapi import FastAPI, Request, Response, HTTPException
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from schema_registry.telemetry.metrics import Metrics
 from schema_registry.telemetry.meter import Meter
 from schema_registry.telemetry.middleware import setup_telemetry_middleware, telemetry_middleware
 from schema_registry.telemetry.tracer import Tracer
 from unittest.mock import AsyncMock, call, MagicMock, patch
 
 import logging
+import pytest
+
+
+@pytest.fixture
+def metrics() -> MagicMock:
+    return MagicMock(
+        spec=Metrics,
+        START_TIME_KEY="start_time",
+        meter=MagicMock(spec=Meter),
+        karapace_http_requests_in_progress=MagicMock(),
+        karapace_http_requests_duration_seconds=MagicMock(),
+        karapace_http_requests_total=MagicMock(),
+    )
 
 
 def test_setup_telemetry_middleware(caplog: LogCaptureFixture) -> None:
@@ -31,9 +44,8 @@ def test_setup_telemetry_middleware(caplog: LogCaptureFixture) -> None:
         app.middleware.return_value.assert_called_once_with(telemetry_middleware)
 
 
-async def test_telemetry_middleware() -> None:
+async def test_telemetry_middleware(metrics: MagicMock) -> None:
     tracer = MagicMock(spec=Tracer)
-    meter = MagicMock(spec=Meter, START_TIME_KEY="start_time")
 
     request_mock = AsyncMock(spec=Request)
     request_mock.method = "GET"
@@ -42,13 +54,16 @@ async def test_telemetry_middleware() -> None:
     response_mock = AsyncMock(spec=Response)
     response_mock.status_code = 200
 
-    config_mock = MagicMock(spec=Config)
-
     call_next = AsyncMock()
     call_next.return_value = response_mock
 
-    with patch("schema_registry.telemetry.middleware.time.monotonic", return_value=1):
-        response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, meter=meter)
+    SpanStatus = MagicMock(spec=Status, status_code=StatusCode.OK)
+
+    with (
+        patch("schema_registry.telemetry.middleware.time.monotonic", return_value=1),
+        patch("schema_registry.telemetry.middleware.Status", return_value=SpanStatus),
+    ):
+        response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, metrics=metrics)
         span = tracer.get_tracer.return_value.start_as_current_span.return_value.__enter__.return_value
 
         tracer.get_tracer.assert_called_once()
@@ -58,41 +73,157 @@ async def test_telemetry_middleware() -> None:
 
         # Check that the request handler is called
         call_next.assert_awaited_once_with(request_mock)
+        span.set_status.assert_called_once_with(SpanStatus)
 
         span.add_event.assert_has_calls(
             [
                 call("Creating metering resources"),
                 call("Metering requests in progress (increase)"),
                 call("Calling request handler"),
-                call("Metering request duration"),
                 call("Metering total requests"),
+                call("Update span with response details"),
+                call("Metering request duration"),
                 call("Metering requests in progress (decrease)"),
             ]
         )
 
-        meter.get_meter.assert_has_calls(
+        metrics.assert_has_calls(
             [
-                call(),
-                call().create_up_down_counter(
-                    name="karapace_http_requests_in_progress", description="In-progress requests for HTTP/TCP Protocol"
+                call.karapace_http_requests_in_progress.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
                 ),
-                call(),
-                call().create_histogram(
-                    unit="seconds",
-                    name="karapace_http_requests_duration_seconds",
-                    description="Request Duration for HTTP/TCP Protocol",
+                call.karapace_http_requests_total.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "status": 200, "resource": "test"}
                 ),
-                call(),
-                call().create_counter(
-                    name="karapace_http_requests_total", description="Total Request Count for HTTP/TCP Protocol"
+                call.karapace_http_requests_duration_seconds.record(
+                    amount=0, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
                 ),
-                call().create_up_down_counter().add(amount=1, attributes={"method": "GET", "path": "/test/inner-path"}),
-                call().create_histogram().record(amount=0, attributes={"method": "GET", "path": "/test/inner-path"}),
-                call()
-                .create_counter()
-                .add(amount=1, attributes={"method": "GET", "path": "/test/inner-path", "status": 200}),
-                call().create_up_down_counter().add(amount=-1, attributes={"method": "GET", "path": "/test/inner-path"}),
+                call.karapace_http_requests_in_progress.add(
+                    amount=-1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
             ]
         )
 
         assert response == response_mock
+
+
+async def test_telemetry_middleware_when_call_next_raises_unknown_error(metrics: MagicMock) -> None:
+    tracer = MagicMock(spec=Tracer)
+
+    request_mock = AsyncMock(spec=Request)
+    request_mock.method = "GET"
+    request_mock.url.path = "/test/inner-path"
+
+    call_next = AsyncMock()
+    call_next.side_effect = Exception("Something went wrong")
+
+    SpanStatus = MagicMock(spec=Status, status_code=StatusCode.ERROR)
+
+    with (
+        patch("schema_registry.telemetry.middleware.time.monotonic", return_value=1),
+        patch("schema_registry.telemetry.middleware.Status", return_value=SpanStatus),
+    ):
+        response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, metrics=metrics)
+        span = tracer.get_tracer.return_value.start_as_current_span.return_value.__enter__.return_value
+
+        tracer.get_tracer.assert_called_once()
+        tracer.get_tracer.return_value.start_as_current_span.assert_called_once_with(name="GET: /test", kind=SpanKind.SERVER)
+        tracer.update_span_with_request.assert_called_once_with(request=request_mock, span=span)
+
+        # Check that the request handler is called, the exception is caught and the span
+        # is not updated with response as there will be no response due to the exception
+        call_next.assert_awaited_once_with(request_mock)
+        span.set_status.assert_called_once_with(SpanStatus)
+        span.record_exception.assert_called_once_with(call_next.side_effect)
+        assert not tracer.update_span_with_response.called
+
+        span.add_event.assert_has_calls(
+            [
+                call("Creating metering resources"),
+                call("Metering requests in progress (increase)"),
+                call("Calling request handler"),
+                call("Metering total requests on exception"),
+                call("Metering request duration"),
+                call("Metering requests in progress (decrease)"),
+            ]
+        )
+
+        metrics.assert_has_calls(
+            [
+                call.karapace_http_requests_in_progress.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+                call.karapace_http_requests_total.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "status": 0, "resource": "test"}
+                ),
+                call.karapace_http_requests_duration_seconds.record(
+                    amount=0, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+                call.karapace_http_requests_in_progress.add(
+                    amount=-1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+            ]
+        )
+
+        assert not response
+
+
+async def test_telemetry_middleware_when_call_next_raises_http_error(metrics: MagicMock) -> None:
+    tracer = MagicMock(spec=Tracer)
+
+    request_mock = AsyncMock(spec=Request)
+    request_mock.method = "GET"
+    request_mock.url.path = "/test/inner-path"
+
+    call_next = AsyncMock()
+    call_next.side_effect = HTTPException(status_code=401, detail="Unauthorized")
+
+    SpanStatus = MagicMock(spec=Status, status_code=StatusCode.ERROR)
+
+    with (
+        patch("schema_registry.telemetry.middleware.time.monotonic", return_value=1),
+        patch("schema_registry.telemetry.middleware.Status", return_value=SpanStatus),
+    ):
+        response = await telemetry_middleware(request=request_mock, call_next=call_next, tracer=tracer, metrics=metrics)
+        span = tracer.get_tracer.return_value.start_as_current_span.return_value.__enter__.return_value
+
+        tracer.get_tracer.assert_called_once()
+        tracer.get_tracer.return_value.start_as_current_span.assert_called_once_with(name="GET: /test", kind=SpanKind.SERVER)
+        tracer.update_span_with_request.assert_called_once_with(request=request_mock, span=span)
+
+        # Check that the request handler is called, the exception is caught and the span
+        # is not updated with response as there will be no response due to the exception
+        call_next.assert_awaited_once_with(request_mock)
+        span.set_status.assert_called_once_with(SpanStatus)
+        span.record_exception.assert_called_once_with(call_next.side_effect)
+        assert not tracer.update_span_with_response.called
+
+        span.add_event.assert_has_calls(
+            [
+                call("Creating metering resources"),
+                call("Metering requests in progress (increase)"),
+                call("Calling request handler"),
+                call("Metering total requests on exception"),
+                call("Metering request duration"),
+                call("Metering requests in progress (decrease)"),
+            ]
+        )
+
+        metrics.assert_has_calls(
+            [
+                call.karapace_http_requests_in_progress.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+                call.karapace_http_requests_total.add(
+                    amount=1, attributes={"method": "GET", "path": "/test/inner-path", "status": 401, "resource": "test"}
+                ),
+                call.karapace_http_requests_duration_seconds.record(
+                    amount=0, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+                call.karapace_http_requests_in_progress.add(
+                    amount=-1, attributes={"method": "GET", "path": "/test/inner-path", "resource": "test"}
+                ),
+            ]
+        )
+
+        assert not response


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
- we add OTel metering and HTTP metrics to the service.
- the metrics are exported to `prometheus` via the `opentelemetry-collector` as shown below

<img width="1510" alt="Screenshot 2024-12-19 at 10 47 58" src="https://github.com/user-attachments/assets/b775be15-8bfe-4f7b-8103-03bee2cd936c" />

- no changes to  the `grafana` dashboard shows that the `prometheus` source still works as expected

<img width="1510" alt="Screenshot 2024-12-19 at 10 49 00" src="https://github.com/user-attachments/assets/80ef134d-6144-4d61-a2b9-96703e62fa46" />

# Follow up
- update the `schema_reader` metrics to use the OTel meter
- maybe deprecate `statsd`
- close the prometheus PR #1007 as we now use the OTel metering and exporting to prometheus, thus native prometheus instrumentation is not needed