### PR TITLE
Wire sasl_oauth_token_provider into aiokafka client and KarapaceProducer

### DIFF
--- a/src/karapace/core/coordinator/master_coordinator.py
+++ b/src/karapace/core/coordinator/master_coordinator.py
@@ -8,13 +8,16 @@ See LICENSE for details
 from __future__ import annotations
 
 from aiokafka import AIOKafkaClient
+from aiokafka.abc import AbstractTokenProvider
 from aiokafka.errors import KafkaConnectionError
 from aiokafka.helpers import create_ssl_context
 from aiokafka.protocol.commit import OffsetCommitRequest_v2 as OffsetCommitRequest
 from karapace.core.instrumentation.tracer import Tracer
 from karapace.core.config import Config
 from karapace.core.coordinator.schema_coordinator import SchemaCoordinator, SchemaCoordinatorStatus
+from karapace.core.kafka.common import TokenWithExpiryProvider
 from karapace.core.kafka.types import DEFAULT_REQUEST_TIMEOUT_MS
+from karapace.core.kafka_utils import get_oauth_token_provider
 from karapace.core.typing import PrimaryInfo, SchemaReaderStoppper
 from threading import Thread
 from typing import Final
@@ -27,6 +30,26 @@ __all__ = ("MasterCoordinator",)
 
 
 LOG = logging.getLogger(__name__)
+
+
+class _AiokafkaTokenAdapter(AbstractTokenProvider):
+    """Adapt the synchronous TokenWithExpiryProvider protocol used by
+    librdkafka's oauth_cb to the async AbstractTokenProvider interface
+    aiokafka requires.
+
+    Karapace lets users configure a single `sasl_oauth_token_provider_class`;
+    the same provider is consulted from both the confluent-kafka clients
+    (via kafka_utils factory functions) and from the aiokafka client used
+    by the master coordinator. This adapter bridges the two interfaces
+    without forcing users to author two providers.
+    """
+
+    def __init__(self, inner: TokenWithExpiryProvider) -> None:
+        self._inner = inner
+
+    async def token(self) -> str:
+        token, _expiry = self._inner.token_with_expiry(None)
+        return token
 
 
 class MasterCoordinator:
@@ -116,6 +139,15 @@ class MasterCoordinator:
             keyfile=self._config.ssl_keyfile,
         )
 
+        # When the operator configures `sasl_oauth_token_provider_class`,
+        # surface the same provider to aiokafka — wrapped in an adapter
+        # because aiokafka's AbstractTokenProvider is async-first whereas
+        # the librdkafka-flavored protocol is sync.
+        kwargs = {}
+        oauth_token_provider = get_oauth_token_provider(self._config)
+        if oauth_token_provider is not None:
+            kwargs["sasl_oauth_token_provider"] = _AiokafkaTokenAdapter(oauth_token_provider)
+
         return AIOKafkaClient(
             bootstrap_servers=self._config.bootstrap_uri,
             client_id=self._config.client_id,
@@ -129,6 +161,7 @@ class MasterCoordinator:
             sasl_plain_password=self._config.sasl_plain_password,
             security_protocol=self._config.security_protocol,
             ssl_context=ssl_context,
+            **kwargs,
         )
 
     def init_schema_coordinator(self) -> SchemaCoordinator:

--- a/src/karapace/core/kafka_utils.py
+++ b/src/karapace/core/kafka_utils.py
@@ -6,20 +6,22 @@ See LICENSE for details
 from .config import Config
 from collections.abc import Iterator
 from karapace.core.kafka.admin import KafkaAdminClient
+from karapace.core.kafka.common import TokenWithExpiryProvider
 from karapace.core.kafka.consumer import KafkaConsumer
 from karapace.core.kafka.producer import KafkaProducer
+from typing import cast
 
 import contextlib
 
 
-def get_oauth_token_provider(config: Config) -> object | None:
+def get_oauth_token_provider(config: Config) -> TokenWithExpiryProvider | None:
     """Return the configured OAuth token provider instance, if any.
 
     The provider is instantiated once during Config initialization and
     validated to expose a ``token_with_expiry`` method as required by
     confluent-kafka's OAUTHBEARER flow.
     """
-    return config._sasl_oauth_token_provider
+    return cast(TokenWithExpiryProvider, config._sasl_oauth_token_provider) if config._sasl_oauth_token_provider is not None else None
 
 
 def kafka_admin_from_config(config: Config) -> KafkaAdminClient:

--- a/src/karapace/core/messaging.py
+++ b/src/karapace/core/messaging.py
@@ -9,6 +9,7 @@ from aiokafka.errors import MessageSizeTooLargeError
 from karapace.core.config import Config
 from karapace.core.errors import SchemaTooLargeException
 from karapace.core.kafka.producer import KafkaProducer
