### PR TITLE
Add sasl_oauth_token_provider_class for native OAUTHBEARER support

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,104 @@
+OAUTHBEARER Authentication
+==========================
+
+Karapace supports pluggable OAUTHBEARER token providers for authenticating to
+Kafka brokers. This is useful for deployments using AWS MSK with IAM
+authentication, or any Kafka cluster that uses the OAUTHBEARER SASL mechanism.
+
+How it works
+------------
+
+Set the ``sasl_oauth_token_provider_class`` config option to a Python import
+path pointing to your token provider class. Karapace will import and
+instantiate the class, then pass it to every Kafka client (admin, consumer,
+producer) it creates — including the schema reader's internal clients.
+
+Your class must implement a single method::
+
+    def token_with_expiry(self, config: str | None = None) -> tuple[str, int | None]:
+        """Return (token_string, expiry_epoch_timestamp_or_None)."""
+
+This matches the ``TokenWithExpiryProvider`` protocol defined in
+``karapace.core.kafka.common``.
+
+Configuration
+-------------
+
+Three config values are needed:
+
+.. code-block:: bash
+
+    # The Kafka security protocol
+    KARAPACE_SECURITY_PROTOCOL=SASL_SSL
+
+    # The SASL mechanism
+    KARAPACE_SASL_MECHANISM=OAUTHBEARER
+
+    # Python import path to your token provider class
+    KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=my_module:MyTokenProvider
+
+The import path format is ``dotted.module.path:ClassName``. Karapace uses
+pydantic's ``ImportString`` to resolve it, so standard Python import rules
+apply.
+
+Loading a provider that is not in the Karapace package
+------------------------------------------------------
+
+Your token provider class does **not** need to live inside the Karapace
+repository. It just needs to be importable by Python at runtime. Here are
+common approaches:
+
+**Option 1: Install as a Python package**
+
+Package your provider and install it into the same environment as Karapace:
+
+.. code-block:: bash
+
+    pip install my-msk-auth
+    # or for local development:
+    pip install -e /path/to/my-msk-auth
+
+Then reference it by its package name:
+
+.. code-block:: bash
+
+    KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=my_msk_auth.provider:MSKIAMTokenProvider
+
+**Option 2: Add to PYTHONPATH**
+
+Place your provider file anywhere on disk and add its parent directory to
+``PYTHONPATH``:
+
+.. code-block:: bash
+
+    export PYTHONPATH=/opt/custom:$PYTHONPATH
+    export KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=msk_iam_token_provider:MSKIAMTokenProvider
+
+Where ``/opt/custom/msk_iam_token_provider.py`` contains your class.
+
+**Option 3: Docker — mount and extend the path**
+
+.. code-block:: dockerfile
+
+    COPY msk_iam_token_provider.py /opt/custom/
+    ENV PYTHONPATH=/opt/custom
+    ENV KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=msk_iam_token_provider:MSKIAMTokenProvider
+
+AWS MSK IAM example
+-------------------
+
+An example provider for AWS MSK IAM authentication is included at
+``examples/msk_iam_token_provider.py``. It uses the
+``aws-msk-iam-sasl-signer-python`` library:
+
+.. code-block:: bash
+
+    pip install aws-msk-iam-sasl-signer-python
+
+    export KARAPACE_SECURITY_PROTOCOL=SASL_SSL
+    export KARAPACE_SASL_MECHANISM=OAUTHBEARER
+    export KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=examples.msk_iam_token_provider:MSKIAMTokenProvider
+    export AWS_DEFAULT_REGION=us-east-1
+
+The provider uses the default boto3 credential chain (environment variables,
+instance profile, ECS task role, etc.).

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -21,6 +21,18 @@ Your class must implement a single method::
 This matches the ``TokenWithExpiryProvider`` protocol defined in
 ``karapace.core.kafka.common``.
 
+.. note::
+
+   This protocol shape is a transitive consequence of Karapace's Kafka
+   client layer: all admin/consumer/producer clients are built on
+   ``confluent-kafka`` (librdkafka), and the provider's
+   ``token_with_expiry`` method is wired directly into librdkafka's
+   ``oauth_cb`` callback, which expects ``(token, expiry)``. Providers
+   written against ``aiokafka`` or ``kafka-python`` — which use
+   ``AbstractTokenProvider.token()`` returning just a string, with no
+   expiry or refresh callback — are **not** compatible and cannot be
+   used here.
+
 Configuration
 -------------
 

