### PR TITLE
Consumer commit fix

### DIFF
--- a/src/karapace/kafka_rest_apis/consumer_manager.py
+++ b/src/karapace/kafka_rest_apis/consumer_manager.py
@@ -298,7 +298,7 @@ class ConsumerManager:
                 error_trace = traceback.format_exc()  # Capture the full stack trace
                 offset_stored_err_message = "Commit failed: Local: No offset stored"
                 if offset_stored_err_message in error_trace:
-                    LOG.warning("Ignoring KafkaError: No offset stored.")
+                    LOG.warning("Ignoring KafkaError: No offset stored. %s", internal_name)
                 else:
                     KarapaceBase.internal_error(message=f"error sending commit request: {ue}", content_type=content_type)
             except KafkaError as e:

--- a/src/karapace/kafka_rest_apis/consumer_manager.py
+++ b/src/karapace/kafka_rest_apis/consumer_manager.py
@@ -2,6 +2,7 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+
 import traceback
 
 from aiokafka.errors import (
@@ -10,7 +11,8 @@ from aiokafka.errors import (
     KafkaConfigurationError,
     KafkaError,
     TopicAuthorizationFailedError,
-    UnknownTopicOrPartitionError, UnknownError,
+    UnknownTopicOrPartitionError,
+    UnknownError,
 )
 from asyncio import Lock
 from collections import defaultdict, namedtuple

--- a/tests/integration/kafka_rest_apis/test_rest_consumer.py
+++ b/tests/integration/kafka_rest_apis/test_rest_consumer.py
@@ -11,7 +11,7 @@ import random
 import time
 
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 
 from karapace.kafka_rest_apis.consumer_manager import KNOWN_FORMATS
 from tests.utils import (

--- a/tests/integration/kafka_rest_apis/test_rest_consumer.py
+++ b/tests/integration/kafka_rest_apis/test_rest_consumer.py
@@ -293,6 +293,14 @@ async def test_offsets_no_payload(rest_async_client, admin_client, producer, tra
     producer.send(topic_name, value=b"message-value")
     producer.flush()
 
+    # Commit should not throw any error, even before consuming events
+    res = await rest_async_client.post(
+        offsets_path,
+        headers=header,
+        json={}
+    )
+    assert res.ok, f"Expected a successful response: {res}"
+
     resp = await rest_async_client.get(consume_path, headers=header)
     assert resp.ok, f"Expected a successful response: {resp}"
 

--- a/tests/integration/kafka_rest_apis/test_rest_consumer.py
+++ b/tests/integration/kafka_rest_apis/test_rest_consumer.py
@@ -294,11 +294,7 @@ async def test_offsets_no_payload(rest_async_client, admin_client, producer, tra
     producer.flush()
 
     # Commit should not throw any error, even before consuming events
-    res = await rest_async_client.post(
-        offsets_path,
-        headers=header,
-        json={}
-    )
+    res = await rest_async_client.post(offsets_path, headers=header, json={})
     assert res.ok, f"Expected a successful response: {res}"
 
     resp = await rest_async_client.get(consume_path, headers=header)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

When committing a consumer offset via karapace `/offsets` without having consumed a message, the rest proxy returns 

{"error_code":500,"message":"error sending commit request: [Error -1] UnknownError"}

This is now fixed, to return a success response, as it is safe to return 200.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
