### PR TITLE
back-port: Add support for CPython 3.13

### DIFF
--- a/.github/workflows/container-smoke-test.yml
+++ b/.github/workflows/container-smoke-test.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   smoke-test-container:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     env:
       BUILDKIT_PROGRESS: plain
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
     env:
       PYTEST_ADDOPTS: >-
         --log-dir=/tmp/ci-logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ classifiers=[
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Database :: Database Engines/Servers",
   "Topic :: Software Development :: Libraries",
 ]

--- a/src/karapace/utils.py
+++ b/src/karapace/utils.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import AnyStr, cast, IO, Literal, NoReturn, overload, TypeVar
 
-import importlib
+import importlib.util
 import logging
 import signal
 import time


### PR DESCRIPTION
This commit adds test matrix coverage for CPython 3.13 and fixes a regression where `import importlib; importlib.util` stopped accidentally working.

Back-port for Karapace 4 of #1184.