--- a/examples/msk_iam_token_provider.py
+++ b/examples/msk_iam_token_provider.py
@@ -1,5 +1,8 @@
 """Example: AWS MSK IAM token provider for Karapace OAUTHBEARER auth.
 
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+
 This module provides a token provider that generates short-lived AWS MSK
 authentication tokens using IAM credentials. It implements the
 ``TokenWithExpiryProvider`` protocol expected by Karapace's Kafka clients.

--- a/examples/msk_iam_token_provider.py
+++ b/examples/msk_iam_token_provider.py
@@ -1,0 +1,85 @@
+"""Example: AWS MSK IAM token provider for Karapace OAUTHBEARER auth.
+
+This module provides a token provider that generates short-lived AWS MSK
+authentication tokens using IAM credentials. It implements the
+``TokenWithExpiryProvider`` protocol expected by Karapace's Kafka clients.
+
+Usage
+-----
+Configure Karapace via environment variables::
+
+    KARAPACE_SECURITY_PROTOCOL=SASL_SSL
+    KARAPACE_SASL_MECHANISM=OAUTHBEARER
+    KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=examples.msk_iam_token_provider:MSKIAMTokenProvider
+
+Or pass ``sasl_oauth_token_provider_class`` in any config source that
+Karapace supports (JSON config, pydantic-settings, etc.).
+
+Requirements
+------------
+Install the AWS MSK auth helper::
+
+    pip install aws-msk-iam-sasl-signer-python
+
+The provider uses the default boto3 credential chain (env vars, instance
+profile, ECS task role, etc.). For a specific profile or role, subclass
+and override ``_generate_token``.
+
+Protocol
+--------
+Karapace expects a class whose **instances** expose::
+
+    def token_with_expiry(self, config: str | None) -> tuple[str, int | None]
+
+The first element is the OAuth token string; the second is an optional
+UNIX-epoch expiry timestamp (``int``) or ``None`` for no expiry.
+"""
+
+from __future__ import annotations
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class MSKIAMTokenProvider:
+    """Generates MSK IAM auth tokens via ``aws_msk_iam_sasl_signer``.
+
+    Instantiated once by Karapace; ``token_with_expiry`` is called by
+    confluent-kafka's ``oauth_cb`` each time a token is needed (including
+    automatic refresh before expiry).
+    """
+
+    def __init__(self, region: str | None = None) -> None:
+        # Import here so the dependency is only required when this provider is used
+        from aws_msk_iam_sasl_signer import MSKAuthTokenProvider  # type: ignore[import-untyped]
+
+        self._msk_provider = MSKAuthTokenProvider
+        self._region = region
+
+    def _get_region(self) -> str:
+        """Resolve the AWS region, falling back to boto3 session default."""
+        if self._region:
+            return self._region
+        import boto3
+
+        session = boto3.session.Session()
+        region = session.region_name
+        if not region:
+            raise ValueError(
+                "AWS region could not be determined. "
+                "Set AWS_DEFAULT_REGION, pass region= to the provider, "
+                "or configure a default region in your AWS profile."
+            )
+        return region
+
+    def token_with_expiry(self, config: str | None = None) -> tuple[str, int | None]:
+        """Return a fresh MSK auth token and its expiry.
+
+        :param config: Unused; required by the ``oauth_cb`` callback signature.
+        :returns: ``(token, expiry_epoch_ms)`` tuple.
+        """
+        region = self._get_region()
+        token, expiry_ms = self._msk_provider.generate_auth_token(region)
+        LOG.debug("Generated MSK IAM token for region=%s, expires=%s", region, expiry_ms)
+        return token, expiry_ms

--- a/examples/msk_iam_token_provider.py
+++ b/examples/msk_iam_token_provider.py
@@ -1,6 +1,6 @@
 """Example: AWS MSK IAM token provider for Karapace OAUTHBEARER auth.
 
-Copyright (c) 2024 Aiven Ltd
+Copyright (c) 2026 Aiven Ltd
 See LICENSE for details
 
 This module provides a token provider that generates short-lived AWS MSK

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -15,7 +15,7 @@ from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRO
 from karapace.core.typing import ElectionStrategy, NameStrategy
 from karapace.core.utils import json_encode
 from pathlib import Path
-from pydantic import BaseModel, ImportString, field_validator
+from pydantic import BaseModel, ImportString, PrivateAttr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 import enum
@@ -143,6 +143,7 @@ class Config(BaseSettings):
     sasl_plain_password: str | None = None
     sasl_oauth_token: str | None = None
     sasl_oauth_token_provider_class: ImportString | None = None
+    _sasl_oauth_token_provider: object = PrivateAttr(default=None)
     topic_name: str = DEFAULT_SCHEMA_TOPIC
     metadata_max_age_ms: int = 60000
     admin_metadata_max_age: int = 5
