### PR TITLE
Fix: Name strategy validation bypass for value_schema

### DIFF
--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -321,13 +321,24 @@ class SchemaRegistrySerializer:
             self.ids_to_schemas[schema_id] = schema
         return schema
 
-    async def upsert_id_for_schema(self, schema_typed: ValidatedTypedSchema, subject: str) -> SchemaId:
+    async def _schema_id_has_subject(self, schema_id: SchemaId, subject: Subject) -> bool:
+        def subject_not_included(_: TypedSchema, subjects: list[Subject]) -> bool:
+            return subject not in subjects
+
+        try:
+            _, subjects = await self.get_schema_for_id(schema_id, need_new_call=subject_not_included)
+        except SchemaRetrievalError:
+            return False
+
+        return subject in subjects
+
+    async def upsert_id_for_schema(self, schema_typed: ValidatedTypedSchema, subject: Subject) -> SchemaId:
         assert self.registry_client, "must not call this method after the object is closed."
 
         schema_ser = str(schema_typed)
-
-        if schema_ser in self.schemas_to_ids:
-            return self.schemas_to_ids[schema_ser]
+        cached_schema_id = self.schemas_to_ids.get(schema_ser)
+        if cached_schema_id is not None and await self._schema_id_has_subject(cached_schema_id, subject):
+            return cached_schema_id
 
         # note: the post is idempotent, so it is like a get or insert (aka upsert)
         schema_id = await self.registry_client.post_new_schema(subject, schema_typed)
@@ -335,6 +346,10 @@ class SchemaRegistrySerializer:
         async with self.state_lock:
             self.schemas_to_ids[schema_ser] = schema_id
             self.ids_to_schemas[schema_id] = schema_typed