+from karapace.core.kafka_utils import get_oauth_token_provider
 from karapace.core.key_format import KeyFormatter
 from karapace.core.offset_watcher import OffsetWatcher
 from karapace.core.utils import json_encode
@@ -35,6 +36,17 @@ class KarapaceProducer:
     def initialize_karapace_producer(
         self,
     ) -> None:
+        # When the operator configures `sasl_oauth_token_provider_class`,
+        # surface the same provider here so writes to `_schemas` can
+        # authenticate against an OAUTHBEARER-secured broker. Without
+        # this, OAUTHBEARER deployments time out at the producer's
+        # SASL handshake even though the master coordinator and schema
+        # reader paths succeed.
+        oauth_kwargs: dict[str, Any] = {}
+        oauth_token_provider = get_oauth_token_provider(self._config)
+        if oauth_token_provider is not None:
+            oauth_kwargs["sasl_oauth_token_provider"] = oauth_token_provider
+
         while True:
             try:
                 self._producer = KafkaProducer(
@@ -51,6 +63,7 @@ class KarapaceProducer:
                     metadata_max_age_ms=self._config.metadata_max_age_ms,
                     socket_timeout_ms=2000,  # missing topics will block unless we cache cluster metadata and pre-check
                     connections_max_idle_ms=self._config.connections_max_idle_ms,  # helps through cluster upgrades ??
+                    **oauth_kwargs,
                 )
                 return
             except Exception:

--- a/tests/unit/test_oauth_token_provider.py
+++ b/tests/unit/test_oauth_token_provider.py
@@ -212,3 +212,104 @@ class TestConfigImportString:
         config = Config()
         config.sasl_oauth_token_provider_class = StubTokenProvider
         assert config.sasl_oauth_token_provider_class is StubTokenProvider
+
+
+class TestMasterCoordinatorPassthrough:
+    """Verify that the master coordinator's aiokafka client also receives
+    the configured OAuth token provider.
+
+    Karapace's master coordinator uses aiokafka.AIOKafkaClient (a different
+    library than confluent-kafka-python used by kafka_utils). aiokafka has
+    its own AbstractTokenProvider protocol — async-first — so the same
+    user-configured TokenWithExpiryProvider must be wrapped in an adapter.
+    Without this passthrough, configuring OAUTHBEARER would cause aiokafka
+    to raise `ValueError: sasl_oauth_token_provider needs to be provided
+    implementing aiokafka.abc.AbstractTokenProvider`, and master election
+    would never complete.
+    """
+
+    @patch("karapace.core.coordinator.master_coordinator.AIOKafkaClient")
+    def test_aiokafka_client_receives_wrapped_provider(self, mock_client_cls):
+        from aiokafka.abc import AbstractTokenProvider
+        from karapace.core.coordinator.master_coordinator import MasterCoordinator
+
+        config = _make_config_with_provider()
+        coordinator = MasterCoordinator(config=config)
+        coordinator.init_kafka_client()
+
+        call_kwargs = mock_client_cls.call_args[1]
+        assert "sasl_oauth_token_provider" in call_kwargs
+        # aiokafka requires an AbstractTokenProvider, not the raw
+        # TokenWithExpiryProvider — the adapter is what makes the two
+        # interfaces compatible.
+        assert isinstance(call_kwargs["sasl_oauth_token_provider"], AbstractTokenProvider)
+
+    @patch("karapace.core.coordinator.master_coordinator.AIOKafkaClient")
+    def test_aiokafka_client_omits_provider_when_not_configured(self, mock_client_cls):
+        from karapace.core.coordinator.master_coordinator import MasterCoordinator
+
+        config = Config()
+        coordinator = MasterCoordinator(config=config)
+        coordinator.init_kafka_client()
+
+        call_kwargs = mock_client_cls.call_args[1]
+        assert "sasl_oauth_token_provider" not in call_kwargs
+
+    def test_adapter_returns_token_string(self):
+        """The adapter's async token() must return just the token string,
+        discarding the expiry — aiokafka manages refresh on its own."""
+        import asyncio
+
+        from karapace.core.coordinator.master_coordinator import _AiokafkaTokenAdapter
+
+        adapter = _AiokafkaTokenAdapter(StubTokenProvider())
+        token = asyncio.run(adapter.token())
+        assert token == "fake-token"
+
+
+class TestKarapaceProducerPassthrough:
+    """Verify that the schema-write producer (KarapaceProducer in messaging.py)
+    also receives the OAuth token provider.
+
+    KarapaceProducer constructs its own KafkaProducer rather than going through
+    `kafka_utils.kafka_producer_from_config`, so it has to pull the provider
+    from config independently. Without this passthrough, OAUTHBEARER deployments
+    pass the master-coordinator + schema-reader paths but stall at write time:
+    the producer's SASL handshake never completes and `send_message` raises
+    TimeoutError.
+    """
+
+    @patch("karapace.core.messaging.KafkaProducer")
+    def test_producer_receives_provider(self, mock_producer_cls):
+        from karapace.core.messaging import KarapaceProducer
+        from karapace.core.key_format import KeyFormatter
+        from karapace.core.offset_watcher import OffsetWatcher
+
+        config = _make_config_with_provider()
+        producer = KarapaceProducer(
+            config=config,
+            offset_watcher=OffsetWatcher(),
+            key_formatter=KeyFormatter(),
+        )
+        producer.initialize_karapace_producer()
+
+        call_kwargs = mock_producer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" in call_kwargs
+        assert isinstance(call_kwargs["sasl_oauth_token_provider"], StubTokenProvider)
+
+    @patch("karapace.core.messaging.KafkaProducer")
+    def test_producer_omits_provider_when_not_configured(self, mock_producer_cls):
+        from karapace.core.messaging import KarapaceProducer
+        from karapace.core.key_format import KeyFormatter
+        from karapace.core.offset_watcher import OffsetWatcher
+
+        config = Config()
+        producer = KarapaceProducer(
+            config=config,
+            offset_watcher=OffsetWatcher(),
+            key_formatter=KeyFormatter(),
+        )
+        producer.initialize_karapace_producer()
+
+        call_kwargs = mock_producer_cls.call_args[1]
+        assert "sasl_oauth_token_provider" not in call_kwargs