@@ -174,6 +175,16 @@ class Config(BaseSettings):
 
     # set tags if not set
     #  new_config["tags"]["app"] = "Karapace"
+
+    def model_post_init(self, __context: object) -> None:
+        if self.sasl_oauth_token_provider_class is not None:
+            instance = self.sasl_oauth_token_provider_class()
+            if not callable(getattr(instance, "token_with_expiry", None)):
+                raise ValueError(
+                    f"OAuth token provider {self.sasl_oauth_token_provider_class.__name__} must implement a "
+                    f"token_with_expiry() method returning (token: str, expiry: float)"
+                )
+            self._sasl_oauth_token_provider = instance
 
     def get_advertised_port(self) -> int:
         return self.advertised_port or self.port

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -142,6 +142,7 @@ class Config(BaseSettings):
     sasl_plain_username: str | None = None
     sasl_plain_password: str | None = None
     sasl_oauth_token: str | None = None
+    sasl_oauth_token_provider_class: ImportString | None = None
     topic_name: str = DEFAULT_SCHEMA_TOPIC
     metadata_max_age_ms: int = 60000
     admin_metadata_max_age: int = 5

--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -12,28 +12,14 @@ from karapace.core.kafka.producer import KafkaProducer
 import contextlib
 
 
-_oauth_token_provider_cache: dict[type, object] = {}
-
-
 def get_oauth_token_provider(config: Config) -> object | None:
-    """Return the configured OAuth token provider singleton, if any.
+    """Return the configured OAuth token provider instance, if any.
 
