### PR TITLE
improvement: delete high carinality metrics

### DIFF
--- a/container/grafana/dashboards/karapace.json
+++ b/container/grafana/dashboards/karapace.json
@@ -352,83 +352,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 10
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "karapace_http_requests_duration_seconds_bucket",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "instance={{instance}} method={{method}} path={{path}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "HTTP Requests Duration",
-      "type": "histogram"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -501,7 +424,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "karapace_schema_reader_subjects_total{exported_job=\"karapace-schema-registry\"}",
+          "expr": "karapace_schema_reader_subjects{app=\"karapace-schema-registry\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -574,7 +497,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "karapace_schema_reader_schemas_total{exported_job=\"karapace-schema-registry\"}",
+          "expr": "karapace_schema_reader_schemas{app=\"karapace-schema-registry\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -719,7 +642,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "karapace_schema_reader_subject_data_schema_versions_total",
+          "expr": "karapace_schema_reader_subject_data_schema_versions",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/src/karapace/api/middlewares/__init__.py
+++ b/src/karapace/api/middlewares/__init__.py
@@ -8,10 +8,9 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from karapace.api.telemetry.middleware import setup_telemetry_middleware
 from karapace.core.instrumentation.path_normalization import normalize_path
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter
 from prometheus_fastapi_instrumentator import Instrumentator
-from prometheus_fastapi_instrumentator.metrics import Info
-from prometheus_fastapi_instrumentator.metrics import default as default_metrics
+from prometheus_fastapi_instrumentator.metrics import Info, request_size, requests, response_size
 
 from karapace.api.oidc.middleware import OIDCMiddleware
 from karapace.core.auth import AuthenticationError
@@ -78,7 +77,7 @@ def setup_middlewares(app: FastAPI, config: Config) -> None:
     # Metrics via prometheus-fastapi-instrumentator.
     # .add() before .instrument(): Starlette defers middleware construction, so if the
     # instrumentations list is non-empty the middleware skips its built-in defaults.
-    # We include default_metrics() explicitly to get both standard and karapace_* names.
+    # Latency histograms are intentionally omitted to limit Prometheus series cardinality.
     instrumentator = Instrumentator(
         should_group_status_codes=False,
         should_instrument_requests_inprogress=True,
@@ -86,9 +85,10 @@ def setup_middlewares(app: FastAPI, config: Config) -> None:
         inprogress_labels=True,
     )
     instrumentator.add(
-        default_metrics(),
+        requests(),
+        request_size(),
+        response_size(),
         _karapace_requests_total(),
-        _karapace_requests_duration(),
     )
     instrumentator.instrument(app).expose(app, include_in_schema=False)
 
@@ -104,20 +104,5 @@ def _karapace_requests_total() -> Callable[[Info], None]:
     def instrumentation(info: Info) -> None:
         path = normalize_path(info.request.url.path)
         counter.labels(info.request.method, path, info.modified_status).inc()
-
-    return instrumentation
-
-
-def _karapace_requests_duration() -> Callable[[Info], None]:
-    """Deprecated: use http_request_duration_seconds instead. Subject to removal."""
-    histogram = Histogram(
-        "karapace_http_requests_duration_seconds",
-        "Deprecated: use http_request_duration_seconds. Request Duration for HTTP/TCP Protocol",
-        labelnames=("method", "path"),
-    )
-
-    def instrumentation(info: Info) -> None:
-        path = normalize_path(info.request.url.path)
-        histogram.labels(info.request.method, path).observe(info.modified_duration)
 
     return instrumentation

--- a/src/karapace/core/instrumentation/prometheus.py
+++ b/src/karapace/core/instrumentation/prometheus.py
@@ -13,11 +13,10 @@ from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from karapace.core.instrumentation.path_normalization import normalize_path
 from karapace.rapu import HTTPResponse, RestApp
-from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest, Histogram
+from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
 from typing import Final, NoReturn
 
 import logging
-import time
 
 LOG = logging.getLogger(__name__)
 
@@ -25,7 +24,6 @@ LOG = logging.getLogger(__name__)
 class PrometheusInstrumentation:
     METRICS_ENDPOINT_PATH: Final[str] = "/metrics"
     CONTENT_TYPE_LATEST: Final[str] = "text/plain; version=0.0.4; charset=utf-8"
-    START_TIME_REQUEST_KEY: Final[str] = "start_time"
 
     registry: Final[CollectorRegistry] = CollectorRegistry()
 
@@ -34,13 +32,6 @@ class PrometheusInstrumentation:
         name="karapace_http_requests_total",
         documentation="Total Request Count for HTTP/TCP Protocol",
         labelnames=("method", "path", "status"),
-    )
-
-    karapace_http_requests_duration_seconds: Final[Histogram] = Histogram(
-        registry=registry,
-        name="karapace_http_requests_duration_seconds",
-        documentation="Request Duration for HTTP/TCP Protocol",
-        labelnames=("method", "path"),
     )
 
     karapace_http_requests_in_progress: Final[Gauge] = Gauge(
@@ -68,7 +59,6 @@ class PrometheusInstrumentation:
         # the issue is in the type difference (Counter, Gauge, etc) of the arguments which we are
         # passing to `__setitem__()`, but we need to keep these objects in the `app.app` dict.
         app.app[cls.karapace_http_requests_total] = cls.karapace_http_requests_total
-        app.app[cls.karapace_http_requests_duration_seconds] = cls.karapace_http_requests_duration_seconds
         app.app[cls.karapace_http_requests_in_progress] = cls.karapace_http_requests_in_progress
 
     @classmethod
@@ -88,8 +78,6 @@ class PrometheusInstrumentation:
         request: Request,
         handler: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        request[cls.START_TIME_REQUEST_KEY] = time.time()
-
         # Extract request labels - normalize path to prevent unbounded cardinality
         path = normalize_path(request.path)
         method = request.method
@@ -102,9 +90,4 @@ class PrometheusInstrumentation:
             request.app[cls.karapace_http_requests_total].labels(method, path, response.status).inc()
             return response
         finally:
-            try:
-                request.app[cls.karapace_http_requests_duration_seconds].labels(method, path).observe(
-                    time.time() - request[cls.START_TIME_REQUEST_KEY]
-                )
-            finally:
-                in_progress.dec()
+            in_progress.dec()

--- a/src/karapace/core/stats.py
+++ b/src/karapace/core/stats.py
@@ -76,20 +76,12 @@ class StatsClient:
         )
 
     def set_schemas_num_total(self, *, value: int) -> None:
