### PR TITLE
gha: use docker layer cache for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,16 @@ jobs:
     - run: echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
     - run: echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
 
+    - name: Cache docker layers
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        cache-to: type=inline
+        push: false
+        build-args: KARAPACE_VERSION=${{ env.KARAPACE_VERSION }}
+        file: container/Dockerfile
+        platforms: linux/amd64
+
     - run: make unit-tests-in-docker
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
We try to speed up the tests by caching the docker layer. 