### PR TITLE
feat: re-add `karapace_version` to sr api endpoint `_health`

### DIFF
--- a/src/karapace/api/routers/health.py
+++ b/src/karapace/api/routers/health.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 from dependency_injector.wiring import inject, Provide
 from fastapi import APIRouter, Depends, HTTPException, status
+from karapace import version as karapace_version
 from karapace.api.container import SchemaRegistryContainer
 from karapace.core.instrumentation.tracer import Tracer
 from karapace.core.schema_registry import KarapaceSchemaRegistry
@@ -26,6 +27,7 @@ class HealthStatus(BaseModel):
 
 
 class HealthCheck(BaseModel):
+    karapace_version: str
     status: HealthStatus
     healthy: bool
 
@@ -83,4 +85,4 @@ async def health(
             health_check_span.set_status(status=StatusCode.ERROR, description="Schema reader is not healthy")
             raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
 
-        return HealthCheck(status=health_status, healthy=True)
+        return HealthCheck(karapace_version=karapace_version.__version__, status=health_status, healthy=True)

--- a/tests/integration/test_health_check.py
+++ b/tests/integration/test_health_check.py
@@ -9,6 +9,7 @@ from tenacity import retry, stop_after_delay, wait_fixed
 
 from karapace.core.client import Client
 from karapace.core.kafka.admin import KafkaAdminClient
+from karapace.version import __version__
 from tests.integration.utils.cluster import RegistryDescription
 
 
@@ -17,6 +18,12 @@ async def test_health_check(
 ) -> None:
     res = await registry_async_client.get("/_health")
     assert res.ok
+    response = res.json()
+    assert "karapace_version" in response
+    assert response["karapace_version"] == __version__
+    response_status = response.get("status")
+    assert "schema_registry_startup_time_sec" in response_status
+    assert response_status["schema_registry_startup_time_sec"] > 0
 
     admin_client.delete_topic(registry_cluster.schemas_topic)
 


### PR DESCRIPTION
Schema Registry API lib changed from aiohttp to fastapi with Karapace v5. Following to that, the api endpoint `_health` was missing `karapace_version`.

v4 /_health response:
```
{
  "process_uptime_sec": 265,
  "karapace_version": "4.1.2",
  ...
}
```
v5 /_health response (before this change)
```
{
  "status": {
    "schema_registry_ready": true,
    "schema_registry_startup_time_sec": 0.255569011999796,
    ...
  }
}
```
v5 /_health response (aftter this change)
```
{
  "karapace_version":"5.0.1.dev16+gf199ad007.d20250818",
  "status": {
    "schema_registry_ready": true,
    "schema_registry_startup_time_sec": 8.353399749998061,
    ...
  }
}
```