-    The provider class is instantiated once and cached for the lifetime of the
-    process.  The instance must expose a ``token_with_expiry`` method as
-    required by confluent-kafka's OAUTHBEARER flow.
+    The provider is instantiated once during Config initialization and
+    validated to expose a ``token_with_expiry`` method as required by
+    confluent-kafka's OAUTHBEARER flow.
     """
-    if config.sasl_oauth_token_provider_class is None:
-        return None
-    cls = config.sasl_oauth_token_provider_class
-    if cls not in _oauth_token_provider_cache:
-        instance = cls()
-        if not callable(getattr(instance, "token_with_expiry", None)):
-            raise ValueError(
-                f"OAuth token provider {cls.__name__} must implement a "
-                f"token_with_expiry() method returning {{'token': str, 'expiry': float}}"
-            )
-        _oauth_token_provider_cache[cls] = instance
-    return _oauth_token_provider_cache[cls]
+    return config._sasl_oauth_token_provider
 
 
 def kafka_admin_from_config(config: Config) -> KafkaAdminClient:

--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -12,7 +12,7 @@ from karapace.core.kafka.producer import KafkaProducer
 import contextlib
 
 
-def _get_oauth_token_provider(config: Config):
+def _get_oauth_token_provider(config: Config) -> object | None:
     """Instantiate the configured OAuth token provider, if any."""
     if config.sasl_oauth_token_provider_class is not None:
         return config.sasl_oauth_token_provider_class()

--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -12,8 +12,15 @@ from karapace.core.kafka.producer import KafkaProducer
 import contextlib
 
 
+def _get_oauth_token_provider(config: Config):
+    """Instantiate the configured OAuth token provider, if any."""
+    if config.sasl_oauth_token_provider_class is not None:
+        return config.sasl_oauth_token_provider_class()
+    return None
+
+
 def kafka_admin_from_config(config: Config) -> KafkaAdminClient:
-    return KafkaAdminClient(
+    kwargs: dict = dict(
         bootstrap_servers=config.bootstrap_uri,
         client_id=config.client_id,
         security_protocol=config.security_protocol,
@@ -24,11 +31,15 @@ def kafka_admin_from_config(config: Config) -> KafkaAdminClient:
         ssl_certfile=config.ssl_certfile,
         ssl_keyfile=config.ssl_keyfile,
     )
+    token_provider = _get_oauth_token_provider(config)
+    if token_provider is not None:
+        kwargs["sasl_oauth_token_provider"] = token_provider
+    return KafkaAdminClient(**kwargs)
 
 
 @contextlib.contextmanager
 def kafka_consumer_from_config(config: Config, topic: str) -> Iterator[KafkaConsumer]:
-    consumer = KafkaConsumer(
+    kwargs: dict = dict(
         bootstrap_servers=config.bootstrap_uri,
         topic=topic,
         enable_auto_commit=False,
@@ -44,6 +55,10 @@ def kafka_consumer_from_config(config: Config, topic: str) -> Iterator[KafkaCons
         session_timeout_ms=config.session_timeout_ms,
         metadata_max_age_ms=config.metadata_max_age_ms,
     )
+    token_provider = _get_oauth_token_provider(config)
+    if token_provider is not None:
+        kwargs["sasl_oauth_token_provider"] = token_provider
+    consumer = KafkaConsumer(**kwargs)
     try:
         yield consumer
     finally:
@@ -52,7 +67,7 @@ def kafka_consumer_from_config(config: Config, topic: str) -> Iterator[KafkaCons
 
 @contextlib.contextmanager
 def kafka_producer_from_config(config: Config) -> Iterator[KafkaProducer]:
-    producer = KafkaProducer(
+    kwargs: dict = dict(
         bootstrap_servers=config.bootstrap_uri,
         client_id=config.client_id,
         security_protocol=config.security_protocol,
@@ -65,6 +80,10 @@ def kafka_producer_from_config(config: Config) -> Iterator[KafkaProducer]:
         retries=0,
         session_timeout_ms=config.session_timeout_ms,
     )
+    token_provider = _get_oauth_token_provider(config)
+    if token_provider is not None:
+        kwargs["sasl_oauth_token_provider"] = token_provider
+    producer = KafkaProducer(**kwargs)
     try:
         yield producer
     finally:

--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -12,11 +12,28 @@ from karapace.core.kafka.producer import KafkaProducer
 import contextlib
 
 
-def _get_oauth_token_provider(config: Config) -> object | None:
-    """Instantiate the configured OAuth token provider, if any."""
-    if config.sasl_oauth_token_provider_class is not None:
-        return config.sasl_oauth_token_provider_class()
-    return None
+_oauth_token_provider_cache: dict[type, object] = {}
+
+
+def get_oauth_token_provider(config: Config) -> object | None:
+    """Return the configured OAuth token provider singleton, if any.
+
+    The provider class is instantiated once and cached for the lifetime of the
+    process.  The instance must expose a ``token_with_expiry`` method as
+    required by confluent-kafka's OAUTHBEARER flow.
+    """
+    if config.sasl_oauth_token_provider_class is None:
+        return None
+    cls = config.sasl_oauth_token_provider_class
+    if cls not in _oauth_token_provider_cache:
+        instance = cls()
+        if not callable(getattr(instance, "token_with_expiry", None)):
+            raise ValueError(
+                f"OAuth token provider {cls.__name__} must implement a "
+                f"token_with_expiry() method returning {{'token': str, 'expiry': float}}"
+            )
+        _oauth_token_provider_cache[cls] = instance
+    return _oauth_token_provider_cache[cls]
 
 
 def kafka_admin_from_config(config: Config) -> KafkaAdminClient:
@@ -31,7 +48,7 @@ def kafka_admin_from_config(config: Config) -> KafkaAdminClient:
         ssl_certfile=config.ssl_certfile,
         ssl_keyfile=config.ssl_keyfile,
     )
-    token_provider = _get_oauth_token_provider(config)
+    token_provider = get_oauth_token_provider(config)
     if token_provider is not None:
         kwargs["sasl_oauth_token_provider"] = token_provider
     return KafkaAdminClient(**kwargs)
@@ -55,7 +72,7 @@ def kafka_consumer_from_config(config: Config, topic: str) -> Iterator[KafkaCons
         session_timeout_ms=config.session_timeout_ms,
         metadata_max_age_ms=config.metadata_max_age_ms,
     )
-    token_provider = _get_oauth_token_provider(config)
+    token_provider = get_oauth_token_provider(config)
     if token_provider is not None:
         kwargs["sasl_oauth_token_provider"] = token_provider
     consumer = KafkaConsumer(**kwargs)
@@ -80,7 +97,7 @@ def kafka_producer_from_config(config: Config) -> Iterator[KafkaProducer]:
         retries=0,
         session_timeout_ms=config.session_timeout_ms,
     )
-    token_provider = _get_oauth_token_provider(config)
+    token_provider = get_oauth_token_provider(config)
     if token_provider is not None:
         kwargs["sasl_oauth_token_provider"] = token_provider
     producer = KafkaProducer(**kwargs)

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -89,12 +89,19 @@ class MessageType(Enum):
     no_operation = "NOOP"
 
 
+def _get_oauth_token_provider(config: Config):
+    """Instantiate the configured OAuth token provider, if any."""
+    if config.sasl_oauth_token_provider_class is not None:
+        return config.sasl_oauth_token_provider_class()
+    return None
+
+
 def _create_consumer_from_config(config: Config) -> KafkaConsumer:
     # Group not set on purpose, all consumers read the same data
     # NOTE: Don't pass topic= here to avoid subscribing before the topic exists
     # (causes issues with confluent-kafka 2.13+). Subscribe after topic creation instead.
     session_timeout_ms = config.session_timeout_ms
-    return KafkaConsumer(
+    kwargs: dict = dict(
         bootstrap_servers=config.bootstrap_uri,
         enable_auto_commit=False,
         client_id=config.client_id,
@@ -110,10 +117,14 @@ def _create_consumer_from_config(config: Config) -> KafkaConsumer:
         session_timeout_ms=session_timeout_ms,
         metadata_max_age_ms=config.metadata_max_age_ms,
     )
+    token_provider = _get_oauth_token_provider(config)
+    if token_provider is not None:
+        kwargs["sasl_oauth_token_provider"] = token_provider
+    return KafkaConsumer(**kwargs)
 
 
 def _create_admin_client_from_config(config: Config) -> KafkaAdminClient:
-    return KafkaAdminClient(
+    kwargs: dict = dict(
         bootstrap_servers=config.bootstrap_uri,
         client_id=config.client_id,
         security_protocol=config.security_protocol,
@@ -124,6 +135,10 @@ def _create_admin_client_from_config(config: Config) -> KafkaAdminClient:
         sasl_plain_username=config.sasl_plain_username,
         sasl_plain_password=config.sasl_plain_password,
     )
+    token_provider = _get_oauth_token_provider(config)
+    if token_provider is not None:
+        kwargs["sasl_oauth_token_provider"] = token_provider
+    return KafkaAdminClient(**kwargs)
 
 
 class KafkaSchemaReader(Thread, SchemaReaderStoppper):

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -89,7 +89,7 @@ class MessageType(Enum):
     no_operation = "NOOP"
 
 
-def _get_oauth_token_provider(config: Config):
+def _get_oauth_token_provider(config: Config) -> object | None:
     """Instantiate the configured OAuth token provider, if any."""
     if config.sasl_oauth_token_provider_class is not None:
         return config.sasl_oauth_token_provider_class()

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -38,6 +38,7 @@ from karapace.core.kafka.admin import KafkaAdminClient
 from karapace.core.kafka.common import translate_from_kafkaerror
 from karapace.core.kafka.consumer import KafkaConsumer
 from karapace.core.kafka_error_handler import KafkaErrorHandler, KafkaErrorLocation
+from karapace.core.kafka_utils import get_oauth_token_provider
 from karapace.core.key_format import is_key_in_canonical_format, KeyFormatter, KeyMode
 from karapace.core.offset_watcher import OffsetWatcher
 from karapace.core.protobuf.exception import ProtobufException
@@ -89,13 +90,6 @@ class MessageType(Enum):
     no_operation = "NOOP"
 
 
-def _get_oauth_token_provider(config: Config) -> object | None:
-    """Instantiate the configured OAuth token provider, if any."""
-    if config.sasl_oauth_token_provider_class is not None:
-        return config.sasl_oauth_token_provider_class()
-    return None
-
-
 def _create_consumer_from_config(config: Config) -> KafkaConsumer:
     # Group not set on purpose, all consumers read the same data
     # NOTE: Don't pass topic= here to avoid subscribing before the topic exists
@@ -117,7 +111,7 @@ def _create_consumer_from_config(config: Config) -> KafkaConsumer:
         session_timeout_ms=session_timeout_ms,
         metadata_max_age_ms=config.metadata_max_age_ms,
     )
-    token_provider = _get_oauth_token_provider(config)
+    token_provider = get_oauth_token_provider(config)
     if token_provider is not None:
         kwargs["sasl_oauth_token_provider"] = token_provider
     return KafkaConsumer(**kwargs)
@@ -135,7 +129,7 @@ def _create_admin_client_from_config(config: Config) -> KafkaAdminClient:
         sasl_plain_username=config.sasl_plain_username,
         sasl_plain_password=config.sasl_plain_password,
     )
-    token_provider = _get_oauth_token_provider(config)
+    token_provider = get_oauth_token_provider(config)
     if token_provider is not None:
         kwargs["sasl_oauth_token_provider"] = token_provider
     return KafkaAdminClient(**kwargs)

--- a/tests/e2e/schema_registry/test_oidc.py
+++ b/tests/e2e/schema_registry/test_oidc.py
@@ -3,6 +3,7 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 
+import asyncio
 import json
 
 from karapace.core.client import Client
@@ -10,10 +11,28 @@ from karapace.core.schema_reader import SchemaType
 from tests.utils import new_random_name
 
 
+async def _wait_for_primary(client: Client, timeout: float = 30.0) -> None:
+    """Wait until the schema registry has elected a primary (master).
+
+    Without this, write requests may be forwarded to a node that hasn't
+    become primary yet, causing a forwarding loop and a timeout.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        res = await client.get("master_available")
+        if res.status_code == 200 and res.json_result and res.json_result.get("master_available") is True:
+            return
+        await asyncio.sleep(1.0)
+    raise TimeoutError("Schema registry did not elect a primary within timeout")
+
+
 async def test_schema_registry_oidc(
     registry_async_client_oidc: Client,
 ) -> None:
     subject = new_random_name("subject")
