### PR TITLE
api: handle `InvalidReferences` error on compatibility check endpoint

### DIFF
--- a/src/karapace/api/controller.py
+++ b/src/karapace/api/controller.py
@@ -917,6 +917,14 @@ class KarapaceSchemaRegistryController:
                     "message": f"Invalid {schema_request.schema_type} schema",
                 },
             ) from exc
+        except InvalidReferences as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
+                    "message": f"New {schema_request.schema_type} schema has invalid references",
+                },
+            ) from exc
 
     def get_old_schema(self, subject: Subject, version: Version) -> ParsedTypedSchema:
         old: JsonObject | None = None
@@ -947,5 +955,13 @@ class KarapaceSchemaRegistryController:
                 detail={
                     "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
                     "message": f"Found an invalid {old_schema_type} schema registered",
+                },
+            ) from exc
+        except InvalidReferences as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "error_code": SchemaErrorCodes.INVALID_SCHEMA.value,
+                    "message": f"Existing {old_schema_type} schema has invalid references",
                 },
             ) from exc


### PR DESCRIPTION
The compatibility endpoint causes the application server to crash when it fails to handle the possibility of invalid references on both the old and new schema, this PR catches this error. 

The error was made evident to us by a recent issue where the Karapace state was corrupt, the API allowed the deletion of a schema that was still referenced. This should not be allowed as #1137 verifies, we still do not know why/how this happened and are actively investigating this. 
So because a schema existed with a reference that had been deleted, the request to the compatibility check endpoint failed with `InvalidReferences` and it was unhandled. 