### PR TITLE
fix: backup tool shall still use the JSON config file

### DIFF
--- a/tests/integration/backup/test_v3_backup.py
+++ b/tests/integration/backup/test_v3_backup.py
@@ -66,10 +66,7 @@ def config_file_fixture(
     file_path = directory_path / "config.json"
     try:
         file_path.write_text(
-            f"""\
-            BOOTSTRAP_URI={kafka_servers.bootstrap_servers[0]}
-            TOPIC_NAME={registry_cluster.schemas_topic}
-            """
+            json.dumps({"bootstrap_uri": kafka_servers.bootstrap_servers[0], "topic_name": registry_cluster.schemas_topic})
         )
         yield file_path
     finally:


### PR DESCRIPTION
The config for backup tool is still the full Karapace config. Config for Karapace is a set of environment variables opposed to prior JSON file. Backup tool will still use the JSON format.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
