### PR TITLE
Adding more wait time for schema fwd

### DIFF
--- a/tests/integration/test_request_forwarding.py
+++ b/tests/integration/test_request_forwarding.py
@@ -187,7 +187,7 @@ async def test_schema_request_forwarding_tls(
     master_url, follower_url = registry_async_pair_tls
 
     max_tries = 10
-    wait_time = 0.5
+    wait_time = 10
     subject = create_subject_name_factory(subject)()
     schema = {"type": "string"}
     other_schema = {"type": "int"}

--- a/tests/integration/test_schema_registry_auth.py
+++ b/tests/integration/test_schema_registry_auth.py
@@ -213,7 +213,7 @@ async def test_sr_auth_forwarding(
     # Test primary/replica forwarding with global config setting
     primary_url, replica_url = registry_async_auth_pair
     max_tries = 5
-    wait_time = 0.5
+    wait_time = 10
     for compat in ["FULL", "BACKWARD", "FORWARD", "NONE"]:
         counter = 0
         resp = await registry_async_retry_client_auth.put(f"{replica_url}/config", json={"compatibility": compat}, auth=auth)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

There was a bug with counter in the below 2 tests which was fixed, but that does not seem to be enough.
wait_time was 0.5 secs which looks like is not sufficient for the schema forwarding.
Updating it to 10 secs

Failing build

https://github.com/Aiven-Open/karapace/actions/runs/18469227364/job/52618715218?pr=1149

FAILED tests/integration/test_request_forwarding.py::test_schema_request_forwarding_tls[pyloop-test_forw/arding] - AssertionError: Compat update not propagated
assert 10 < 10
FAILED tests/integration/test_schema_registry_auth.py::test_sr_auth_forwarding[pyloop] - AssertionError: Compat update not propagated
assert 5 < 5
=========== 2 failed, 364 passed, 137 warnings in 3277.30s (0:54:37) ===========

this is the other test with 60 secs  wait time never fails. https://github.com/Aiven-Open/karapace/blob/635c56af5d571c3b60696698c169cd57ebc5488b/tests/integration/test_request_forwarding.py#L85

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
