### PR TITLE
Fix producer acks

### DIFF
--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
+from typing import Literal
+
 from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRODUCER_MAX_REQUEST, DEFAULT_SCHEMA_TOPIC
 from karapace.core.typing import ElectionStrategy, NameStrategy
 from karapace.core.utils import json_encode
 from pathlib import Path
-from pydantic import BaseModel, ImportString
+from pydantic import BaseModel, ImportString, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 import enum
@@ -118,7 +120,7 @@ class Config(BaseSettings):
     topic_name: str = DEFAULT_SCHEMA_TOPIC
     metadata_max_age_ms: int = 60000
     admin_metadata_max_age: int = 5
-    producer_acks: int = 1
+    producer_acks: int | Literal["all"] = 1
     producer_compression_type: str | None = None
     producer_count: int = 5
     producer_linger_ms: int = 100
@@ -155,6 +157,12 @@ class Config(BaseSettings):
 
     def get_address(self) -> str:
         return f"{self.host}:{self.port}"
+
+    @field_validator("producer_acks", mode="before")
+    def normalize_producer_acks(cls, v):
+        if isinstance(v, str) and v.lower() == "all":
+            return -1
+        return v
 
     def get_rest_base_uri(self) -> str:
         return (


### PR DESCRIPTION
If producer_acks is set to all, sometimes it fails in integer parsing.

_producer_acks :   Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='all', input_type=str]_

It is now being fixed in config with this decorator.