### PR TITLE
Split OIDC AuthN and AuthZ in Schema Registry

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -140,6 +140,7 @@ unit-tests-in-docker: start-karapace-docker-resources
 	rm -fr runtime/*
 
 .PHONY: e2e-tests-in-docker
+e2e-tests-in-docker: export COMPOSE_PROFILES = e2e
 e2e-tests-in-docker: stop-karapace-docker-resources start-karapace-docker-resources
 	rm -fr runtime/*
 	sleep 10

--- a/README.rst
+++ b/README.rst
@@ -118,10 +118,15 @@ or with curl ::
 
 To enable oidc authentication on the karapace, configure oidc jwks url config details ::
 
+   sasl_oauthbearer_authentication_enabled: bool = True
    sasl_oauthbearer_jwks_endpoint_url = "",
    sasl_oauthbearer_expected_issuer = "",
    sasl_oauthbearer_expected_audience = "",
    sasl_oauthbearer_sub_claim_name = "sub",
+
+When ``sasl_oauthbearer_authentication_enabled`` is true, every request must carry a valid
+Bearer token (the JWT signature, issuer and audience are verified via JWKS). Authorization
+(role-based access) is opt-in on top of this with ``sasl_oauthbearer_authorization_enabled``.
 
 There is a detailed section about OAuth2 authentication for karapace below.
 
@@ -131,6 +136,11 @@ To enable oidc authorization on karapace, configure the below params together wi
    sasl_oauthbearer_client_id: str | None = None
    sasl_oauthbearer_roles_claim_path: str | None = None
    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
+
+Note: ``sasl_oauthbearer_authorization_enabled=true`` requires
+``sasl_oauthbearer_authentication_enabled=true``. For backwards compatibility, enabling
+authorization without explicitly enabling authentication will auto-enable authentication and
+log a deprecation warning — set both flags explicitly.
 
 There is a detailed section about OAuth2 authorization for karapace below.
 
@@ -677,13 +687,15 @@ eg. ``Authorization: Bearer $JWT``. If a ``Bearer`` token is present in schema r
 
 Below here is an example of karapace OpenId connect config ::
 
+   sasl_oauthbearer_authentication_enabled: bool = True
    sasl_oauthbearer_jwks_endpoint_url = "http://localhost:8383/realms/karapace/protocol/openid-connect/certs",
    sasl_oauthbearer_expected_issuer = "http://localhost:8383/realms/karapace",
    sasl_oauthbearer_expected_audience = "account",
    sasl_oauthbearer_sub_claim_name = "sub",
 
-  For authorization::
+  For authorization (requires authentication to be enabled)::
 
+   sasl_oauthbearer_authentication_enabled: bool = True
    sasl_oauthbearer_authorization_enabled: bool = False
    sasl_oauthbearer_client_id: str | None = None
    sasl_oauthbearer_roles_claim_path: str | None = None
@@ -692,6 +704,7 @@ Below here is an example of karapace OpenId connect config ::
 
 Below here is an example of karapace OpenId connect docker config ::
 
+    KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: True
     KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
     KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
     KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "account"
@@ -699,11 +712,21 @@ Below here is an example of karapace OpenId connect docker config ::
 
   For authorization, example config::
 
+  KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: True
   KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: True
   KARAPACE_SASL_OAUTHBEARER_CLIENT_ID: "karapace"
   KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.[client_id].roles"
   KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: dict[str, list[str]] = {"GET": ["schema:read", "subject:read"],
                                                            "POST": ["schema:write", "subject:write"], "PUT": [], "DELETE": []}
+
+
+Production hardening notes
+--------------------------
+
+* ``sasl_oauthbearer_jwks_endpoint_url`` must use ``https://``; startup fails otherwise.
+  The ``sasl_oauthbearer_allow_insecure_jwks`` flag overrides this for dev/test only.
+* ``/docs``, ``/redoc``, ``/openapi.json`` bypass the auth gate (by design, for Swagger UI).
+  Block them at the reverse proxy in production to avoid leaking the API surface.
 
 
 Testing the authentication and authorization with docker

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -86,8 +86,11 @@ services:
       KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
       KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
       KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
       KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: true
       KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
+      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
+      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
@@ -144,14 +147,68 @@ services:
       KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
       KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
       KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
       KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: true
       KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
+      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
+      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_CLIENT_ID: "karapace-client"
       KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
       KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
+      KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
+
+  # Schema Registry running with OIDC authentication only (no role-based authorization).
+  # Used to verify the sasl_oauthbearer_authentication_enabled flag in isolation.
+  karapace-schema-registry-authn-only:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-schema-registry-authn-only
+    container_name: karapace-schema-registry-authn-only
+    entrypoint:
+      - python3
+      - -m
+      - karapace
+    depends_on:
+      - kafka
+      - opentelemetry-collector
+    ports:
+      - 8281:8281
+    volumes:
+      - ./certs:/opt/karapace/certs
+    environment:
+      KARAPACE_KARAPACE_REGISTRY: true
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-schema-registry-authn-only
+      KARAPACE_ADVERTISED_PROTOCOL: https
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_PORT: 8281
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_CLIENT_ID: karapace-schema-registry-authn-only
+      KARAPACE_GROUP_ID: karapace-schema-registry-authn-only
+      KARAPACE_MASTER_ELECTION_STRATEGY: highest
+      KARAPACE_MASTER_ELIGIBILITY: true
+      KARAPACE_TOPIC_NAME: _schemas_authn_only
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_COMPATIBILITY: FULL
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_TAGS__APP: karapace-schema-registry-authn-only
+      KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
+      KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
+      KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
+      KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: false
+      KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
+      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
+      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
+      KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
   karapace-rest-proxy:

--- a/src/karapace/api/middlewares/__init__.py
+++ b/src/karapace/api/middlewares/__init__.py
@@ -12,12 +12,58 @@ from prometheus_client import Counter
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import Info, request_size, requests, response_size
 
-from karapace.api.oidc.middleware import OIDCMiddleware
+from karapace.api.oidc.middleware import OIDCMiddleware, TokenExpiredError
 from karapace.core.auth import AuthenticationError
 from karapace.core.config import Config
 import logging
 
 log = logging.getLogger(__name__)
+
+
+def _authenticate_and_authorize(request: Request, config: Config, oidc_middleware: OIDCMiddleware) -> JSONResponse | None:
+    """Run the OIDC auth gate. Return a JSONResponse on failure, or None to continue."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return JSONResponse(
+            status_code=401,
+            content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
+        )
+
+    token = auth_header[len("Bearer ") :].strip()
+    if not token:
+        return JSONResponse(
+            status_code=401,
+            content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
+        )
+
+    try:
+        payload = oidc_middleware.validate_jwt(token)
+    except TokenExpiredError:
+        return JSONResponse(
+            status_code=401,
+            content={"error": "Unauthorized", "reason": "Token expired"},
+        )
+    except AuthenticationError:
+        return JSONResponse(
+            status_code=401,
+            content={"error": "Unauthorized", "reason": "Invalid token/payload"},
+        )
+
+    # Expose only the configured subject claim to handlers, never the full payload.
+    # Prevents downstream code from picking up attacker-controlled claims (e.g. "roles")
+    # and using them for authz decisions.
+    request.state.user = payload.get(oidc_middleware.claim_name) if oidc_middleware.claim_name else None
+    log.debug("Authenticated")
+
+    if config.sasl_oauthbearer_authorization_enabled:
+        try:
+            oidc_middleware.authorize_request(payload, request.method)
+        except HTTPException as e:
+            return JSONResponse(
+                {"error": "Authorization error", "reason": e.detail},
+                status_code=e.status_code,
+            )
+    return None
 
 
 def setup_middlewares(app: FastAPI, config: Config) -> None:
@@ -33,36 +79,10 @@ def setup_middlewares(app: FastAPI, config: Config) -> None:
         if request.url.path in config.sasl_oauthbearer_skip_auth_paths:
             return await call_next(request)
 
-        # Check for bearer token in header
-        auth_header = request.headers.get("Authorization")
-
-        if config.sasl_oauthbearer_authorization_enabled:
-            if not auth_header or not auth_header.startswith("Bearer "):
-                # Fail fast if header is missing or invalid
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
-                )
-
-            # Header exists and starts with Bearer → validate JWT
-            token = auth_header.split(" ", 1)[1]
-            try:
-                payload = oidc_middleware.validate_jwt(token)
-                request.state.user = payload
-                log.debug("Authenticated")
-            except AuthenticationError:
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "Unauthorized", "reason": "Invalid token/payload"},
-                )
-
-            try:
-                oidc_middleware.authorize_request(payload, request.method)
-            except HTTPException as e:
-                return JSONResponse(
-                    {"error": "Authorization error", "reason": e.detail},
-                    status_code=e.status_code,
-                )
+        if config.sasl_oauthbearer_authentication_enabled:
+            failure = _authenticate_and_authorize(request, config, oidc_middleware)
+            if failure is not None:
+                return failure
 
         response = await call_next(request)
 

--- a/src/karapace/api/oidc/middleware.py
+++ b/src/karapace/api/oidc/middleware.py
@@ -8,11 +8,14 @@ from typing import Any
 import jwt
 import logging
 from fastapi import FastAPI, HTTPException
-from jwt import PyJWKClient, InvalidTokenError
-from starlette.responses import JSONResponse
+from jwt import ExpiredSignatureError, PyJWKClient, InvalidTokenError
 from karapace.core.auth import AuthenticationError
 from karapace.core.config import Config
-from starlette.types import Scope, Receive, Send
+
+
+class TokenExpiredError(AuthenticationError):
+    """Raised when an OIDC JWT is rejected because its `exp` claim is in the past."""
+
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +30,7 @@ class OIDCMiddleware:
         self.issuer = config.sasl_oauthbearer_expected_issuer
         self.audience = config.sasl_oauthbearer_expected_audience
         self.claim_name = config.sasl_oauthbearer_sub_claim_name
+        self.authentication_enabled = config.sasl_oauthbearer_authentication_enabled
         self.authorization_enabled = config.sasl_oauthbearer_authorization_enabled
         self.client_id = config.sasl_oauthbearer_client_id
         self.sasl_oauthbearer_method_roles: dict[str, list[str]] = config.sasl_oauthbearer_method_roles
@@ -37,6 +41,18 @@ class OIDCMiddleware:
 
         # Validate required fields if JWKS URL is set
         if self.jwks_url:
+            if not self.jwks_url.lower().startswith("https://"):
+                if not config.sasl_oauthbearer_allow_insecure_jwks:
+                    # Plain HTTP lets an in-path attacker swap the signing keys and
+                    # forge tokens that pass validation. Fail closed by default.
+                    raise ValueError(
+                        "OIDC config error: sasl_oauthbearer_jwks_endpoint_url must use https://. "
+                        "Set sasl_oauthbearer_allow_insecure_jwks=true to override (dev only)."
+                    )
+                log.warning(
+                    "OIDC: JWKS URL uses plain HTTP (%s) — INSECURE override is active. " "DO NOT use in production.",
+                    self.jwks_url,
+                )
             if not self.issuer or not self.audience:
                 raise ValueError(
                     "OIDC config error: 'issuer' and 'audience' must be set if 'jwks_endpoint_url' is provided."
@@ -48,23 +64,23 @@ class OIDCMiddleware:
                 self.audience,
             )
 
-            self._jwks_client = PyJWKClient(self.jwks_url)
+            # lifespan caps how long a key stays cached after IdP rotation/revocation.
+            # max_cached_keys=16 is generous; IdPs typically expose 1-3 active signing keys.
+            self._jwks_client = PyJWKClient(self.jwks_url, cache_keys=True, lifespan=300, max_cached_keys=16)
 
             log.info("OIDC Authorization enabled: %s", self.authorization_enabled)
             if self.authorization_enabled:
                 if self.client_id is None or self.sasl_oauthbearer_roles_claim_path is None:
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Invalid configuration: client_id and roles_claim_path are required when authorization is enabled.",
+                    raise ValueError(
+                        "OIDC config error: client_id and roles_claim_path are required when authorization is enabled."
                     )
 
                 required_http_methods = set(self.sasl_oauthbearer_method_roles.keys())
                 # Validate required HTTP methods in method_roles
                 missing_methods = required_http_methods - self.sasl_oauthbearer_method_roles.keys()
                 if missing_methods:
-                    raise HTTPException(
-                        status_code=500,
-                        detail=f"Invalid configuration: method_roles is missing definitions for: {', '.join(sorted(missing_methods))}",
+                    raise ValueError(
+                        f"OIDC config error: method_roles is missing definitions for: {', '.join(sorted(missing_methods))}"
                     )
                 log.info(
                     "OIDC Authorization configured. — client_id: %s, method_roles: %s, roles_claim_path: %s",
@@ -73,13 +89,16 @@ class OIDCMiddleware:
                     self.sasl_oauthbearer_roles_claim_path,
                 )
         else:
+            if self.authentication_enabled or self.authorization_enabled:
+                raise ValueError(
+                    "OIDC config error: sasl_oauthbearer_jwks_endpoint_url is required when "
+                    "authentication or authorization is enabled. Also set expected_issuer and expected_audience."
+                )
             self._jwks_client = None
-            log.warning("OIDC middleware initialized without JWKS URL — token validation will be skipped.")
 
     def validate_jwt(self, token: str) -> dict:
         if not self._jwks_client:
-            log.warning("Skipping JWT validation due to missing JWKS configs. Ignoring authentication.")
-            return {}
+            raise AuthenticationError("OIDC not configured: JWKS client unavailable")
 
         try:
             signing_key = self._jwks_client.get_signing_key_from_jwt(token)
@@ -94,8 +113,16 @@ class OIDCMiddleware:
                 algorithms=self.algorithms,
                 audience=audiences,
                 issuer=self.issuer,
+                # Require exp/iss/aud so a token missing any of these is rejected,
+                # not silently accepted (PyJWT does not require them by default).
+                options={"require": ["exp", "iss", "aud"]},
             )
             return payload
+        except ExpiredSignatureError:
+            # Surface expiry distinctly so callers can return a clearer 401 reason
+            # and operators can debug clock-skew vs. real-auth failures.
+            log.warning("JWT validation failed: token expired")
+            raise TokenExpiredError("OIDC token expired")
         except InvalidTokenError:
             log.error("JWT validation failed")
             raise AuthenticationError("Invalid OIDC token")
@@ -111,7 +138,11 @@ class OIDCMiddleware:
         if self.sasl_oauthbearer_roles_claim_path is not None and self.client_id is not None:
             roles_claim_path = self.sasl_oauthbearer_roles_claim_path.replace("[client_id]", self.client_id)
         else:
-            raise HTTPException(status_code=403, detail="Insufficient roles. Invalid roles_claim_path.")
+            # Same body as the role-mismatch branch below so an attacker cannot use the
+            # response to distinguish a valid token with bad config from a token that
+            # simply lacks the required role.
+            log.error("Authorization misconfigured: roles_claim_path or client_id is unset")
+            raise HTTPException(status_code=403, detail="Forbidden")
 
         user_roles = self.get_roles_from_claim_path(payload, roles_claim_path)
 
@@ -122,7 +153,7 @@ class OIDCMiddleware:
                 user_roles,
                 allowed_roles,
             )
-            raise HTTPException(status_code=403, detail="Insufficient roles")
+            raise HTTPException(status_code=403, detail="Forbidden")
         log.debug("Authorized")
         return True
 
@@ -143,17 +174,3 @@ class OIDCMiddleware:
         except Exception:
             pass
         return []
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        headers = dict(scope.get("headers", []))
-        auth_header = headers.get(b"authorization", b"").decode()
-        if auth_header.startswith("Bearer "):
-            try:
-                payload = self.validate_jwt(auth_header.split(" ", 1)[1])
-                scope["user"] = payload  # inject user info into scope
-            except AuthenticationError as e:
-                response = JSONResponse({"error": "Authentication error", "reason": str(e)}, status_code=401)
-                await response(scope, receive, send)
-                return
-
-        await self.app(scope, receive, send)

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -15,7 +15,7 @@ from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRO
 from karapace.core.typing import ElectionStrategy, NameStrategy
 from karapace.core.utils import json_encode
 from pathlib import Path
-from pydantic import BaseModel, ImportString, PrivateAttr, field_validator
+from pydantic import BaseModel, ImportString, PrivateAttr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 import enum
@@ -25,6 +25,8 @@ import socket
 import ssl
 
 HOSTNAME = socket.gethostname()
+
+log = logging.getLogger(__name__)
 
 
 try:
@@ -131,8 +133,13 @@ class Config(BaseSettings):
     ssl_crlfile: str | None = None
     ssl_password: str | None = None
     sasl_mechanism: str | None = None
+    # OIDC for Schema Registry (OIDCMiddleware). authZ requires authN.
+    sasl_oauthbearer_authentication_enabled: bool = False
     sasl_oauthbearer_authorization_enabled: bool = False
     sasl_oauthbearer_jwks_endpoint_url: str | None = None
+    # Dev/test only — allows http:// JWKS URLs. Plain HTTP lets an in-path attacker swap
+    # the signing keys and forge tokens. Production deployments must leave this false.
+    sasl_oauthbearer_allow_insecure_jwks: bool = False
     sasl_oauthbearer_expected_issuer: str | None = None
     sasl_oauthbearer_expected_audience: str | None = None
     sasl_oauthbearer_sub_claim_name: str | None = "sub"
@@ -140,6 +147,7 @@ class Config(BaseSettings):
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics"]
+    # Kafka SASL client credentials (used by both services; selected by sasl_mechanism).
     sasl_plain_username: str | None = None
     sasl_plain_password: str | None = None
     sasl_oauth_token: str | None = None
@@ -201,6 +209,20 @@ class Config(BaseSettings):
         if isinstance(v, str) and v.lower() == "all":
             return -1
         return v
+
+    @model_validator(mode="after")
+    def _enforce_authn_when_authz_enabled(self) -> Config:
+        # Backwards-compat: prior to splitting authN/authZ, sasl_oauthbearer_authorization_enabled was the
+        # single OIDC switch and implied authentication. Auto-enable authN if only authZ was set, with a
+        # deprecation warning so operators migrate to setting both flags explicitly.
+        if self.sasl_oauthbearer_authorization_enabled and not self.sasl_oauthbearer_authentication_enabled:
+            log.warning(
+                "sasl_oauthbearer_authorization_enabled=true without sasl_oauthbearer_authentication_enabled=true "
+                "is deprecated. Set sasl_oauthbearer_authentication_enabled=true explicitly. "
+                "Auto-enabling authentication for backwards compatibility."
+            )
+            self.sasl_oauthbearer_authentication_enabled = True
+        return self
 
     def get_rest_base_uri(self) -> str:
         return (

--- a/src/karapace/kafka_rest_apis/authentication.py
+++ b/src/karapace/kafka_rest_apis/authentication.py
@@ -84,6 +84,9 @@ def get_auth_config_from_header(
 
 
 def get_expiration_timestamp_from_jwt(token: str) -> int | None:
+    # REST Proxy forwards the Bearer JWT to Kafka via SASL/OAUTHBEARER; Kafka validates
+    # signature/issuer/audience. This unverified decode is only used to evict the per-user
+    # proxy when the token expires. SR `sasl_oauthbearer_*` validation fields do not apply.
     return jwt.decode(token, options={"verify_signature": False}).get("exp")
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -222,6 +222,84 @@ async def registry_async_client_oidc_no_auth_header(
         await client.close()
 
 
+# ---------------------------------------------------------------------------
+# AuthN-only registry fixtures: a separate Schema Registry instance that has
+# sasl_oauthbearer_authentication_enabled=true and authorization_enabled=false.
+# Defined as karapace-schema-registry-authn-only in container/compose.yml.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function", name="registry_authn_only_cluster")
+async def fixture_registry_authn_only_cluster(
+    loop: asyncio.AbstractEventLoop,
+) -> RegistryDescription:
+    endpoint = RegistryEndpoint("https", "karapace-schema-registry-authn-only", 8281)
+    return RegistryDescription(endpoint, "_schemas_authn_only")
+
+
+@pytest.fixture(scope="function", name="registry_async_client_oidc_authn_only")
+async def fixture_registry_async_client_oidc_authn_only(
+    request: SubRequest,
+    registry_authn_only_cluster: RegistryDescription,
+    loop: asyncio.AbstractEventLoop,
+    oidc_token,
+) -> AsyncGenerator[Client, None]:
+    async def factory(auth):
+        return ClientSession(headers={"Authorization": f"Bearer {oidc_token}"})
+
+    client = Client(
+        server_uri=registry_authn_only_cluster.endpoint.to_url(),
+        server_ca=request.config.getoption("server_ca"),
+        client_factory=factory,
+        session_auth=None,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="registry_async_client_oidc_authn_only_invalid")
+async def fixture_registry_async_client_oidc_authn_only_invalid(
+    request: SubRequest,
+    registry_authn_only_cluster: RegistryDescription,
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    async def factory(auth):
+        return ClientSession(headers={"Authorization": "Bearer invalid_token"})
+
+    client = Client(
+        server_uri=registry_authn_only_cluster.endpoint.to_url(),
+        server_ca=request.config.getoption("server_ca"),
+        client_factory=factory,
+        session_auth=None,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="registry_async_client_oidc_authn_only_no_auth_header")
+async def fixture_registry_async_client_oidc_authn_only_no_auth_header(
+    request: SubRequest,
+    registry_authn_only_cluster: RegistryDescription,
+) -> AsyncGenerator[Client, None]:
+    async def factory(auth):
+        return ClientSession(headers={})
+
+    client = Client(
+        server_uri=registry_authn_only_cluster.endpoint.to_url(),
+        server_ca=request.config.getoption("server_ca"),
+        client_factory=factory,
+        session_auth=None,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
 class TokenProvider:
     def __init__(self, token: str, expiry_seconds: int = 3600):
         self._token = token

--- a/tests/e2e/schema_registry/test_oidc.py
+++ b/tests/e2e/schema_registry/test_oidc.py
@@ -82,3 +82,72 @@ async def test_integration_oidc_enabled_no_auth_header_skipped_endpoints_success
     # metrics should not require auth
     res = await registry_async_client_oidc_no_auth_header.get("metrics", json_response=False)
     assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AuthN-only mode: sasl_oauthbearer_authentication_enabled=true with
+# sasl_oauthbearer_authorization_enabled=false. Backed by the
+# karapace-schema-registry-authn-only service in compose.yml.
+#
+# Expected behavior:
+#   - Valid token  → 200 (no role check)
+#   - Invalid token → 401
+#   - No header   → 401
+#   - Skip paths  → 200 even without a token
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_registry_oidc_authn_only_valid_token(
+    registry_async_client_oidc_authn_only: Client,
+) -> None:
+    """A valid token must succeed even though the user has no roles configured for the resource."""
+    subject = new_random_name("subject")
+
+    await _wait_for_primary(registry_async_client_oidc_authn_only)
+
+    subject_res = await registry_async_client_oidc_authn_only.get(f"subjects/{subject}/versions")
+    assert subject_res.status_code == 404
+
+    subject_res = await registry_async_client_oidc_authn_only.post(
+        f"subjects/{subject}/versions",
+        json={
+            "schema": json.dumps({"type": "string"}),
+            "schemaType": SchemaType.JSONSCHEMA.value,
+        },
+    )
+    # Authorization is disabled — the write must succeed for any valid token.
+    assert subject_res.status_code == 200
+
+
+async def test_schema_registry_oidc_authn_only_invalid_token(
+    registry_async_client_oidc_authn_only_invalid: Client,
+) -> None:
+    subject = new_random_name("subject")
+
+    subject_res = await registry_async_client_oidc_authn_only_invalid.get(f"subjects/{subject}/versions")
+
+    assert subject_res.status_code == 401
+    assert subject_res.json_result["error"] == "Unauthorized"
+    assert subject_res.json_result["reason"] == "Invalid token/payload"
+
+
+async def test_schema_registry_oidc_authn_only_no_auth_header_fails(
+    registry_async_client_oidc_authn_only_no_auth_header: Client,
+) -> None:
+    subject = new_random_name("subject")
+
+    subject_res = await registry_async_client_oidc_authn_only_no_auth_header.get(f"subjects/{subject}/versions")
+
+    assert subject_res.status_code == 401
+    assert subject_res.json_result["error"] == "Unauthorized"
+    assert subject_res.json_result["reason"] == "Missing or invalid Authorization header"
+
+
+async def test_schema_registry_oidc_authn_only_skip_paths(
+    registry_async_client_oidc_authn_only_no_auth_header: Client,
+) -> None:
+    res = await registry_async_client_oidc_authn_only_no_auth_header.get("_health")
+    assert res.status_code == 200
+
+    res = await registry_async_client_oidc_authn_only_no_auth_header.get("metrics", json_response=False)
+    assert res.status_code == 200

--- a/tests/unit/api/test_middlewares.py
+++ b/tests/unit/api/test_middlewares.py
@@ -25,6 +25,20 @@ def _clean_prometheus_registry() -> Iterator[None]:
             pass
 
 
+def _oidc_config(**overrides) -> Config:
+    """Build a Config with the OIDC fields the middleware constructor needs."""
+    base: dict = {
+        "sasl_oauthbearer_jwks_endpoint_url": "https://oidc.test/realms/r/protocol/openid-connect/certs",
+        "sasl_oauthbearer_expected_issuer": "https://oidc.test/realms/r",
+        "sasl_oauthbearer_expected_audience": "audience",
+        "sasl_oauthbearer_sub_claim_name": "sub",
+        "sasl_oauthbearer_client_id": "client-id",
+        "sasl_oauthbearer_roles_claim_path": "realm_access.roles",
+    }
+    base.update(overrides)
+    return Config(**base)
+
+
 def _build_app(config: Config) -> FastAPI:
     app = FastAPI()
 
@@ -49,7 +63,7 @@ def _client(config: Config) -> TestClient:
 
 
 def test_docs_path_bypasses_auth() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     response = _client(config).get("/docs")
 
@@ -58,7 +72,8 @@ def test_docs_path_bypasses_auth() -> None:
 
 
 def test_skip_auth_path_bypasses_bearer_check() -> None:
-    config = Config(
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
         sasl_oauthbearer_authorization_enabled=True,
         sasl_oauthbearer_skip_auth_paths=["/_health", "/metrics"],
     )
@@ -84,7 +99,7 @@ def test_auth_disabled_allows_requests_without_token() -> None:
 
 
 def test_missing_authorization_header_returns_401() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     response = _client(config).get("/subjects")
 
@@ -95,7 +110,7 @@ def test_missing_authorization_header_returns_401() -> None:
 
 
 def test_non_bearer_authorization_returns_401() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     response = _client(config).get("/subjects", headers={"Authorization": "Basic abc"})
 
@@ -106,7 +121,7 @@ def test_non_bearer_authorization_returns_401() -> None:
 
 
 def test_valid_bearer_token_passes_and_sets_content_type() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with (
         patch("karapace.api.middlewares.OIDCMiddleware.validate_jwt", return_value={"sub": "u1"}),
@@ -119,7 +134,7 @@ def test_valid_bearer_token_passes_and_sets_content_type() -> None:
 
 
 def test_invalid_jwt_returns_401() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with patch(
         "karapace.api.middlewares.OIDCMiddleware.validate_jwt",
@@ -132,7 +147,7 @@ def test_invalid_jwt_returns_401() -> None:
 
 
 def test_authorization_failure_returns_role_error() -> None:
-    config = Config(sasl_oauthbearer_authorization_enabled=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with (
         patch("karapace.api.middlewares.OIDCMiddleware.validate_jwt", return_value={"sub": "u1"}),

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -8,14 +8,15 @@ See LICENSE for details
 from __future__ import annotations
 
 import datetime
+import logging
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-from jwt import InvalidTokenError
-from karapace.api.oidc.middleware import OIDCMiddleware
+from jwt import ExpiredSignatureError, InvalidTokenError
+from karapace.api.oidc.middleware import OIDCMiddleware, TokenExpiredError
 from karapace.core.auth import AuthenticationError
 from karapace.core.config import Config
 from karapace.rapu import JSON_CONTENT_TYPE, HTTPResponse
@@ -35,6 +36,7 @@ class DummyConfig:
     sasl_oauthbearer_expected_audience: str | None
     sasl_oauthbearer_sub_claim_name: str | None
     sasl_oauthbearer_authorization_enabled: bool
+    sasl_oauthbearer_authentication_enabled: bool = False
     sasl_oauthbearer_client_id: str | None = None
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = field(
@@ -44,7 +46,7 @@ class DummyConfig:
 
 valid_configs = [
     DummyConfig(
-        sasl_oauthbearer_jwks_endpoint_url="http://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
+        sasl_oauthbearer_jwks_endpoint_url="https://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
         sasl_oauthbearer_expected_issuer="https://oidcprovider.com",
         sasl_oauthbearer_expected_audience="accounts-audience",
         sasl_oauthbearer_sub_claim_name="sub",
@@ -67,7 +69,7 @@ valid_configs = [
 
 invalid_configs = [
     DummyConfig(
-        sasl_oauthbearer_jwks_endpoint_url="http://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
+        sasl_oauthbearer_jwks_endpoint_url="https://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
         sasl_oauthbearer_expected_issuer=None,
         sasl_oauthbearer_expected_audience="accounts-audience",
         sasl_oauthbearer_sub_claim_name="sub",
@@ -77,7 +79,7 @@ invalid_configs = [
         sasl_oauthbearer_method_roles={"GET": [], "POST": [], "PUT": [], "DELETE": []},
     ),
     DummyConfig(
-        sasl_oauthbearer_jwks_endpoint_url="http://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
+        sasl_oauthbearer_jwks_endpoint_url="https://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
         sasl_oauthbearer_expected_issuer=None,
         sasl_oauthbearer_expected_audience=None,
         sasl_oauthbearer_sub_claim_name="sub",
@@ -135,17 +137,17 @@ def test_validate_token_valid_configs(
     mock_jwt_decode.return_value = mock_payload
 
     token = auth_header.split(" ", 1)[1]
-    payload = oidc_middleware.validate_jwt(token)
 
     if dummy_config.sasl_oauthbearer_jwks_endpoint_url:
-        # JWKS URL is present, validate normally
+        payload = oidc_middleware.validate_jwt(token)
         if expected_expiration is not None:
             assert payload.get("exp") == int(expected_expiration.timestamp())
         else:
             assert "exp" not in payload or payload.get("exp") is None
     else:
-        # No JWKS URL, validation is skipped, payload is empty dict
-        assert payload == {}
+        # No JWKS URL: validate_jwt fails closed instead of returning an empty payload.
+        with pytest.raises(AuthenticationError, match="OIDC not configured"):
+            oidc_middleware.validate_jwt(token)
 
 
 @pytest.mark.parametrize("dummy_config", invalid_configs)
@@ -161,6 +163,28 @@ def test_oidc_middleware_raises_on_incomplete_config(dummy_config):
         ValueError, match="OIDC config error: 'issuer' and 'audience' must be set if 'jwks_endpoint_url' is provided."
     ):
         OIDCMiddleware(app=MagicMock(), config=config)
+
+
+def test_oidc_middleware_rejects_http_jwks_url_by_default():
+    config = Config(
+        sasl_oauthbearer_jwks_endpoint_url="http://idp/realms/r/protocol/openid-connect/certs",
+        sasl_oauthbearer_expected_issuer="http://idp/realms/r",
+        sasl_oauthbearer_expected_audience="aud",
+    )
+    with pytest.raises(ValueError, match="https://"):
+        OIDCMiddleware(app=MagicMock(), config=config)
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+def test_oidc_middleware_allows_http_jwks_when_override_set(mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    config = Config(
+        sasl_oauthbearer_jwks_endpoint_url="http://idp/realms/r/protocol/openid-connect/certs",
+        sasl_oauthbearer_expected_issuer="http://idp/realms/r",
+        sasl_oauthbearer_expected_audience="aud",
+        sasl_oauthbearer_allow_insecure_jwks=True,
+    )
+    OIDCMiddleware(app=MagicMock(), config=config)
 
 
 @pytest.mark.parametrize("dummy_config", valid_configs, ids=["valid_full", "no_oidc"], indirect=True)
@@ -189,9 +213,9 @@ def test_validate_token_invalid_token(mock_jwt_decode, mock_pyjwks_client, dummy
             oidc_middleware.validate_jwt(invalid_token)
         assert "Invalid OIDC token" in str(exc_info.value)
     else:
-        # When JWKS URL is missing, validate_jwt returns empty dict instead of raising
-        payload = oidc_middleware.validate_jwt(invalid_token)
-        assert payload == {}
+        # When JWKS URL is missing, validate_jwt fails closed.
+        with pytest.raises(AuthenticationError, match="OIDC not configured"):
+            oidc_middleware.validate_jwt(invalid_token)
 
 
 @pytest.mark.parametrize(
@@ -223,7 +247,7 @@ def test_get_roles_from_claim_path(payload, path, expected_roles):
 )
 def test_authorize_request_roles(monkeypatch, roles, method, method_roles, expect_error):
     config = DummyConfig(
-        sasl_oauthbearer_jwks_endpoint_url="http://fake",
+        sasl_oauthbearer_jwks_endpoint_url="https://fake",
         sasl_oauthbearer_expected_issuer="issuer",
         sasl_oauthbearer_expected_audience="aud",
         sasl_oauthbearer_sub_claim_name="sub",
@@ -242,3 +266,263 @@ def test_authorize_request_roles(monkeypatch, roles, method, method_roles, expec
         assert exc_info.value.status_code == 403
     else:
         middleware.authorize_request(payload, method)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests for the authN / authZ flag split (sasl_oauthbearer_authentication_enabled
+# is independent from sasl_oauthbearer_authorization_enabled).
+# ---------------------------------------------------------------------------
+
+
+def _oidc_config(**overrides) -> Config:
+    """Build a Config with sane OIDC defaults plus any overrides for the test."""
+    base: dict = {
+        "sasl_oauthbearer_jwks_endpoint_url": "https://oidcprovider/realms/testrealm/protocol/openid-connect/certs",
+        "sasl_oauthbearer_expected_issuer": "https://oidcprovider.com",
+        "sasl_oauthbearer_expected_audience": "accounts-audience",
+    }
+    base.update(overrides)
+    return Config(**base)
+
+
+def test_config_bc_shim_authz_implies_authn(caplog):
+    """Setting only authorization_enabled=True must auto-enable authentication_enabled with a warning."""
+    with caplog.at_level(logging.WARNING):
+        config = _oidc_config(sasl_oauthbearer_authorization_enabled=True)
+    assert config.sasl_oauthbearer_authentication_enabled is True
+    assert config.sasl_oauthbearer_authorization_enabled is True
+    assert any("deprecated" in rec.message for rec in caplog.records)
+
+
+def test_config_authn_only_does_not_warn(caplog):
+    """Enabling only authN must not trigger the BC deprecation warning."""
+    with caplog.at_level(logging.WARNING):
+        config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    assert config.sasl_oauthbearer_authentication_enabled is True
+    assert config.sasl_oauthbearer_authorization_enabled is False
+    assert not any("deprecated" in rec.message for rec in caplog.records)
+
+
+def test_config_both_enabled_no_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        config = _oidc_config(
+            sasl_oauthbearer_authentication_enabled=True,
+            sasl_oauthbearer_authorization_enabled=True,
+        )
+    assert config.sasl_oauthbearer_authentication_enabled is True
+    assert config.sasl_oauthbearer_authorization_enabled is True
+    assert not any("deprecated" in rec.message for rec in caplog.records)
+
+
+def test_config_both_disabled_default():
+    config = Config()
+    assert config.sasl_oauthbearer_authentication_enabled is False
+    assert config.sasl_oauthbearer_authorization_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP middleware behavior: authN-only vs authN+authZ vs disabled.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_prometheus_registry():
+    """setup_middlewares registers prometheus collectors into a global REGISTRY.
+    Re-running it across tests in this module collides — unregister between tests.
+    """
+    from prometheus_client import REGISTRY
+
+    yield
+    for collector in list(REGISTRY._names_to_collectors.values()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+def _build_app_with_middleware(
+    monkeypatch, config: Config, *, validate_jwt_payload: dict | None = None, validate_jwt_raises: Exception | None = None
+):
+    """Build a minimal FastAPI app wired to setup_middlewares, with OIDCMiddleware patched."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from karapace.api import middlewares as middlewares_mod
+
+    app = FastAPI()
+
+    @app.get("/subjects")
+    async def subjects():
+        return []
+
+    @app.get("/_health")
+    async def health():
+        return {"ok": True}
+
+    def _fake_validate_jwt(self, token):
+        if validate_jwt_raises is not None:
+            raise validate_jwt_raises
+        return validate_jwt_payload or {}
+
+    def _fake_authorize(self, payload, method):
+        # Re-use real role logic to verify the gate, but make it raise if enabled+roles missing.
+        return True
+
+    # Patch heavy bits of OIDCMiddleware: skip real JWKS client construction.
+    monkeypatch.setattr(
+        "karapace.api.oidc.middleware.PyJWKClient",
+        lambda *a, **kw: MagicMock(),
+    )
+    monkeypatch.setattr(OIDCMiddleware, "validate_jwt", _fake_validate_jwt)
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _fake_authorize)
+
+    middlewares_mod.setup_middlewares(app=app, config=config)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_middleware_disabled_allows_unauth_request(monkeypatch):
+    config = Config()  # authN/authZ both False
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    r = client.get("/subjects")
+    assert r.status_code == 200
+
+
+def test_middleware_authn_only_requires_bearer(monkeypatch):
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    r = client.get("/subjects")
+    assert r.status_code == 401
+    assert r.json()["reason"] == "Missing or invalid Authorization header"
+
+
+def test_middleware_authn_only_valid_token_passes(monkeypatch):
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
+    assert r.status_code == 200
+
+
+def test_middleware_authn_only_invalid_token_returns_401(monkeypatch):
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_raises=AuthenticationError("bad"))
+    r = client.get("/subjects", headers={"Authorization": "Bearer bad.token"})
+    assert r.status_code == 401
+    assert r.json()["reason"] == "Invalid token/payload"
+
+
+def test_middleware_authn_only_skips_authorize_request(monkeypatch):
+    """When only authN is enabled, authorize_request must NOT be invoked even with a valid token."""
+    calls: list = []
+
+    def _spy_authorize(self, payload, method):
+        calls.append((payload, method))
+        return True
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    # Re-patch authorize_request after _build_app_with_middleware (which also patches it).
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+
+    r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
+    assert r.status_code == 200
+    assert calls == []  # authZ never called
+
+
+def test_middleware_authn_and_authz_calls_authorize(monkeypatch):
+    """When both flags are on, authorize_request must be invoked with the validated payload."""
+    calls: list = []
+
+    def _spy_authorize(self, payload, method):
+        calls.append((payload, method))
+        return True
+
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
+        sasl_oauthbearer_authorization_enabled=True,
+        sasl_oauthbearer_client_id="client-id",
+        sasl_oauthbearer_roles_claim_path="realm_access.roles",
+    )
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+
+    r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
+    assert r.status_code == 200
+    assert calls and calls[0][1] == "GET"
+
+
+def test_middleware_authn_and_authz_returns_403_on_role_failure(monkeypatch):
+    def _deny(self, payload, method):
+        raise HTTPException(status_code=403, detail="Insufficient roles")
+
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
+        sasl_oauthbearer_authorization_enabled=True,
+        sasl_oauthbearer_client_id="client-id",
+        sasl_oauthbearer_roles_claim_path="realm_access.roles",
+    )
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _deny)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _deny)
+
+    r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
+    assert r.status_code == 403
+    assert r.json()["reason"] == "Insufficient roles"
+
+
+def test_middleware_skip_paths_bypass_auth(monkeypatch):
+    """Paths in sasl_oauthbearer_skip_auth_paths must bypass the gate even when authN is enabled."""
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
+    r = client.get("/_health")  # no Authorization header
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Expired token: ExpiredSignatureError must surface as TokenExpiredError from
+# validate_jwt and translate to a 401 with reason "Token expired".
+# ---------------------------------------------------------------------------
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_expired_token_raises_token_expired(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.side_effect = ExpiredSignatureError("Signature has expired")
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+
+    with pytest.raises(TokenExpiredError) as exc_info:
+        middleware.validate_jwt("expired.jwt.token")
+    assert "expired" in str(exc_info.value).lower()
+    # TokenExpiredError must remain a subclass of AuthenticationError so existing handlers still catch it.
+    assert isinstance(exc_info.value, AuthenticationError)
+
+
+def test_middleware_returns_401_token_expired_on_expired_token(monkeypatch):
+    """An expired token must produce a 401 with a distinct 'Token expired' reason."""
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(
+        monkeypatch,
+        config,
+        validate_jwt_raises=TokenExpiredError("OIDC token expired"),
+    )
+    r = client.get("/subjects", headers={"Authorization": "Bearer expired.token"})
+    assert r.status_code == 401
+    assert r.json()["error"] == "Unauthorized"
+    assert r.json()["reason"] == "Token expired"
+
+
+def test_middleware_invalid_token_still_returns_invalid_reason(monkeypatch):
+    """Generic AuthenticationError (non-expiry) must keep the original 'Invalid token/payload' reason."""
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    client = _build_app_with_middleware(
+        monkeypatch,
+        config,
+        validate_jwt_raises=AuthenticationError("bad sig"),
+    )
+    r = client.get("/subjects", headers={"Authorization": "Bearer bogus.token"})
+    assert r.status_code == 401
+    assert r.json()["reason"] == "Invalid token/payload"


### PR DESCRIPTION
Issue : 
sasl_oauthbearer_authorization_enabled gates both authentication and authorization in the Schema Registry. The naming is a bit misleading. There isn't a separate flag to enable authN without authZ; they're coupled behind this one switch even though implementation exists for both.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- Adds sasl_oauthbearer_authentication_enabled so token validation can be enabled without enforcing role-based authorization. sasl_oauthbearer_authorization_enabled continues to gate the role check and now requires authN.
- backwards compatibility: setting only authorization_enabled=true auto-enables authN with a deprecation warning.
- Distinct 401 reason for expired tokens ("Token expired" vs the previous generic "Invalid token/payload") — OIDCMiddleware.validate_jwt catches ExpiredSignatureError and raises a new TokenExpiredError.
- Brief inline docs in Config and kafka_rest_apis/authentication.py clarifying which OIDC fields apply to which service.
- Fix a couple of security issues

| authN | authZ | Behavior |
|---|---|---|
| F | F | No auth |
| T | F | JWT validation (401 on failure) |
| T | T | JWT + role check (401/403) |
| F | T | Invalid → coerced to T/T |

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