+
+    # Wait for the registry to elect a primary before attempting writes.
+    await _wait_for_primary(registry_async_client_oidc)
 
     # sanity check.
     subject_res = await registry_async_client_oidc.get(f"subjects/{subject}/versions")

--- a/tests/unit/test_oauth_token_provider.py
+++ b/tests/unit/test_oauth_token_provider.py
@@ -1,13 +1,25 @@
 """
 Tests for sasl_oauth_token_provider_class config and passthrough.
 
-Copyright (c) 2023 Aiven Ltd
+Copyright (c) 2026 Aiven Ltd
 See LICENSE for details
 """
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from karapace.core.config import Config
+from karapace.core import kafka_utils
+from karapace.core.kafka_utils import get_oauth_token_provider
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_cache():
+    """Clear the singleton cache between tests."""
+    kafka_utils._oauth_token_provider_cache.clear()
+    yield
+    kafka_utils._oauth_token_provider_cache.clear()
 
 
 class StubTokenProvider:
@@ -27,19 +39,30 @@ def _make_config_with_provider():
 
 class TestGetOauthTokenProvider:
     def test_returns_none_when_not_configured(self):
-        from karapace.core.kafka_utils import _get_oauth_token_provider
-
         config = Config()
-        assert _get_oauth_token_provider(config) is None
+        assert get_oauth_token_provider(config) is None
 
     def test_returns_instance_when_configured(self):
