### PR TITLE
OIDC karapace authorization

### DIFF
--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -108,6 +108,10 @@ class Config(BaseSettings):
     sasl_oauthbearer_expected_issuer: str | None = None
     sasl_oauthbearer_expected_audience: str | None = None
     sasl_oauthbearer_sub_claim_name: str | None = "sub"
+    sasl_oauthbearer_authorization_enabled: bool = False
+    sasl_oauthbearer_client_id: str | None = None
+    sasl_oauthbearer_roles_claim_path: str | None = None
+    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_plain_username: str | None = None
     sasl_plain_password: str | None = None
     sasl_oauth_token: str | None = None


### PR DESCRIPTION
- Ability to authorize karapace schema registry requests based on oidc roles

New example configs in karapace config

```
    sasl_oauthbearer_jwks_endpoint_url: str = "http://localhost:8080/realms/klaw/protocol/openid-connect/certs"
    sasl_oauthbearer_expected_issuer: str = "http://localhost:8080/realms/klaw"
    sasl_oauthbearer_expected_audience: str = "account"
    sasl_oauthbearer_sub_claim_name: str | None = "sub"
    sasl_oauthbearer_authorization_enabled: bool = True
    sasl_oauthbearer_client_id: str = "klaw"
    sasl_oauthbearer_roles_claim_path: str = "resource_access.[client_id].roles"
    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": ["schema:read", "subject:read"],
                                                           "POST": [], "PUT": [], "DELETE": []}
```

Authorization for GET/POST/PUT/DELETE