### PR TITLE
Add support for CPython 3.13

### DIFF
--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     env:
       BUILDKIT_PROGRESS: plain
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
     - uses: actions/checkout@v4
       # Need fetch-depth 0 to fetch tags, see https://github.com/actions/checkout/issues/701

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,7 +59,7 @@ ENV CAROOT=/opt/karapace/certs/ca
 
 # Setup files and directories.
 RUN mkdir -p /opt/karapace /opt/karapace/runtime /var/log/karapace /opt/karapace/coverage $CAROOT \
-&& touch /opt/karapace/coverage/.coverage.3.10 /opt/karapace/coverage/.coverage.3.11 /opt/karapace/coverage/.coverage.3.12 \
+&& touch /opt/karapace/coverage/.coverage.3.10 /opt/karapace/coverage/.coverage.3.11 /opt/karapace/coverage/.coverage.3.12 /opt/karapace/coverage/.coverage.3.13 \
 && chown --recursive "$RUNNER_UID:$RUNNER_GID" /opt/karapace /opt/karapace/coverage /var/log/karapace
 
 # Install Java via openjdk-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ classifiers=[
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Database :: Database Engines/Servers",
   "Topic :: Software Development :: Libraries",
 ]

--- a/src/karapace/core/utils.py
+++ b/src/karapace/core/utils.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import AnyStr, cast, IO, Literal, NoReturn, overload, TypeVar
 
-import importlib
+import importlib.util
 import logging
 import signal
 import time


### PR DESCRIPTION
This commit adds test matrix coverage for CPython 3.13 and fixes a regression where `import importlib; importlib.util` stopped accidentally working.

Once merged, this needs to be back-ported to Karapace 4.