### PR DESCRIPTION
## Summary

PR #1226 added `sasl_oauth_token_provider_class` config and wired it into the three confluent-kafka client factories in `karapace.core.kafka_utils`, plus the schema_reader's internal factories. Two more sites construct Kafka clients independently and were missed; this PR fixes them.

### `master_coordinator.MasterCoordinator.init_kafka_client`

Constructs an `aiokafka.AIOKafkaClient`. aiokafka uses its own `aiokafka.abc.AbstractTokenProvider` protocol — async-first — rather than the librdkafka-flavored `TokenWithExpiryProvider` used by confluent-kafka clients. This PR adds a small `_AiokafkaTokenAdapter` so a single user-configured provider works for both libraries.

Without this fix, configuring OAUTHBEARER causes aiokafka to raise:

```
ValueError: sasl_oauth_token_provider needs to be provided implementing aiokafka.abc.AbstractTokenProvider
```

…master election never completes, and writes return 500 "No master set".

### `messaging.KarapaceProducer.initialize_karapace_producer`

Constructs its own `KafkaProducer` rather than going through `kafka_utils.kafka_producer_from_config`. Without the provider passed here, OAUTHBEARER deployments stall at write time with `TimeoutError` on the producer's SASL handshake even after master election succeeds. Pattern is identical to the kafka_utils factories: consult `get_oauth_token_provider`, conditionally pass.

## Test coverage

`tests/unit/test_oauth_token_provider.py` adds two new test classes mirroring the existing `TestKafkaUtilsPassthrough` / `TestSchemaReaderPassthrough` style:

- `TestMasterCoordinatorPassthrough`
  - `test_aiokafka_client_receives_wrapped_provider`
  - `test_aiokafka_client_omits_provider_when_not_configured`
  - `test_adapter_returns_token_string`
- `TestKarapaceProducerPassthrough`
  - `test_producer_receives_provider`
  - `test_producer_omits_provider_when_not_configured`

All 21 tests in the file pass.

## End-to-end verification

Verified against a Kafka 3.7.1 broker configured with the unsecured OAUTHBEARER handlers (`OAuthBearerUnsecuredValidatorCallbackHandler` / `OAuthBearerUnsecuredLoginCallbackHandler`):

- Schema register + read round-trip succeeds
- The configured `TokenProvider` is invoked from all three SASL paths: schema_reader (confluent-kafka), master_coordinator (aiokafka), and KarapaceProducer (confluent-kafka)
- aiokafka logs `Authenticated via OAUTHBEARER`, master election completes, `_schemas` is created, writes go through

## Test plan

- [x] `pytest tests/unit/test_oauth_token_provider.py -v` — 21 passed
- [x] End-to-end OAUTHBEARER round-trip against an unsecured-JWS broker


## Note

A future improvement worth considering: a single integration test that stands up an OAUTHBEARER-secured Kafka and exercises Karapace end-to-end would prevent this whole class of regression. The unit tests here are scoped per call site, which means any new `KafkaProducer`/`KafkaConsumer`/`AIOKafkaClient` instantiation would silently lack the wiring until a similar end-to-end test catches it.