### PR TITLE
Preempt topic creation action with metadata list

### DIFF
--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -239,11 +239,13 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
+            #
+            # check if schema topic is already created, if not try to create it
             try:
                 schema_topic_exists = (
                     self.config.topic_name in self.admin_client.list_topics().topics.keys()
                 )
-            except TopicAuthorizationFailedError:
+            except Exception:
                 schema_topic_exists = False
                 LOG.warning(
                     "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -240,7 +240,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
             schema_topic_exists = (
-                self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+                self.config.topic_name in self.admin_client.list_topics().topics.keys()
             )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
@@ -350,7 +350,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         except KafkaTimeoutError:
             LOG.warning("Reading begin offsets timed out.")
         except UnknownTopicOrPartitionError:
-            LOG.warning("Topic does not yet exist.")
+            LOG.warning("Topic: %r does not yet exist.", self.config.topic_name)
         except (LeaderNotAvailableError, NotLeaderForPartitionError):
             LOG.warning("Retrying to find leader for schema topic partition.")
         except Exception as e:

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -237,7 +237,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             assert self.consumer is not None
 
-            schema_topic_exists = False
+            # Perform a metadata list, which is allowed in a describe permission, whereas
+            # topic-create permissions are a coarser permission grant, not typically given out
+            schema_topic_exists = self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -160,6 +160,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         self.kafka_error_handler: KafkaErrorHandler = KafkaErrorHandler(config=config)
         self._tracer = Tracer()
 
+        # indicate whether karapace created the schema_topic
+        self._karapace_created_schema_topic: bool = False
+
         # Thread synchronization objects
         # - offset is used by the REST API to wait until this thread has
         # consumed the produced messages. This makes the REST APIs more
@@ -261,6 +264,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
                         config={"cleanup.policy": "compact"},
                     )
                     LOG.debug("[Schema Topic] Successfully created %r", topic.topic)
