### PR TITLE
Add configurable mTLS client auth via server_tls_client_auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -491,6 +491,9 @@ Keys to take special care are the ones needed to configure Kafka and advertised_
    * - ``server_tls_cafile``
      - ``/path/to/cafile``
      - Filename to the SSL CA certificate.
+  * - ``server_tls_client_auth``
+    - ``none``
+    - Client certificate requirement: ``none``, ``optional``, or ``required``.
    * - ``registry_scheme``
      - ``http``
      - Schema Registry scheme to use for rest-proxy, http | https (if certificates are provided).

--- a/karapace.config.json
+++ b/karapace.config.json
@@ -13,6 +13,8 @@
     "port": 8081,
     "server_tls_certfile": null,
     "server_tls_keyfile": null,
+    "server_tls_cafile": null,
+    "server_tls_client_auth": "none",
     "registry_ca": null,
     "master_eligibility": true,
     "replication_factor": 1,

--- a/tests/integration/test_mtls.py
+++ b/tests/integration/test_mtls.py
@@ -1,0 +1,91 @@
+"""
+karapace - schema tests
+
+Copyright (c) 2025 Aiven Ltd
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+
+import aiohttp
+import pytest
+import ssl
+
+from karapace.core.config import Config, ServerTLSClientAuth
+from tests.integration.utils.cluster import start_schema_registry_cluster
+
+
+@pytest.mark.asyncio
+async def test_mtls_requires_client_certificate(
+    tmp_path,
+    kafka_servers,
+    server_ca: str,
+    server_cert: str,
+    server_key: str,
+) -> None:
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.waiting_time_before_acting_as_master_ms = 500
+    config.advertised_protocol = "https"
+    config.server_tls_cafile = server_ca
+    config.server_tls_certfile = server_cert
+    config.server_tls_keyfile = server_key
+    config.server_tls_client_auth = ServerTLSClientAuth.REQUIRED
+
+    async with start_schema_registry_cluster(
+        config_templates=[config],
+        data_dir=tmp_path,
+    ) as registries:
+        endpoint = registries[0].endpoint.to_url()
+
+        # Build an SSL context that trusts the server CA but does not present a client certificate.
+        ssl_ctx = ssl.create_default_context(cafile=server_ca)
+        ssl_ctx.check_hostname = False
+
+        async with aiohttp.ClientSession() as session:
+            failed = False
+            resp = None
+            try:
+                resp = await session.get(f"{endpoint}/subjects", ssl=ssl_ctx)
+                if resp.status >= 400:
+                    failed = True
+            except (aiohttp.ClientError, ssl.SSLError):
+                failed = True
+            finally:
+                if resp is not None:
+                    resp.release()
+                    await resp.wait_for_close()
+
+            assert failed, "mTLS required but request without client cert succeeded"
+
+
+async def test_mtls_not_required_allows_without_client_certificate(
+    tmp_path,
+    kafka_servers,
+    server_ca: str,
+    server_cert: str,
+    server_key: str,
+) -> None:
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.waiting_time_before_acting_as_master_ms = 500
+    config.advertised_protocol = "https"
+    config.server_tls_cafile = server_ca
+    config.server_tls_certfile = server_cert
+    config.server_tls_keyfile = server_key
+    config.server_tls_client_auth = ServerTLSClientAuth.NONE
+
+    async with start_schema_registry_cluster(
+        config_templates=[config],
+        data_dir=tmp_path,
+    ) as registries:
+        endpoint = registries[0].endpoint.to_url()
+
+        # SSL context trusts the server CA and presents no client certificate.
+        ssl_ctx = ssl.create_default_context(cafile=server_ca)
+        ssl_ctx.check_hostname = False
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{endpoint}/subjects", ssl=ssl_ctx) as resp:
+                assert resp.status == 200

--- a/tests/integration/utils/cluster.py
+++ b/tests/integration/utils/cluster.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import ExitStack, asynccontextmanager
 from dataclasses import dataclass
+import enum
 from pathlib import Path
 
 from karapace.core.client import Client
@@ -66,6 +67,12 @@ async def start_schema_registry_cluster(
             logfile = stack.enter_context(open(log_path, "w"))
             errfile = stack.enter_context(open(error_path, "w"))
 
+            client_auth = (
+                config.server_tls_client_auth.value
+                if isinstance(config.server_tls_client_auth, enum.Enum)
+                else config.server_tls_client_auth
+            )
+
             env = {
                 "KARAPACE_HOST": config.host,
                 "KARAPACE_PORT": str(port),
@@ -85,6 +92,7 @@ async def start_schema_registry_cluster(
                 "KARAPACE_SERVER_TLS_CAFILE": config.server_tls_cafile if config.server_tls_cafile else "",
                 "KARAPACE_SERVER_TLS_CERTFILE": config.server_tls_certfile if config.server_tls_certfile else "",
                 "KARAPACE_SERVER_TLS_KEYFILE": config.server_tls_keyfile if config.server_tls_keyfile else "",
+                "KARAPACE_SERVER_TLS_CLIENT_AUTH": client_auth if client_auth else "none",
                 "KARAPACE_USE_PROTOBUF_FORMATTER": "true" if config.use_protobuf_formatter else "false",
                 "KARAPACE_WAITING_TIME_BEFORE_ACTING_AS_MASTER_MS": str(config.waiting_time_before_acting_as_master_ms),
                 "KARAPACE_MASTER_ELIGIBILITY": str(config.master_eligibility),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -6,9 +6,11 @@ See LICENSE for details
 """
 
 import runpy
-from unittest.mock import patch, MagicMock
+import ssl
+from unittest.mock import MagicMock, patch
 
 from karapace import __main__
+from karapace.core.config import ServerTLSClientAuth
 
 
 def test_main_container_initialization():
@@ -24,11 +26,21 @@ def test_main_container_initialization():
         mock_app = MagicMock()
         mock_create_app.return_value = mock_app
 
+        mock_config = MagicMock()
+        mock_config.host = "127.0.0.1"
+        mock_config.port = 8081
+        mock_config.log_level = "debug"
+        mock_config.server_tls_keyfile = None
+        mock_config.server_tls_certfile = None
+        mock_config.server_tls_cafile = None
+        mock_config.server_tls_client_auth = ServerTLSClientAuth.NONE
+
+        mock_karapace_container_instance = mock_karapace_container.return_value
+        mock_karapace_container_instance.config.return_value = mock_config
+
         with patch("sys.argv", ["-m", "karapace.__main__"]):
             runpy.run_module("karapace.__main__", run_name="__main__")
 
-        # Mock return values for container initialization
-        mock_karapace_container_instance = mock_karapace_container.return_value
         mock_auth_container_instance = mock_auth_container.return_value
         mock_metrics_container_instance = mock_metrics_container.return_value
         mock_telemetry_container_instance = mock_telemetry_container.return_value
@@ -110,4 +122,5 @@ def test_uvicorn_run() -> None:
             ssl_keyfile=None,
             ssl_certfile=None,
             ssl_ca_certs=None,
+            ssl_cert_reqs=ssl.CERT_NONE,
         )


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Add configurable mTLS client auth via server_tls_client_auth and pass ssl_cert_reqs to uvicorn, enforcing client certs when set to required.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
#1175 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
