### PR TITLE
Updating session timeout tests

### DIFF
--- a/tests/integration/backup/test_session_timeout.py
+++ b/tests/integration/backup/test_session_timeout.py
@@ -6,18 +6,22 @@ See LICENSE for details
 from pathlib import Path
 
 import pytest
-from aiokafka.errors import NoBrokersAvailable
+from aiokafka.errors import InvalidSessionTimeoutError
+from confluent_kafka import TopicPartition
 from confluent_kafka.admin import NewTopic
 
-from karapace.backup.api import BackupVersion, create_backup
 from karapace.core.config import Config
 from karapace.core.kafka.admin import KafkaAdminClient
-from karapace.core.kafka_utils import kafka_producer_from_config
+
+from src.karapace.backup.api import _consume_records
+from src.karapace.backup.poll_timeout import PollTimeout
+from src.karapace.core.kafka_utils import kafka_producer_from_config, kafka_consumer_from_config
 from tests.integration.conftest import create_kafka_server
 from tests.integration.utils.config import KafkaDescription
 from tests.integration.utils.kafka_server import KafkaServers
 
 SESSION_TIMEOUT_MS = 65000
+INVALID_SESSION_TIMEOUT_MS = 5000
 GROUP_MIN_SESSION_TIMEOUT_MS = 60000
 GROUP_MAX_SESSION_TIMEOUT_MS = 70000
 
@@ -44,13 +48,13 @@ def fixture_kafka_server(
     )
 
 
-def test_producer_with_custom_kafka_properties_does_not_fail(
+def test_consumer_with_custom_kafka_properties_does_not_fail(
     kafka_server_session_timeout: KafkaServers,
     new_topic: NewTopic,
     tmp_path: Path,
 ) -> None:
     """
-    This test checks wether the custom properties are accepted by kafka.
+    This test checks weather the custom properties are accepted by kafka.
     We know by the implementation of the consumer startup code that if
     `group.session.min.timeout.ms` > `session.timeout.ms` the consumer
     will raise an exception during the startup.
@@ -64,9 +68,38 @@ def test_producer_with_custom_kafka_properties_does_not_fail(
     admin_client = KafkaAdminClient(bootstrap_servers=kafka_server_session_timeout.bootstrap_servers)
     admin_client.new_topic(new_topic.topic, num_partitions=1, replication_factor=1)
 
+    produce_consume_messages(config, new_topic.topic, False)
+
+
+def test_consumer_with_custom_kafka_properties_fail(
+    kafka_server_session_timeout: KafkaServers,
+    new_topic: NewTopic,
+    tmp_path: Path,
+) -> None:
+    """
+    This test checks weather the custom properties are accepted by kafka.
+    We know by the implementation of the consumer startup code that if
+    `group.session.min.timeout.ms` > `session.timeout.ms` the consumer
+    will raise an exception during the startup.
+    This test ensures that the `session.timeout.ms` can be injected in
+    the kafka config so that the exception is raised
+    """
+    admin_client = KafkaAdminClient(bootstrap_servers=kafka_server_session_timeout.bootstrap_servers)
+    admin_client.new_topic(new_topic.topic, num_partitions=1, replication_factor=1)
+
+    config = Config()
+    # the configured broker from kafka_server_session.
+    config.bootstrap_uri = kafka_server_session_timeout.bootstrap_servers[0]
+    # configure session timeout less than min session time
+    config.session_timeout_ms = INVALID_SESSION_TIMEOUT_MS
+
+    produce_consume_messages(config, new_topic.topic, True)
+
+
+def produce_consume_messages(config: Config, new_topic: str, invalid_config: bool):
     with kafka_producer_from_config(config) as producer:
         producer.send(
-            new_topic.topic,
+            new_topic,
             key=b"foo",
             value=b"bar",
             partition=0,
@@ -76,39 +109,19 @@ def test_producer_with_custom_kafka_properties_does_not_fail(
             ],
             timestamp=1683474657,
         )
-        producer.flush()
-
-    # without performing the backup the exception isn't raised.
-    create_backup(
-        config=config,
-        backup_location=tmp_path / "backup",
-        topic_name=new_topic.topic,
-        version=BackupVersion.V3,
-        replication_factor=1,
-    )
+    if invalid_config:
+        with pytest.raises(InvalidSessionTimeoutError):
+            consume_messages(config, new_topic)
+    else:
+        consume_messages(config, new_topic)
 
 
-def test_producer_with_custom_kafka_properties_fail(
-    kafka_server_session_timeout: KafkaServers,
-    new_topic: NewTopic,
-) -> None:
-    """
-    This test checks wether the custom properties are accepted by kafka.
-    We know by the implementation of the consumer startup code that if
-    `group.session.min.timeout.ms` > `session.timeout.ms` the consumer
-    will raise an exception during the startup.
-    This test ensures that the `session.timeout.ms` can be injected in
-    the kafka config so that the exception isn't raised
-    """
-    admin_client = KafkaAdminClient(bootstrap_servers=kafka_server_session_timeout.bootstrap_servers)
-    admin_client.new_topic(new_topic.topic, num_partitions=1, replication_factor=1)
-
-    config = Config()
-    # TODO: This test is broken. Test has used localhost:9092 when this should use
-    # the configured broker from kafka_server_session.
-    # config.bootstrap_uri = kafka_server_session_timeout.bootstrap_servers[0]
-    config.bootstrap_uri = "localhost:9092"
-
-    with pytest.raises(NoBrokersAvailable):
-        with kafka_producer_from_config(config) as producer:
-            _ = producer
+def consume_messages(config, new_topic):
+    with kafka_consumer_from_config(config, new_topic) as consumer:
+        (partition,) = consumer.partitions_for_topic(new_topic)
+        for _ in _consume_records(
+            consumer=consumer,
+            topic_partition=TopicPartition(new_topic, partition),
+            poll_timeout=PollTimeout.default(),
+        ):
+            pass


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

There is a test which uses producer instead of consumer to test session.timeout.ms (consumer config).
This PR updates it

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