-        from karapace.core.kafka_utils import _get_oauth_token_provider
-
         config = _make_config_with_provider()
-        provider = _get_oauth_token_provider(config)
+        provider = get_oauth_token_provider(config)
         assert provider is not None
         assert isinstance(provider, StubTokenProvider)
         assert provider.token_with_expiry() == ("fake-token", 9999999999)
+
+    def test_raises_when_missing_token_with_expiry(self):
+        class BadProvider:
+            pass
+
+        config = Config()
+        config.sasl_oauth_token_provider_class = BadProvider
+        with pytest.raises(ValueError, match="must implement a token_with_expiry"):
+            get_oauth_token_provider(config)
+
+    def test_returns_cached_instance(self):
+        config = _make_config_with_provider()
+        first = get_oauth_token_provider(config)
+        second = get_oauth_token_provider(config)
+        assert first is second
 
 
 class TestKafkaUtilsPassthrough:

--- a/tests/unit/test_oauth_token_provider.py
+++ b/tests/unit/test_oauth_token_provider.py
@@ -10,16 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from karapace.core.config import Config
-from karapace.core import kafka_utils
 from karapace.core.kafka_utils import get_oauth_token_provider
-
-
-@pytest.fixture(autouse=True)
-def _clear_provider_cache():
-    """Clear the singleton cache between tests."""
-    kafka_utils._oauth_token_provider_cache.clear()
-    yield
-    kafka_utils._oauth_token_provider_cache.clear()
 
 
 class StubTokenProvider:
@@ -34,6 +25,7 @@ def _make_config_with_provider():
     config.sasl_mechanism = "OAUTHBEARER"
     config.security_protocol = "SASL_SSL"
     config.sasl_oauth_token_provider_class = StubTokenProvider
+    config.model_post_init(None)
     return config
 
 
@@ -54,11 +46,11 @@ class TestGetOauthTokenProvider:
             pass
 
         config = Config()
-        config.sasl_oauth_token_provider_class = BadProvider
         with pytest.raises(ValueError, match="must implement a token_with_expiry"):
-            get_oauth_token_provider(config)
+            config.sasl_oauth_token_provider_class = BadProvider
+            config.model_post_init(None)
 
-    def test_returns_cached_instance(self):
+    def test_returns_same_instance(self):
         config = _make_config_with_provider()
         first = get_oauth_token_provider(config)
         second = get_oauth_token_provider(config)