-        LOG.debug("Setting schemas gauge to %s with labels %s", value, self._tags)
         self._total_schemas_gauge.labels(**self._tags).set(value)
 
     def set_subjects_num_total(self, *, value: int) -> None:
-        LOG.debug("Setting subjects gauge to %s with labels %s", value, self._tags)
         self._total_subjects_gauge.labels(**self._tags).set(value)
 
     def set_schema_versions_num_total(self, *, live_versions: int, soft_deleted_versions: int) -> None:
-        LOG.debug(
-            "Setting schema versions gauge: live=%s, soft_deleted=%s with labels %s",
-            live_versions,
-            soft_deleted_versions,
-            self._tags,
-        )
         self._schema_versions_gauge.labels(state="live", **self._tags).set(live_versions)
         self._schema_versions_gauge.labels(state="soft_deleted", **self._tags).set(soft_deleted_versions)
 

--- a/tests/e2e/instrumentation/test_prometheus.py
+++ b/tests/e2e/instrumentation/test_prometheus.py
@@ -49,9 +49,7 @@ async def test_metrics_endpoint_parsed_response(registry_async_client: Client) -
 
     # Standard metrics (from prometheus-fastapi-instrumentator)
     assert "http_requests" in metrics
-    assert "http_request_duration_seconds" in metrics
     assert "http_requests_inprogress" in metrics
 
     # Backwards-compatible karapace_* metrics
     assert "karapace_http_requests" in metrics
