### PR TITLE
docker: pin kafka versions in compose.yml

### DIFF
--- a/container/compose.yml
+++ b/container/compose.yml
@@ -1,6 +1,6 @@
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:6.2.6
     ports:
       - 2181:2181
     environment:
@@ -8,7 +8,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:6.2.6
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
# About this change - What it does
Using `:latest` started to cause issues as now this has the KRaft mode enforced. We will work on migrating to KRaft in another iteration, so for now we pin the docker kafka/zookeeper versions to ones without KRaft.