### PR TITLE
Fix flakiness of tests

### DIFF
--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -204,7 +204,8 @@ async def test_regression_config_for_inexisting_object_should_not_throw(
             producer.flush()
             msg = future.result(timeout=2)
 
-            schema_reader._offset_watcher.wait_for_offset(msg.offset(), timeout=5)
+            seen = schema_reader._offset_watcher.wait_for_offset(msg.offset(), timeout=5)
+            assert seen is True
 
             assert (
                 database.find_subject(subject=Subject(subject)) is not None


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

For the below tests
test_regression_config_for_inexisting_object_should_not_throw
test_regression_soft_delete_schemas_should_be_registered

- After events are produced, a timout is necessary when getting the future object. timeout is added now.
- Also producer acks is set to all, so that we wait for event to be produced for sure.
- Added another assert to see if the offset is seen.


<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
