### PR TITLE
Add startup warning when REST proxy authorization is disabled 

### DIFF
--- a/container/compose.yml
+++ b/container/compose.yml
@@ -186,6 +186,10 @@ services:
       KARAPACE_STATSD_PORT: 8125
       KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
       KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      # Enable rest_authorization in production to enforce Kafka ACLs on REST proxy requests.
+      # When disabled (default), the REST proxy bypasses all Kafka ACLs.
+      # KARAPACE_REST_AUTHORIZATION: true
+      # KARAPACE_SASL_BOOTSTRAP_URI: kafka:29094
 
   kafka:
     networks:

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -186,7 +186,7 @@ services:
       KARAPACE_STATSD_PORT: 8125
       KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
       KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
-      # Enable rest_authorization in production to enforce Kafka ACLs on REST proxy requests.
+      # Enable rest_authorization to enforce Kafka ACLs on REST proxy requests.
       # When disabled (default), the REST proxy bypasses all Kafka ACLs.
       # KARAPACE_REST_AUTHORIZATION: true
       # KARAPACE_SASL_BOOTSTRAP_URI: kafka:29094

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -114,6 +114,7 @@ class Config(BaseSettings):
     registry_password: str | None = None
     registry_ca: str | None = None
     registry_authfile: str | None = None
+    # When False (default), the REST proxy bypasses Kafka ACLs. Set to True for production use.
     rest_authorization: bool = False
     rest_base_uri: str | None = None
     log_handler: str | None = "stdout"

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -114,7 +114,7 @@ class Config(BaseSettings):
     registry_password: str | None = None
     registry_ca: str | None = None
     registry_authfile: str | None = None
-    # When False (default), the REST proxy bypasses Kafka ACLs. Set to True for production use.
+    # When False (default), the REST proxy bypasses Kafka ACLs.
     rest_authorization: bool = False
     rest_base_uri: str | None = None
     log_handler: str | None = "stdout"

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -85,7 +85,7 @@ class KafkaRest(KarapaceBase):
             log.warning(
                 "REST proxy starting with authorization disabled (rest_authorization=false). "
                 "All Kafka ACLs will be bypassed for REST proxy requests. "
-                "Set rest_authorization=true and configure sasl_bootstrap_uri for production use."
+                "Set rest_authorization=true and configure sasl_bootstrap_uri."
             )
         self._idle_proxy_janitor_task: asyncio.Task | None = None
 

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -79,7 +79,15 @@ class KafkaRest(KarapaceBase):
         self.serializer = SchemaRegistrySerializer(config=config)
         self.proxies: dict[str, UserRestProxy] = {}
         self._proxy_lock = asyncio.Lock()
-        log.info("REST proxy starting with (delegated authorization=%s)", self.config.rest_authorization)
+        if self.config.rest_authorization:
+            log.info("REST proxy starting with delegated authorization enabled")
+        else:
+            log.warning(
+                "REST proxy starting with authorization disabled (rest_authorization=false). "
+                "All Kafka ACLs will be bypassed for REST proxy requests. "
+                "This is suitable for development only. "
+                "Set rest_authorization=true and configure sasl_bootstrap_uri for production use."
+            )
         self._idle_proxy_janitor_task: asyncio.Task | None = None
 
     async def close(self) -> None:

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -85,7 +85,6 @@ class KafkaRest(KarapaceBase):
             log.warning(
                 "REST proxy starting with authorization disabled (rest_authorization=false). "
                 "All Kafka ACLs will be bypassed for REST proxy requests. "
-                "This is suitable for development only. "
                 "Set rest_authorization=true and configure sasl_bootstrap_uri for production use."
             )
         self._idle_proxy_janitor_task: asyncio.Task | None = None


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Add startup warning when REST proxy authorization is disabled                                                                                  

The REST proxy's rest_authorization config defaults to false, which causes all Kafka ACLs to be bypassed for REST proxy requests. Operators following the default configuration may not realize their Kafka ACLs are not being enforced.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
