### PR TITLE
tests: add poll timeout to `test_roundtrip_from_file`

### DIFF
--- a/tests/integration/backup/test_v3_backup.py
+++ b/tests/integration/backup/test_v3_backup.py
@@ -406,6 +406,7 @@ def test_roundtrip_from_file(
             "--replication-factor=1",
             "--location",
             str(backup_location),
+            "--poll-timeout=PT5M",
         ],
         capture_output=True,
         check=True,


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Attempt to improve the test and reduce the flakiness by increasing the poll timeout from default 1 minute to 5 minutes. 

# Why this way
As this is only mostly flaky on the CI, as it passes every time on local setup, we suspect that the tests resources are struggling. We've also scoped the fix to just this test, it may be necessary to add this increased timeout to other places that fail using the soon to be deprecated backup CLI. 

If this doesn't work, we can go ahead and `xfail` it (#1158) as the backup feature will be deprecated. 
