### PR TITLE
Added kafka client id

### DIFF
--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -54,6 +54,7 @@ def kafka_consumer_from_config(config: Config, topic: str) -> Iterator[KafkaCons
 def kafka_producer_from_config(config: Config) -> Iterator[KafkaProducer]:
     producer = KafkaProducer(
         bootstrap_servers=config.bootstrap_uri,
+        client_id=config.client_id,
         security_protocol=config.security_protocol,
         ssl_cafile=config.ssl_cafile,
         ssl_certfile=config.ssl_certfile,

--- a/src/karapace/core/messaging.py
+++ b/src/karapace/core/messaging.py
@@ -39,6 +39,7 @@ class KarapaceProducer:
             try:
                 self._producer = KafkaProducer(
                     bootstrap_servers=self._config.bootstrap_uri,
+                    client_id=self._config.client_id,
                     verify_connection=False,
                     security_protocol=self._config.security_protocol,
                     ssl_cafile=self._config.ssl_cafile,

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -525,6 +525,7 @@ class UserRestProxy:
 
                 producer = AsyncKafkaProducer(
                     acks=acks,
+                    client_id=self.config.client_id,
                     bootstrap_servers=self.config.bootstrap_uri,
                     compression_type=self.config.producer_compression_type,
                     connections_max_idle_ms=self.config.connections_max_idle_ms,
@@ -752,6 +753,7 @@ class UserRestProxy:
             try:
                 self.admin_client = KafkaAdminClient(
                     bootstrap_servers=self.config.bootstrap_uri,
+                    client_id=self.config.client_id,
                     security_protocol=self.config.security_protocol,
                     ssl_cafile=self.config.ssl_cafile,
                     ssl_certfile=self.config.ssl_certfile,


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This change adds in the Kafka client ID to the Kafka producer. It also adds it to the Kafka Admin. 

<!-- Provide a small sentence that summarizes the change. -->

This is needed to allow the client id to be specified, allowing the difference instances to have different names etc...

<!-- Provide the issue number below if it exists. -->

This does not fix any issue. 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
We needed to be able to specify the actual client id so that we can see the connection appearing from the logs. We also use Kafka rest with a non-standard Kafka, that uses the client ID to specific additional client specific handling. 