### PR TITLE
Update proto compiled runtime path

### DIFF
--- a/src/karapace/core/protobuf/io.py
+++ b/src/karapace/core/protobuf/io.py
@@ -138,7 +138,7 @@ def get_protobuf_class_instance(
                 cwd=work_dir,
             )
 
-    runtime_proto_path = f"./runtime/{proto_name}"
+    runtime_proto_path = str(work_dir.resolve())
     if runtime_proto_path not in sys.path:
         # todo: This will leave residues on sys.path in case of exceptions. If really must
         # mutate sys.path, we should at least wrap in try-finally.

--- a/src/karapace/kafka_rest_apis/consumer_manager.py
+++ b/src/karapace/kafka_rest_apis/consumer_manager.py
@@ -565,6 +565,9 @@ class ConsumerManager:
                     if request_format == "avro":
                         LOG.warning("Cannot process non-empty key using avro deserializer, falling back to binary.")
                         key = await self.deserialize(msg.key(), "binary")
+                    if request_format == "protobuf":
+                        LOG.warning("Cannot process non-empty key using protobuf deserializer, falling back to binary.")
+                        key = await self.deserialize(msg.key(), "binary")
                     else:
                         KarapaceBase.unprocessable_entity(
                             message=f"key deserialization error for format {request_format}: {e}",

--- a/tests/unit/protobuf/test_io.py
+++ b/tests/unit/protobuf/test_io.py
@@ -3,14 +3,21 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 
+import sys
 import textwrap
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from karapace.core.dependency import Dependency
-from karapace.core.protobuf.io import crawl_dependencies
+from karapace.core.protobuf.io import crawl_dependencies, calculate_class_name
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.schema_models import ValidatedTypedSchema
 from karapace.core.schema_type import SchemaType
 from karapace.core.typing import Subject
+
+from karapace.core.protobuf.io import get_protobuf_class_instance
 
 
 def test_crawl_dependencies() -> None:
@@ -71,3 +78,88 @@ def test_crawl_dependencies() -> None:
             "unique_class_name": "c_df098b6b018617c2b8eb95156535dec6",
         },
     }
+
+
+def test_get_protobuf_class_instance_creates_and_imports(tmp_path: Path):
+    # Minimal protobuf schema
+    schema_str = """
+        syntax = "proto3";
+        package testpkg;
+        message TestMessage {
+            string foo = 1;
+        }
+    """
+
+    # Create ProtobufSchema
+    schema = ProtobufSchema(schema=schema_str)
+
+    # Simulate config pointing to runtime directory (e.g. ./runtime)
+    cfg = SimpleNamespace(protobuf_runtime_directory=str(tmp_path / "runtime"))
+
+    # Calculate expected proto_name (same logic as in get_protobuf_class_instance)
+    deps_list = crawl_dependencies(schema)
+    root_class_name = ""
+    for value in deps_list.values():
+        root_class_name = root_class_name + value["unique_class_name"]
+    root_class_name = root_class_name + str(schema)
+    expected_proto_name = calculate_class_name(root_class_name)
+
+    expected_work_dir = tmp_path / "runtime" / expected_proto_name
+    expected_runtime_proto_path = str(expected_work_dir.resolve())
+
+    # Create a custom list class that tracks what gets appended
+    class TrackingList(list):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.appended_items = []
+
+        def append(self, item):
+            self.appended_items.append(item)
+            super().append(item)
+
+    # Replace sys.path with our tracking list
+    original_sys_path = sys.path
+    tracking_sys_path = TrackingList(original_sys_path)
+
+    # Call function with tracking sys.path to capture what gets added
+    with patch("sys.path", tracking_sys_path):
+        instance = get_protobuf_class_instance(schema, "TestMessage", cfg)
+
+    # Restore original sys.path
+    sys.path = original_sys_path
+
+    # Assert: generated module exists
+    generated_dirs = list((tmp_path / "runtime").glob("c_*"))
+    assert generated_dirs, "Expected at least one generated runtime directory"
+
+    generated_dir = generated_dirs[0]
+    pb2_files = list(generated_dir.glob("*_pb2.py"))
+    assert pb2_files, "Expected protoc to generate a *_pb2.py file"
+
+    # Assert: generated directory name matches expected proto_name
+    assert (
+        generated_dir.name == expected_proto_name
+    ), f"Expected directory name {expected_proto_name}, got {generated_dir.name}"
+
+    # Assert: instance is of the expected class
+    assert instance.__class__.__name__ == "TestMessage"
+    assert hasattr(instance, "foo")
+
+    appended_paths = tracking_sys_path.appended_items
+    assert len(appended_paths) > 0, "Expected sys.path.append to be called at least once"
+
+    # Find the runtime_proto_path that was added
+    runtime_path_added = None
+    for path in appended_paths:
+        if expected_proto_name in path or "runtime" in path:
+            runtime_path_added = path
+            break
+
+    assert runtime_path_added is not None, f"Expected a runtime path to be added to sys.path, but got: {appended_paths}"
+
+    assert runtime_path_added == expected_runtime_proto_path, (
+        f"Expected absolute path {expected_runtime_proto_path}, " f"but got {runtime_path_added}. "
+    )
+
+    # Clean up to avoid residue
+    shutil.rmtree(tmp_path)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Fixes 2 issues.

1.
When a protobuf schema  gets compiled, it stores the .pb2 file in a runtime location.
Depending on how the karapace process starts, the cwd differs.

Getting absolute path with .resolve in all situations.

For example if it's not found

Below error in karapace 4 version. (will have another pr for 4.x as well)

 File "/usr/lib64/karapace-4-python/karapace/protobuf/io.py", line 225, in read_in_forked_multiprocess_process
                                                           raise result
                                                       ModuleNotFoundError: No module named 'c_1be0d61dad5863aae26047ecbcfe559c_pb2'

Debug logs

```
working dir /srv/karapace-rest/runtime/c_437ab2456e8d94d09de9426a98f89dde
Nov 12 08:26:05 kafka-murali-local-3 karapace[144386]: karapace.protobuf.io        MainThread        INFO            classpath  dir /srv/karapace-rest/runtime/c_437ab2456e8d94d09de9426a98f89dde/c_437ab2456e8d94d09de9426a98f89dde_pb2.py

```

2. When a key protobuf schema doesn't get deserialized, fallback it to binary.

    To fix the Unprocesseable Entity, as key deserialization fails when no key/or text key is sent. Adding similar logic as avro here.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
