### PR TITLE
Xfail flaky test - test_roundtrip_from_file

### DIFF
--- a/tests/integration/backup/test_v3_backup.py
+++ b/tests/integration/backup/test_v3_backup.py
@@ -358,6 +358,7 @@ def test_exits_with_return_code_3_for_data_restoration_error(
     assert er.value.returncode == 3
 
 
+@pytest.mark.xfail(reason="Flaky and this backup feature will be deleted in next major version")
 def test_roundtrip_from_file(
     tmp_path: Path,
     config_file: Path,


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

Tests for schema backup are flaky, and this backup feature will be removed in the next major. 

https://github.com/Aiven-Open/karapace/actions/runs/18491765623/job/52686864097

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