-    assert "karapace_http_requests_duration_seconds" in metrics

--- a/tests/unit/api/test_prometheus_middleware.py
+++ b/tests/unit/api/test_prometheus_middleware.py
@@ -12,7 +12,7 @@ from prometheus_client import REGISTRY
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import default as default_metrics
 
-from karapace.api.middlewares import _karapace_requests_total, _karapace_requests_duration
+from karapace.api.middlewares import _karapace_requests_total
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +40,6 @@ def app() -> FastAPI:
     instrumentator.add(
         default_metrics(),
         _karapace_requests_total(),
-        _karapace_requests_duration(),
     )
     instrumentator.instrument(app).expose(app, include_in_schema=False)
 

--- a/tests/unit/api/test_prometheus_middleware.py
+++ b/tests/unit/api/test_prometheus_middleware.py
@@ -74,7 +74,6 @@ class TestStandardMetrics:
         body = response.text
 
         assert "http_requests_total{" in body
-        assert "http_request_duration_seconds" in body
 
     def test_standard_metrics_record_error_status(self, client: TestClient) -> None:
         client.get("/fail")
@@ -112,7 +111,6 @@ class TestKarapaceMetrics:
         body = response.text
 
         assert "karapace_http_requests_total{" in body
-        assert "karapace_http_requests_duration_seconds" in body
 
     def test_karapace_metrics_record_error_status(self, client: TestClient) -> None:
         client.get("/fail")

--- a/tests/unit/instrumentation/test_prometheus.py
+++ b/tests/unit/instrumentation/test_prometheus.py
@@ -12,43 +12,30 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import aiohttp.web
 import pytest
 from _pytest.logging import LogCaptureFixture
-from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client import CollectorRegistry, Counter, Gauge
 
 from karapace.core.instrumentation.prometheus import PrometheusInstrumentation
 from karapace.rapu import HTTPResponse, RestApp
 
 
-# Simple request object implementing mapping semantics for START_TIME used by tests
 class DummyRequest:
     def __init__(self, path: str, method: str, app: dict):
         self.path = path
         self.method = method
         self.app = app
-        self._store: dict = {}
-
-    def __setitem__(self, key, value):
-        self._store[key] = value
-
-    def __getitem__(self, key):
-        return self._store[key]
 
 
 def _make_metric_mocks(prometheus: PrometheusInstrumentation):
     """Create isolated metric mocks to avoid cross-test leakage.
 
     Returns a tuple: (app_metrics, in_progress_metric, in_progress_instance,
-    duration_metric, duration_instance, total_metric, total_instance)
+    total_metric, total_instance)
     """
     in_progress_instance = MagicMock()
     in_progress_instance.inc = MagicMock()
     in_progress_instance.dec = MagicMock()
     in_progress_metric = MagicMock()
     in_progress_metric.labels = MagicMock(return_value=in_progress_instance)
-
-    duration_instance = MagicMock()
-    duration_instance.observe = MagicMock()
-    duration_metric = MagicMock()
-    duration_metric.labels = MagicMock(return_value=duration_instance)
 
     total_instance = MagicMock()
     total_instance.inc = MagicMock()
@@ -57,7 +44,6 @@ def _make_metric_mocks(prometheus: PrometheusInstrumentation):
 
     app_metrics = {
         prometheus.karapace_http_requests_in_progress: in_progress_metric,
-        prometheus.karapace_http_requests_duration_seconds: duration_metric,
         prometheus.karapace_http_requests_total: total_metric,
     }
 
@@ -65,8 +51,6 @@ def _make_metric_mocks(prometheus: PrometheusInstrumentation):
         app_metrics,
         in_progress_metric,
         in_progress_instance,
-        duration_metric,
-        duration_instance,
         total_metric,
         total_instance,
     )
@@ -78,21 +62,15 @@ class TestPrometheusInstrumentation:
         return PrometheusInstrumentation()
 
     def test_constants(self, prometheus: PrometheusInstrumentation) -> None:
