### PR TITLE
json schema fix KeyError: 'anyOf' when reader uses type array shorthand

### DIFF
--- a/src/karapace/core/compatibility/jsonschema/checks.py
+++ b/src/karapace/core/compatibility/jsonschema/checks.py
@@ -875,7 +875,8 @@ def compatibility_subschemas(
 
     if reader_type in (Subschema.ANY_OF, Subschema.ONE_OF) and not writer_has_subschema:
         assert isinstance(reader_type, Subschema)
-        for reader_subschema in reader_schema[reader_type.value]:
+        assert reader_subschemas is not None
+        for reader_subschema in reader_subschemas:
             rec_result = compatibility_rec(reader_subschema, writer_schema, subschema_location)
             if is_compatible(rec_result):
                 return rec_result

--- a/tests/schemas/json_schemas.py
+++ b/tests/schemas/json_schemas.py
@@ -83,6 +83,16 @@ ONEOF_INT_SCHEMA = parse_jsonschema_definition('{"oneOf":[{"type":"integer"}]}')
 ONEOF_NUMBER_SCHEMA = parse_jsonschema_definition('{"oneOf":[{"type":"number"}]}')
 TYPES_STRING_INT_SCHEMA = parse_jsonschema_definition('{"type":["string","integer"]}')
 TYPES_STRING_SCHEMA = parse_jsonschema_definition('{"type":["string"]}')
+TYPES_STRING_NULL_SCHEMA = parse_jsonschema_definition('{"type":["string","null"]}')
+TYPES_INT_BOOL_SCHEMA = parse_jsonschema_definition('{"type":["integer","boolean"]}')
+TYPES_STRING_NULL_BOOL_SCHEMA = parse_jsonschema_definition('{"type":["string","null","boolean"]}')
+A_STRING_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","properties":{"a":{"type":"string"}}}')
+A_STRING_OR_NULL_OBJECT_SCHEMA = parse_jsonschema_definition(
+    '{"type":"object","properties":{"a":{"type":["string","null"]}}}'
+)
+A_INT_OR_BOOL_OBJECT_SCHEMA = parse_jsonschema_definition(
+    '{"type":"object","properties":{"a":{"type":["integer","boolean"]}}}'
+)
 EMPTY_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","additionalProperties":false}')
 A_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","properties":{"a":{}}}')
 A_INT_OBJECT_SCHEMA = parse_jsonschema_definition(

--- a/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
+++ b/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
@@ -100,8 +100,14 @@ from tests.schemas.json_schemas import (
     TUPLE_OF_INT_OPEN_SCHEMA,
     TUPLE_OF_INT_SCHEMA,
     TUPLE_OF_INT_WITH_ADDITIONAL_INT_SCHEMA,
+    TYPES_INT_BOOL_SCHEMA,
     TYPES_STRING_INT_SCHEMA,
+    TYPES_STRING_NULL_BOOL_SCHEMA,
+    TYPES_STRING_NULL_SCHEMA,
     TYPES_STRING_SCHEMA,
+    A_INT_OR_BOOL_OBJECT_SCHEMA,
+    A_STRING_OBJECT_SCHEMA,
+    A_STRING_OR_NULL_OBJECT_SCHEMA,
 )
 
 COMPATIBLE = SchemaCompatibilityResult(SchemaCompatibilityType.compatible)
@@ -1452,6 +1458,61 @@ def test_type_with_list():
         reader=TYPES_STRING_INT_SCHEMA,
         writer=TYPES_STRING_SCHEMA,
         msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_type_array_reader_vs_plain_writer():
+    # Regression for KeyError: 'anyOf' raised from compatibility_subschemas when
+    # the reader uses the "type": [...] shorthand (which is normalized to an
+    # anyOf in memory but has no anyOf key on the dict) and the writer has no
+    # subschema construct. See: checks.py:compatibility_subschemas.
+
+    # --- Compatible: reader type-array is a superset of writer's single type ---
+
+    # The customer-reported case: string -> ["string", "null"] (nullable widening)
+    schemas_are_compatible(
+        reader=TYPES_STRING_NULL_SCHEMA,
+        writer=STRING_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+    # Nested: the same widening inside an object property
+    schemas_are_compatible(
+        reader=A_STRING_OR_NULL_OBJECT_SCHEMA,
+        writer=A_STRING_OBJECT_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+    # Non-null widening: integer -> ["integer", "boolean"]
+    schemas_are_compatible(
+        reader=TYPES_INT_BOOL_SCHEMA,
+        writer=INT_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+    # 3-way type-array still works: string -> ["string", "null", "boolean"]
+    schemas_are_compatible(
+        reader=TYPES_STRING_NULL_BOOL_SCHEMA,
+        writer=STRING_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+    # --- Incompatible: writer's single type is not in the reader's type-array ---
+
+    # boolean -> ["string", "null"]: old boolean data no longer validates
+    not_schemas_are_compatible(
+        reader=TYPES_STRING_NULL_SCHEMA,
+        writer=BOOLEAN_SCHEMA,
+        msg=INCOMPATIBLE_READER_CHANGED_FIELD_TYPE,
+    )
+    # Nested: {a: integer} -> {a: ["string", "null"]}
+    not_schemas_are_compatible(
+        reader=A_STRING_OR_NULL_OBJECT_SCHEMA,
+        writer=A_INT_OPEN_OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_CHANGED_FIELD_TYPE,
+    )
+    # Nested: {a: string} -> {a: ["integer", "boolean"]}
+    not_schemas_are_compatible(
+        reader=A_INT_OR_BOOL_OBJECT_SCHEMA,
+        writer=A_STRING_OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_CHANGED_FIELD_TYPE,
     )
 
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Issue : 
when registering a new json schema version under `BACKWARD` compatibility if a field's type was widened from `"type": "string"` to `"type": ["string", "null"]` (or any other `"type": [...]` shorthand), there is a schema compatibility error (500 internal server err) 

Fix : 
Change `for reader_subschema in reader_schema[reader_type.value]:` to `for reader_subschema in reader_subschemas:`
which now returns 'anyOf' key to the dict and compatibility shouldn't fail.

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