+            known_subjects = list(self.ids_to_subjects.get(schema_id, []))
+            if subject not in known_subjects:
+                known_subjects.append(subject)
+            self.ids_to_subjects[schema_id] = known_subjects
         return schema_id
 
     async def get_schema_for_id(

--- a/tests/integration/kafka_rest_apis/test_rest.py
+++ b/tests/integration/kafka_rest_apis/test_rest.py
@@ -617,6 +617,112 @@ async def test_publish_with_schema_id_of_another_subject_novalidation(
     assert res.status_code == 200
 
 
+async def test_publish_with_value_schema_is_rebound_to_new_subject(
+    rest_async_client: Client,
+    registry_async_client: Client,
+    admin_client: KafkaAdminClient,
+) -> None:
+    topic_name_1 = new_topic(admin_client)
+    topic_name_2 = new_topic(admin_client)
+    subject_1 = f"{topic_name_1}-value"
+    subject_2 = f"{topic_name_2}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name_1, topic_name_2], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    schema_1 = {
+        "type": "record",
+        "name": "Schema1",
+        "fields": [
+            {
+                "name": "name",
+                "type": "string",
+            },
+        ],
+    }
+
+    res = await registry_async_client.post(
+        f"subjects/{subject_1}/versions",
+        json={"schema": json.dumps(schema_1)},
+    )
+    assert res.status_code == 200
+    schema_1_id = res.json()["id"]
+
+    # Warm serializer cache with schema string -> id mapping.
+    res = await rest_async_client.post(
+        f"/topics/{topic_name_1}",
+        json={"value_schema": json.dumps(schema_1), "records": [{"value": {"name": "Mr. Mustache"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+    assert res.json()["value_schema_id"] == schema_1_id
+
+    # Producing the same schema to another topic should bind subject_2 as well.
+    res = await rest_async_client.post(
+        f"/topics/{topic_name_2}",
+        json={"value_schema": json.dumps(schema_1), "records": [{"value": {"name": "Mr. Mustache"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert res.status_code == 200
+    assert res.json()["value_schema_id"] == schema_1_id
+
+    subjects = (await registry_async_client.get("subjects")).json()
+    assert subject_1 in subjects
+    assert subject_2 in subjects
+
+    subject_2_latest = (await registry_async_client.get(f"subjects/{subject_2}/versions/latest")).json()
+    assert subject_2_latest["id"] == schema_1_id
+
+
+async def test_publish_with_value_schema_cache_not_cross_subject(
+    rest_async_client: Client,
+    registry_async_client: Client,
+    admin_client: KafkaAdminClient,
+) -> None:
+    topic_name_1 = new_topic(admin_client)
+    topic_name_2 = new_topic(admin_client)
+    subject_1 = f"{topic_name_1}-value"
+    subject_2 = f"{topic_name_2}-value"
+
+    await wait_for_topics(rest_async_client, topic_names=[topic_name_1, topic_name_2], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    schema_1 = {
+        "type": "record",
+        "name": "Schema1",
+        "fields": [
+            {
+                "name": "name",
+                "type": "string",
+            },
+        ],
+    }
+
+    first_res = await rest_async_client.post(
+        f"/topics/{topic_name_1}",
+        json={"value_schema": json.dumps(schema_1), "records": [{"value": {"name": "First"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert first_res.status_code == 200
+    first_schema_id = first_res.json()["value_schema_id"]
+
+    second_res = await rest_async_client.post(
+        f"/topics/{topic_name_2}",
+        json={"value_schema": json.dumps(schema_1), "records": [{"value": {"name": "Second"}}]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert second_res.status_code == 200
+    second_schema_id = second_res.json()["value_schema_id"]
+    assert second_schema_id == first_schema_id
+
+    subjects = (await registry_async_client.get("subjects")).json()
+    assert subject_1 in subjects
+    assert subject_2 in subjects
+
+    subject_1_latest = (await registry_async_client.get(f"subjects/{subject_1}/versions/latest")).json()
+    subject_2_latest = (await registry_async_client.get(f"subjects/{subject_2}/versions/latest")).json()
+    assert subject_1_latest["id"] == first_schema_id
+    assert subject_2_latest["id"] == first_schema_id
+
+
 async def test_brokers(rest_async_client: Client) -> None:
     res = await rest_async_client.get("/brokers")
     assert res.ok

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -374,6 +374,41 @@ async def test_deserialization_fails(karapace_container: KarapaceContainer):
     assert mock_registry_client.method_calls == [call.get_schema_for_id(1)]
 
 
+async def test_upsert_id_for_schema_does_not_reuse_cached_id_from_other_subject(
+    karapace_container: KarapaceContainer,
+) -> None:
+    subject_1 = Subject("upsert-subject-cache-subject-1")
+    subject_2 = Subject("upsert-subject-cache-subject-2")
+    schema_id_1 = 81
+    schema_id_2 = 82
+    mock_registry_client = Mock()
+
+    post_first_future = asyncio.Future()
+    post_first_future.set_result(schema_id_1)
+    get_schema_for_id_future = asyncio.Future()
+    get_schema_for_id_future.set_result((TYPED_AVRO_SCHEMA, [subject_1]))
+    post_second_future = asyncio.Future()
+    post_second_future.set_result(schema_id_2)
+
+    mock_registry_client.post_new_schema.side_effect = [
+        post_first_future,
+        post_second_future,
+    ]
+    mock_registry_client.get_schema_for_id.return_value = get_schema_for_id_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    first_schema_id = await serializer.upsert_id_for_schema(TYPED_AVRO_SCHEMA, subject_1)
+    second_schema_id = await serializer.upsert_id_for_schema(TYPED_AVRO_SCHEMA, subject_2)
+
+    assert first_schema_id == schema_id_1
+    assert second_schema_id == schema_id_2
+    assert mock_registry_client.method_calls == [
+        call.post_new_schema(subject_1, TYPED_AVRO_SCHEMA),
+        call.get_schema_for_id(schema_id_1),
+        call.post_new_schema(subject_2, TYPED_AVRO_SCHEMA),
+    ]
+
+
 @pytest.mark.parametrize(
     "expected_subject,strategy,subject_type",
     (


### PR DESCRIPTION
# About this change - What it does

Fix #1260 

Cache is still in place: both schemas_to_ids[str(schema)] and topic_schema_cache remain.

For value_schema requests:

1. REST derives the expected subject from the topic (<topic>-value / <topic>-key).
2. It may get a schema_id from cache by schema string.
3. New part: before reusing that cached ID, it checks that this ID is actually linked to the expected subject (via Schema Registry subjects for that ID).
4. If the subject matches, cache hit is accepted.
I5. f it does not match, treat it as a subject-level cache miss and continue normal flow: lookup -> register.

For explicit value_schema_id:
1. Behavior stays strict: if that ID is not linked to the topic subject, return 422 Invalid schema