-        assert prometheus.START_TIME_REQUEST_KEY == "start_time"
         assert isinstance(prometheus.registry, CollectorRegistry)
 
     def test_metric_types(self, prometheus: PrometheusInstrumentation) -> None:
         assert isinstance(prometheus.karapace_http_requests_total, Counter)
-        assert isinstance(prometheus.karapace_http_requests_duration_seconds, Histogram)
         assert isinstance(prometheus.karapace_http_requests_in_progress, Gauge)
 
     def test_metric_values(self, prometheus: PrometheusInstrumentation) -> None:
         # `_total` suffix is stripped off the metric name for `Counters`, but needed for clarity.
         assert repr(prometheus.karapace_http_requests_total) == "prometheus_client.metrics.Counter(karapace_http_requests)"
-        assert (
-            repr(prometheus.karapace_http_requests_duration_seconds)
-            == "prometheus_client.metrics.Histogram(karapace_http_requests_duration_seconds)"
-        )
         assert (
             repr(prometheus.karapace_http_requests_in_progress)
             == "prometheus_client.metrics.Gauge(karapace_http_requests_in_progress)"
@@ -117,10 +95,6 @@ class TestPrometheusInstrumentation:
             app.app.__setitem__.assert_has_calls(
                 [
                     call(prometheus.karapace_http_requests_total, prometheus.karapace_http_requests_total),
-                    call(
-                        prometheus.karapace_http_requests_duration_seconds,
-                        prometheus.karapace_http_requests_duration_seconds,
-                    ),
                     call(prometheus.karapace_http_requests_in_progress, prometheus.karapace_http_requests_in_progress),
                 ]
             )
@@ -144,20 +118,11 @@ class TestPrometheusInstrumentation:
         assert exc_info.value.headers.get("Content-Type") == prometheus.CONTENT_TYPE_LATEST
         assert exc_info.value.body == mock_metrics_data
 
-    @patch("karapace.core.instrumentation.prometheus.time")
-    async def test_http_request_metrics_middleware(
-        self,
-        mock_time: MagicMock,
-        prometheus: PrometheusInstrumentation,
-    ) -> None:
-        mock_time.time.return_value = 10
-
+    async def test_http_request_metrics_middleware(self, prometheus: PrometheusInstrumentation) -> None:
         (
             app_metrics,
             in_progress_metric,
             in_progress_instance,
-            duration_metric,
-            duration_instance,
             total_metric,
             total_instance,
         ) = _make_metric_mocks(prometheus)
@@ -177,9 +142,6 @@ class TestPrometheusInstrumentation:
         # Handler was invoked with the request
         assert called == [request]
 
-        # START_TIME should have been set from patched time.time()
-        assert request._store[prometheus.START_TIME_REQUEST_KEY] == 10
-
         # In-progress gauge incremented and then decremented
         in_progress_metric.labels.assert_called_with("GET", "/path")
         in_progress_instance.inc.assert_called_once()
@@ -189,24 +151,11 @@ class TestPrometheusInstrumentation:
         total_metric.labels.assert_called_with("GET", "/path", response.status)
         total_instance.inc.assert_called_once()
 
-        # Duration observed
-        duration_metric.labels.assert_called_with("GET", "/path")
-        duration_instance.observe.assert_called_once()
-
-    @patch("karapace.core.instrumentation.prometheus.time")
-    async def test_http_request_metrics_middleware_exception(
-        self,
-        mock_time: MagicMock,
-        prometheus: PrometheusInstrumentation,
-    ) -> None:
-        mock_time.time.return_value = 10
-
+    async def test_http_request_metrics_middleware_exception(self, prometheus: PrometheusInstrumentation) -> None:
         (
             app_metrics,
             in_progress_metric,
             in_progress_instance,
-            duration_metric,
-            duration_instance,
             total_metric,
             total_instance,
         ) = _make_metric_mocks(prometheus)
@@ -219,36 +168,20 @@ class TestPrometheusInstrumentation:
         with pytest.raises(Exception):
             await prometheus.http_request_metrics_middleware(request=request, handler=handler)
 
-        # START_TIME should have been set from patched time.time()
-        assert request._store[prometheus.START_TIME_REQUEST_KEY] == 10
-
         # In-progress gauge should have been incremented and eventually decremented
         in_progress_metric.labels.assert_called_with("POST", "/error")
         in_progress_instance.inc.assert_called_once()
         in_progress_instance.dec.assert_called_once()
 
-        # Duration should be observed
-        duration_metric.labels.assert_called_with("POST", "/error")
-        duration_instance.observe.assert_called_once()
-
         # Total should NOT be incremented when handler raises a non-HTTP exception
         total_metric.labels.assert_not_called()
 
-    @patch("karapace.core.instrumentation.prometheus.time")
-    async def test_http_request_metrics_middleware_normalizes_path(
-        self,
-        mock_time: MagicMock,
-        prometheus: PrometheusInstrumentation,
-    ) -> None:
+    async def test_http_request_metrics_middleware_normalizes_path(self, prometheus: PrometheusInstrumentation) -> None:
         """Verify that the middleware normalizes dynamic path segments to prevent unbounded metric cardinality."""
-        mock_time.time.return_value = 10
-
         (
             app_metrics,
             in_progress_metric,
             in_progress_instance,
-            duration_metric,
-            duration_instance,
             total_metric,
             total_instance,
         ) = _make_metric_mocks(prometheus)
@@ -264,22 +197,14 @@ class TestPrometheusInstrumentation:
 
         in_progress_metric.labels.assert_called_with("GET", "/schemas/ids/{id}")
         total_metric.labels.assert_called_with("GET", "/schemas/ids/{id}", response.status)
-        duration_metric.labels.assert_called_with("GET", "/schemas/ids/{id}")
 
-    @patch("karapace.core.instrumentation.prometheus.time")
     async def test_http_request_metrics_middleware_normalizes_subject_version_path(
-        self,
-        mock_time: MagicMock,
-        prometheus: PrometheusInstrumentation,
+        self, prometheus: PrometheusInstrumentation
     ) -> None:
-        mock_time.time.return_value = 10
-
         (
             app_metrics,
             in_progress_metric,
             in_progress_instance,
-            duration_metric,
-            duration_instance,
             total_metric,
             total_instance,
         ) = _make_metric_mocks(prometheus)
@@ -296,20 +221,13 @@ class TestPrometheusInstrumentation:
         in_progress_metric.labels.assert_called_with("GET", "/subjects/{subject}/versions/{version}")
         total_metric.labels.assert_called_with("GET", "/subjects/{subject}/versions/{version}", response.status)
 
-    @patch("karapace.core.instrumentation.prometheus.time")
     async def test_http_request_metrics_middleware_normalizes_config_subject_path(
-        self,
-        mock_time: MagicMock,
-        prometheus: PrometheusInstrumentation,
+        self, prometheus: PrometheusInstrumentation
     ) -> None:
-        mock_time.time.return_value = 10
-
         (
             app_metrics,
             in_progress_metric,
             in_progress_instance,
-            duration_metric,
-            duration_instance,
             total_metric,
             total_instance,
         ) = _make_metric_mocks(prometheus)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- High cardinality metrics like karapace_http_requests_duration_seconds_bucket are of not much use, causing memory issues. Deleted from both rest proxy and schema registry metrics
- Delete log statements related counts which are already exposed via metrics
- Rename metrics in container/grafana which are actually exported
- Updated tests

From rest proxy : 

```
# HELP karapace_http_requests_total Total Request Count for HTTP/TCP Protocol
# TYPE karapace_http_requests_total counter
karapace_http_requests_total{method="POST",path="/topics/{topic}",status="200"} 4039.0
# HELP karapace_http_requests_created Total Request Count for HTTP/TCP Protocol
# TYPE karapace_http_requests_created gauge
karapace_http_requests_created{method="GET",path="/metrics",status="200"} 1.7767829389285572e+09
karapace_http_requests_created{method="POST",path="/consumers/consumer-group/instances/consumer_instance_{uuid}/subscription",status="204"} 1.776783019116888e+09
karapace_http_requests_created{method="GET",path="/consumers/consumer-group/instances/consumer_instance_{uuid}/records",status="200"} 1.77678301970256e+09
# HELP karapace_http_requests_in_progress In-progress requests for HTTP/TCP Protocol
# TYPE karapace_http_requests_in_progress gauge
karapace_http_requests_in_progress{method="GET",path="/metrics"} 1.0
karapace_http_requests_in_progress{method="POST",path="/topics/{topic}"} 19.0
karapace_http_requests_in_progress{method="GET",path="/consumers/consumer-group/instances/consumer_instance_{uuid}/records"} 6.0
```

From SR : 
```

# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 1979.0
python_gc_objects_collected_total{generation="1"} 487.0
python_gc_objects_collected_total{generation="2"} 199.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 356.0
python_gc_collections_total{generation="1"} 32.0
python_gc_collections_total{generation="2"} 2.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="0",version="3.12.0"} 1.0
# HELP http_requests_total Total number of requests by method, status and handler.
# TYPE http_requests_total counter
http_requests_total{handler="none",method="GET",status="404"} 1.0
# HELP http_requests_created Total number of requests by method, status and handler.
# TYPE http_requests_created gauge
http_requests_created{handler="none",method="GET",status="404"} 1.776782927230457e+09
# HELP http_request_size_bytes Content bytes of requests.
# TYPE http_request_size_bytes summary
http_request_size_bytes_count{handler="none",method="GET",status="404"} 1.0
http_request_size_bytes_sum{handler="none",method="GET",status="404"} 0.0
# HELP http_request_size_bytes_created Content bytes of requests.
# TYPE http_request_size_bytes_created gauge
http_request_size_bytes_created{handler="none",method="GET",status="404"} 1.776782927230507e+09
# HELP http_response_size_bytes Content bytes of responses.
# TYPE http_response_size_bytes summary
http_response_size_bytes_count{handler="none",method="GET",status="404"} 1.0
http_response_size_bytes_sum{handler="none",method="GET",status="404"} 11.0
# HELP http_response_size_bytes_created Content bytes of responses.
# TYPE http_response_size_bytes_created gauge
http_response_size_bytes_created{handler="none",method="GET",status="404"} 1.7767829272305331e+09
# HELP karapace_http_requests_total Deprecated: use http_requests_total. Total Request Count for HTTP/TCP Protocol
# TYPE karapace_http_requests_total counter
karapace_http_requests_total{method="GET",path="/favicon.ico",status="404"} 1.0
# HELP karapace_http_requests_created Deprecated: use http_requests_total. Total Request Count for HTTP/TCP Protocol
# TYPE karapace_http_requests_created gauge
karapace_http_requests_created{method="GET",path="/favicon.ico",status="404"} 1.776782927230568e+09
# HELP http_requests_inprogress Number of HTTP requests in progress.
# TYPE http_requests_inprogress gauge
http_requests_inprogress{handler="none",method="GET"} 0.0
# HELP karapace_schema_reader_schemas Total number of schemas
# TYPE karapace_schema_reader_schemas gauge
karapace_schema_reader_schemas{app="Karapace"} 0.0
# HELP karapace_schema_reader_subjects Total number of subjects
# TYPE karapace_schema_reader_subjects gauge
karapace_schema_reader_subjects{app="Karapace"} 0.0
# HELP karapace_schema_reader_subject_data_schema_versions Schema versions
# TYPE karapace_schema_reader_subject_data_schema_versions gauge
karapace_schema_reader_subject_data_schema_versions{app="Karapace",state="live"} 0.0
karapace_schema_reader_subject_data_schema_versions{app="Karapace",state="soft_deleted"} 0.0
```

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