+                    self._karapace_created_schema_topic = True
                     schema_topic_exists = True
                 except TopicAlreadyExistsError:
                     LOG.warning("[Schema Topic] Already exists %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -245,14 +245,11 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             #
             # check if schema topic is already created, if not try to create it
             try:
-                schema_topic_exists = (
-                    self.config.topic_name in self.admin_client.list_topics().topics.keys()
-                )
+                schema_topic_exists = self.config.topic_name in self.admin_client.list_topics().topics.keys()
             except Exception:
                 schema_topic_exists = False
                 LOG.warning(
-                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",
-                    self.config.topic_name
+                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist", self.config.topic_name
                 )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -239,9 +239,16 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
-            schema_topic_exists = (
-                self.config.topic_name in self.admin_client.list_topics().topics.keys()
-            )
+            try:
+                schema_topic_exists = (
+                    self.config.topic_name in self.admin_client.list_topics().topics.keys()
+                )
+            except TopicAuthorizationFailedError:
+                schema_topic_exists = False
+                LOG.warning(
+                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",
+                    self.config.topic_name
+                )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -239,7 +239,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
-            schema_topic_exists = self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+            schema_topic_exists = (
+                self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+            )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -241,11 +241,13 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
+            #
+            # check if schema topic is already created, if not try to create it
             try:
                 schema_topic_exists = (
                     self.config.topic_name in self.admin_client.list_topics().topics.keys()
                 )
-            except TopicAuthorizationFailedError:
+            except Exception:
                 schema_topic_exists = False
                 LOG.warning(
                     "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -248,11 +248,12 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             # check if schema topic is already created, if not try to create it
             try:
                 schema_topic_exists = self.config.topic_name in self.admin_client.list_topics().topics.keys()
-            except Exception:
+            except Exception as e:
                 schema_topic_exists = False
-                LOG.warning(
-                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist", self.config.topic_name
+                LOG.exception(
+                    "[Schema Topic] unable to list topics, failed when looking for topic: %r", self.config.topic_name
                 )
+                self.stats.unexpected_exception(ex=e, where="config_topic_existence")
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -241,9 +241,16 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
-            schema_topic_exists = (
-                self.config.topic_name in self.admin_client.list_topics().topics.keys()
-            )
+            try:
+                schema_topic_exists = (
+                    self.config.topic_name in self.admin_client.list_topics().topics.keys()
+                )
+            except TopicAuthorizationFailedError:
+                schema_topic_exists = False
+                LOG.warning(
+                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",
+                    self.config.topic_name
+                )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -247,14 +247,11 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             #
             # check if schema topic is already created, if not try to create it
             try:
-                schema_topic_exists = (
-                    self.config.topic_name in self.admin_client.list_topics().topics.keys()
-                )
+                schema_topic_exists = self.config.topic_name in self.admin_client.list_topics().topics.keys()
             except Exception:
                 schema_topic_exists = False
                 LOG.warning(
-                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist",
-                    self.config.topic_name
+                    "[Schema Topic] not authorized to list topics, assuming topic: %r does not exist", self.config.topic_name
                 )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -159,6 +159,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         self.kafka_error_handler: KafkaErrorHandler = KafkaErrorHandler(config=config)
         self._tracer = Tracer()
 
+        # indicate whether karapace created the schema_topic
+        self._karapace_created_schema_topic: bool = False
+
         # Thread synchronization objects
         # - offset is used by the REST API to wait until this thread has
         # consumed the produced messages. This makes the REST APIs more
@@ -263,6 +266,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
                         config={"cleanup.policy": "compact"},
                     )
                     LOG.debug("[Schema Topic] Successfully created %r", topic.topic)
+                    self._karapace_created_schema_topic = True
                     schema_topic_exists = True
                 except TopicAlreadyExistsError:
                     LOG.warning("[Schema Topic] Already exists %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -239,7 +239,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             assert self.consumer is not None
 
-            schema_topic_exists = False
+            # Perform a metadata list, which is allowed in a describe permission, whereas
+            # topic-create permissions are a coarser permission grant, not typically given out
+            schema_topic_exists = self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -241,7 +241,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
 
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
-            schema_topic_exists = self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+            schema_topic_exists = (
+                self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+            )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
                     LOG.debug("[Schema Topic] Creating %r", self.config.topic_name)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -242,7 +242,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             # Perform a metadata list, which is allowed in a describe permission, whereas
             # topic-create permissions are a coarser permission grant, not typically given out
             schema_topic_exists = (
-                self.config.topic_name in self.admin_client.list_topics(topic=self.config.topic_name).topics.keys()
+                self.config.topic_name in self.admin_client.list_topics().topics.keys()
             )
             while not self._stop_schema_reader.is_set() and not schema_topic_exists:
                 try:
@@ -352,7 +352,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         except KafkaTimeoutError:
             LOG.warning("Reading begin offsets timed out.")
         except UnknownTopicOrPartitionError:
-            LOG.warning("Topic does not yet exist.")
+            LOG.warning("Topic: %r does not yet exist.", self.config.topic_name)
         except (LeaderNotAvailableError, NotLeaderForPartitionError):
             LOG.warning("Retrying to find leader for schema topic partition.")
         except Exception as e:

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -418,6 +418,50 @@ async def test_schema_topic_existence_check_skips_creation_when_exists(
         with closing(schema_reader):
             await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
 
-            assert not schema_reader._karapace_created_schema_topic, "ensures that karapace did _not_ create the schema topic"
+            assert not schema_reader._karapace_created_schema_topic, "ensure schema_reader did not create the schema topic"
+    finally:
+        await master_coordinator.close()
+
+
+async def test_schema_topic_existence_check_attempts_creation(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+) -> None:
+    """Schema reader should attempt to create schema topic if not present."""
+    test_name = "test_schema_topic_existence_check_attempts_creation"
+
+    # randomized_name
+    topic_name = new_random_name("schema_topic")
+    group_id = create_group_name_factory(test_name)()
+    stats_mock = Mock(spec=StatsClient)
+
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.admin_metadata_max_age = 2
+    config.group_id = group_id
+
+    # use the created topic name
+    config.topic_name = topic_name
+
+    master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
+    try:
+        master_coordinator.start()
+        database = InMemoryDatabase()
+        offset_watcher = OffsetWatcher()
+        schema_reader = KafkaSchemaReader(
+            config=config,
+            offset_watcher=offset_watcher,
+            key_formatter=KeyFormatter(),
+            master_coordinator=master_coordinator,
+            database=database,
+            stats=stats_mock,
+        )
+        schema_reader.start()
+
+        with closing(schema_reader):
+            await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
+
+            assert schema_reader._karapace_created_schema_topic, "ensure schema_reader created the schema topic"
     finally:
         await master_coordinator.close()

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -377,3 +377,47 @@ async def test_key_format_detection(
         assert key_formatter.get_keymode() == testcase.expected
     finally:
         await master_coordinator.close()
+
+
+async def test_schema_topic_existence_check_skips_creation_when_exists(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+) -> None:
+    """Schema reader should not attempt to create schema topic if it already exists."""
+    test_name = "test_schema_topic_existence_check_skips_creation_when_exists"
+
+    # topic is created outside of karapace here
+    topic_name = new_topic(admin_client)
+    group_id = create_group_name_factory(test_name)()
+    stats_mock = Mock(spec=StatsClient)
+
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.admin_metadata_max_age = 2
+    config.group_id = group_id
+
+    # use the created topic name
+    config.topic_name = topic_name
+
+    master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
+    try:
+        master_coordinator.start()
+        database = InMemoryDatabase()
+        offset_watcher = OffsetWatcher()
+        schema_reader = KafkaSchemaReader(
+            config=config,
+            offset_watcher=offset_watcher,
+            key_formatter=KeyFormatter(),
+            master_coordinator=master_coordinator,
+            database=database,
+            stats=stats_mock,
+        )
+        schema_reader.start()
+
+        with closing(schema_reader):
+            await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
+
+            assert not schema_reader._karapace_created_schema_topic, "ensures that karapace did _not_ create the schema topic"
+    finally:
+        await master_coordinator.close()

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -254,7 +254,7 @@ async def test_schema_reader_skips_empty_message_and_advances_offset(
     future = producer.send(topic_name, key=None, value=None)
     producer.flush()
     empty_msg = future.result()
-    empty_offset = empty_msg.offset()
+    empty_offset = empty_msg.offset() or 0
 
     config = Config()
     config.bootstrap_uri = kafka_servers.bootstrap_servers[0]

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -473,3 +473,47 @@ async def test_key_format_detection(
         assert key_formatter.get_keymode() == testcase.expected
     finally:
         await master_coordinator.close()
+
+
+async def test_schema_topic_existence_check_skips_creation_when_exists(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+) -> None:
+    """Schema reader should not attempt to create schema topic if it already exists."""
+    test_name = "test_schema_topic_existence_check_skips_creation_when_exists"
+
+    # topic is created outside of karapace here
+    topic_name = new_topic(admin_client)
+    group_id = create_group_name_factory(test_name)()
+    stats_mock = Mock(spec=StatsClient)
+
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.admin_metadata_max_age = 2
+    config.group_id = group_id
+
+    # use the created topic name
+    config.topic_name = topic_name
+
+    master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
+    try:
+        master_coordinator.start()
+        database = InMemoryDatabase()
+        offset_watcher = OffsetWatcher()
+        schema_reader = KafkaSchemaReader(
+            config=config,
+            offset_watcher=offset_watcher,
+            key_formatter=KeyFormatter(),
+            master_coordinator=master_coordinator,
+            database=database,
+            stats=stats_mock,
+        )
+        schema_reader.start()
+
+        with closing(schema_reader):
+            await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
+
+            assert not schema_reader._karapace_created_schema_topic, "ensures that karapace did _not_ create the schema topic"
+    finally:
+        await master_coordinator.close()

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -255,7 +255,7 @@ async def test_schema_reader_skips_empty_message_and_advances_offset(
     future = producer.send(topic_name, key=None, value=None)
     producer.flush()
     empty_msg = future.result()
-    empty_offset = empty_msg.offset()
+    empty_offset = empty_msg.offset() or 0
 
     config = Config()
     config.bootstrap_uri = kafka_servers.bootstrap_servers[0]

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -514,6 +514,50 @@ async def test_schema_topic_existence_check_skips_creation_when_exists(
         with closing(schema_reader):
             await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
 
-            assert not schema_reader._karapace_created_schema_topic, "ensures that karapace did _not_ create the schema topic"
+            assert not schema_reader._karapace_created_schema_topic, "ensure schema_reader did not create the schema topic"
+    finally:
+        await master_coordinator.close()
+
+
+async def test_schema_topic_existence_check_attempts_creation(
+    kafka_servers: KafkaServers,
+    admin_client: KafkaAdminClient,
+) -> None:
+    """Schema reader should attempt to create schema topic if not present."""
+    test_name = "test_schema_topic_existence_check_attempts_creation"
+
+    # randomized_name
+    topic_name = new_random_name("schema_topic")
+    group_id = create_group_name_factory(test_name)()
+    stats_mock = Mock(spec=StatsClient)
+
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.admin_metadata_max_age = 2
+    config.group_id = group_id
+
+    # use the created topic name
+    config.topic_name = topic_name
+
+    master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
+    try:
+        master_coordinator.start()
+        database = InMemoryDatabase()
+        offset_watcher = OffsetWatcher()
+        schema_reader = KafkaSchemaReader(
+            config=config,
+            offset_watcher=offset_watcher,
+            key_formatter=KeyFormatter(),
+            master_coordinator=master_coordinator,
+            database=database,
+            stats=stats_mock,
+        )
+        schema_reader.start()
+
+        with closing(schema_reader):
+            await _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader)
+
+            assert schema_reader._karapace_created_schema_topic, "ensure schema_reader created the schema topic"
     finally:
         await master_coordinator.close()

--- a/tests/integration/utils/process.py
+++ b/tests/integration/utils/process.py
@@ -4,6 +4,7 @@ See LICENSE for details
 """
 
 import os
+import shutil
 import signal
 import time
 from subprocess import Popen
@@ -47,7 +48,7 @@ def stop_process(proc: Popen | None) -> None:
 
 def get_java_process_configuration(java_args: list[str]) -> list[str]:
     command = [
-        "/usr/bin/java",
+        shutil.which("java"),
         "-server",
         "-XX:+UseG1GC",
         "-XX:MaxGCPauseMillis=20",


### PR DESCRIPTION
In an ACL-enabled kafka environment trying to get karapace running as a schema registry, we ran into this hiccup since we aren't giving karapace full admin permissions.

Tracing down the topic authorization failure we were getting, it looks like karapace attempts topic creation before checking if the topic exists, then takes action based on that failure.

Instead, I think it makes sense to check the topic metadata before attempting to create the topic, as that's possible to do with a smaller, more scoped set of permissions.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
- Perform a topic list that match the config topic name before we try to create the schema storage topic


<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: N/A (I figured a small patch may set the scene better than a bug report, but happy to create one if you all prefer!)

# Why this way

In ACL-enabled kafka clusters, karapace would require a "CreateTopics" permission on the "Cluster" resource to complete this operation as-is. With these changes, the karapace identity only requires a "Describe" on a "Topic" resource with the "Metadata" API, which is easier to scope for an administrator perspective.

That being said, happy to consider alternative approaches, as I'm still pretty unfamiliar with this codebase at large!