--- a/tests/unit/test_oauth_token_provider.py
+++ b/tests/unit/test_oauth_token_provider.py
@@ -1,0 +1,199 @@
+"""
+Tests for sasl_oauth_token_provider_class config and passthrough.
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+from unittest.mock import MagicMock, patch
+
+from karapace.core.config import Config
+
+
+class StubTokenProvider:
+    """A minimal token provider implementing the TokenWithExpiryProvider protocol."""
+
+    def token_with_expiry(self, config=None):
+        return ("fake-token", 9999999999)
+
+
+def _make_config_with_provider():
+    config = Config()
+    config.sasl_mechanism = "OAUTHBEARER"
+    config.security_protocol = "SASL_SSL"
+    config.sasl_oauth_token_provider_class = StubTokenProvider
+    return config
+
+
+class TestGetOauthTokenProvider:
+    def test_returns_none_when_not_configured(self):
+        from karapace.core.kafka_utils import _get_oauth_token_provider
+
+        config = Config()
+        assert _get_oauth_token_provider(config) is None
+
+    def test_returns_instance_when_configured(self):
+        from karapace.core.kafka_utils import _get_oauth_token_provider
+
+        config = _make_config_with_provider()
+        provider = _get_oauth_token_provider(config)
+        assert provider is not None
+        assert isinstance(provider, StubTokenProvider)
+        assert provider.token_with_expiry() == ("fake-token", 9999999999)
+
+
+class TestKafkaUtilsPassthrough:
+    """Verify that factory functions pass sasl_oauth_token_provider to Kafka clients."""
+
+    @patch("karapace.core.kafka_utils.KafkaAdminClient")
+    def test_admin_passes_provider(self, mock_admin_cls):
+        from karapace.core.kafka_utils import kafka_admin_from_config
+
+        config = _make_config_with_provider()
+        kafka_admin_from_config(config)
+
+        call_kwargs = mock_admin_cls.call_args[1]
+        assert "sasl_oauth_token_provider" in call_kwargs
+        assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    @patch("karapace.core.kafka_utils.KafkaAdminClient")
+    def test_admin_omits_provider_when_not_configured(self, mock_admin_cls):
+        from karapace.core.kafka_utils import kafka_admin_from_config
+
+        config = Config()
+        kafka_admin_from_config(config)
+
+        call_kwargs = mock_admin_cls.call_args[1]
+        assert "sasl_oauth_token_provider" not in call_kwargs
+
+    @patch("karapace.core.kafka_utils.KafkaConsumer")
+    def test_consumer_passes_provider(self, mock_consumer_cls):
+        from karapace.core.kafka_utils import kafka_consumer_from_config
+
+        config = _make_config_with_provider()
+        with kafka_consumer_from_config(config, "test-topic"):
+            pass
+
+        call_kwargs = mock_consumer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" in call_kwargs
+        assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    @patch("karapace.core.kafka_utils.KafkaConsumer")
+    def test_consumer_omits_provider_when_not_configured(self, mock_consumer_cls):
+        from karapace.core.kafka_utils import kafka_consumer_from_config
+
+        config = Config()
+        with kafka_consumer_from_config(config, "test-topic"):
+            pass
+
+        call_kwargs = mock_consumer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" not in call_kwargs
+
+    @patch("karapace.core.kafka_utils.KafkaProducer")
+    def test_producer_passes_provider(self, mock_producer_cls):
+        from karapace.core.kafka_utils import kafka_producer_from_config
+
+        config = _make_config_with_provider()
+        with kafka_producer_from_config(config):
+            pass
+
+        call_kwargs = mock_producer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" in call_kwargs
+        assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    @patch("karapace.core.kafka_utils.KafkaProducer")
+    def test_producer_omits_provider_when_not_configured(self, mock_producer_cls):
+        from karapace.core.kafka_utils import kafka_producer_from_config
+
+        config = Config()
+        with kafka_producer_from_config(config):
+            pass
+
+        call_kwargs = mock_producer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" not in call_kwargs
+
+
+class TestSchemaReaderPassthrough:
+    """Verify that schema_reader internal factories also pass the provider.
+
+    The schema_reader module transitively imports the protopace Go shared library,
+    which may not be available in all test environments. We mock the protopace
+    module before importing schema_reader to avoid that dependency.
+    """
+
+    @staticmethod
+    def _import_schema_reader():
+        """Import schema_reader with protopace mocked out."""
+        import importlib
+        import sys
+
+        # If already imported, just return the cached module
+        if "karapace.core.schema_reader" in sys.modules:
+            return sys.modules["karapace.core.schema_reader"]
+
+        # Mock the protopace shared library before importing schema_reader
+        mock_protopace = MagicMock()
+        mock_protopace.Proto = MagicMock
+        modules_to_mock = {
+            "karapace.core.protobuf.protopace.protopace": mock_protopace,
+            "karapace.core.protobuf.protopace": mock_protopace,
+        }
+        with patch.dict(sys.modules, modules_to_mock):
+            # Force re-import of dependency that triggers protopace
+            if "karapace.core.dependency" in sys.modules:
+                del sys.modules["karapace.core.dependency"]
+            if "karapace.core.schema_reader" in sys.modules:
+                del sys.modules["karapace.core.schema_reader"]
+            mod = importlib.import_module("karapace.core.schema_reader")
+        return mod
+
+    def test_schema_reader_consumer_passes_provider(self):
+        schema_reader = self._import_schema_reader()
+        with patch.object(schema_reader, "KafkaConsumer") as mock_consumer_cls:
+            config = _make_config_with_provider()
+            schema_reader._create_consumer_from_config(config)
+
+            call_kwargs = mock_consumer_cls.call_args[1]
+            assert "sasl_oauth_token_provider" in call_kwargs
+            assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    def test_schema_reader_consumer_omits_provider_when_not_configured(self):
+        schema_reader = self._import_schema_reader()
+        with patch.object(schema_reader, "KafkaConsumer") as mock_consumer_cls:
+            config = Config()
+            schema_reader._create_consumer_from_config(config)
+
+            call_kwargs = mock_consumer_cls.call_args[1]
+            assert "sasl_oauth_token_provider" not in call_kwargs
+
+    def test_schema_reader_admin_passes_provider(self):
+        schema_reader = self._import_schema_reader()
+        with patch.object(schema_reader, "KafkaAdminClient") as mock_admin_cls:
+            config = _make_config_with_provider()
+            schema_reader._create_admin_client_from_config(config)
+
+            call_kwargs = mock_admin_cls.call_args[1]
+            assert "sasl_oauth_token_provider" in call_kwargs
+            assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    def test_schema_reader_admin_omits_provider_when_not_configured(self):
+        schema_reader = self._import_schema_reader()
+        with patch.object(schema_reader, "KafkaAdminClient") as mock_admin_cls:
+            config = Config()
+            schema_reader._create_admin_client_from_config(config)
+
+            call_kwargs = mock_admin_cls.call_args[1]
+            assert "sasl_oauth_token_provider" not in call_kwargs
+
+
+class TestConfigImportString:
+    """Verify the config field works with importable string paths."""
+
+    def test_config_accepts_none_by_default(self):
+        config = Config()
+        assert config.sasl_oauth_token_provider_class is None
+
+    def test_config_accepts_class_directly(self):
+        config = Config()
+        config.sasl_oauth_token_provider_class = StubTokenProvider
+        assert config.sasl_oauth_token_provider_class is StubTokenProvider


### PR DESCRIPTION
## Summary

- Adds `sasl_oauth_token_provider_class` config option that accepts a Python import path (via pydantic `ImportString`) to a class implementing the `TokenWithExpiryProvider` protocol
- When configured, an instance is created and passed as `sasl_oauth_token_provider` to all Kafka client factories — admin, consumer, and producer — including the schema reader's internal clients
- Enables native OAUTHBEARER auth (e.g. AWS MSK IAM) without monkey-patching

### Problem

`kafka_utils.py` and `schema_reader.py` create Kafka clients but never pass `sasl_oauth_token_provider`, even though `_KafkaConfigMixin` already supports it via `KafkaClientParams` → `oauth_cb`. Anyone deploying Karapace against AWS MSK with IAM auth must monkey-patch the client factories or build a custom wrapper.

### Solution

New config option configurable via env var:
```
KARAPACE_SECURITY_PROTOCOL=SASL_SSL
KARAPACE_SASL_MECHANISM=OAUTHBEARER
KARAPACE_SASL_OAUTH_TOKEN_PROVIDER_CLASS=examples.msk_iam_token_provider:MSKIAMTokenProvider
```

The referenced class must implement:
```python
def token_with_expiry(self, config: str | None) -> tuple[str, int | None]
```

### Changes

- **`src/karapace/core/config.py`**: Add `sasl_oauth_token_provider_class: ImportString | None` field
- **`src/karapace/core/kafka_utils.py`**: Instantiate provider and pass to all 3 factory functions
- **`src/karapace/core/schema_reader.py`**: Same for the 2 internal factory functions
- **`examples/msk_iam_token_provider.py`**: Example AWS MSK IAM token provider using `aws-msk-iam-sasl-signer-python`
- **`tests/unit/test_oauth_token_provider.py`**: 14 unit tests covering config, all 5 factories (with/without provider)

## Test plan

- [x] 14 unit tests pass locally (`tests/unit/test_oauth_token_provider.py`)
- [x] Existing tests unaffected (no behavior change when option is unset)