### PR TITLE
fix: 504 on map-of-union Avro fetch

### DIFF
--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from aiohttp import BasicAuth
 from async_lru import alru_cache
 from avro.io import BinaryDecoder, BinaryEncoder, DatumReader, DatumWriter
-from cachetools import TTLCache
+from cachetools import LRUCache, TTLCache
 from collections.abc import Callable, MutableMapping
 from google.protobuf.message import DecodeError
 from jsonschema import ValidationError
@@ -42,6 +42,9 @@ import struct
 START_BYTE = 0x0
 HEADER_FORMAT = ">bI"
 HEADER_SIZE = 5
+
+_datum_reader_cache: MutableMapping[str, DatumReader] = LRUCache(maxsize=100)
+_datum_writer_cache: MutableMapping[str, DatumWriter] = LRUCache(maxsize=100)
 
 
 class DeserializationError(Exception):
@@ -452,7 +455,11 @@ def flatten_unions(schema: avro.schema.Schema, value: Any) -> Any:
 
 def read_value(config: Config, schema: TypedSchema, bio: io.BytesIO):
     if schema.schema_type is SchemaType.AVRO:
-        reader = DatumReader(writers_schema=schema.schema)
+        fp = schema.fingerprint()
+        reader = _datum_reader_cache.get(fp)
+        if reader is None:
+            reader = DatumReader(writers_schema=schema.schema)
+            _datum_reader_cache[fp] = reader
         return reader.read(BinaryDecoder(bio))
     if schema.schema_type is SchemaType.JSONSCHEMA:
         value = json_decode(bio)
@@ -480,7 +487,11 @@ def write_value(config: Config, schema: TypedSchema, bio: io.BytesIO, value: dic
         else:
             data = flatten_unions(schema.schema, value)
 
-        writer = DatumWriter(writers_schema=schema.schema)
+        fp = schema.fingerprint()
+        writer = _datum_writer_cache.get(fp)
+        if writer is None:
+            writer = DatumWriter(writers_schema=schema.schema)
+            _datum_writer_cache[fp] = writer
         writer.write(data, BinaryEncoder(bio))
     elif schema.schema_type is SchemaType.JSONSCHEMA:
         try:

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -9,7 +9,7 @@ import io
 import json
 import logging
 import struct
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import avro
 import pytest
@@ -26,6 +26,7 @@ from karapace.core.serialization import (
     SchemaRegistrySerializer,
     flatten_unions,
     get_subject_name,
+    read_value,
     write_value,
 )
 from karapace.core.typing import NameStrategy, Subject, SubjectType
@@ -441,4 +442,77 @@ def test_name_strategy_for_protobuf(expected_subject: Subject, strategy: NameStr
     assert (
         get_subject_name(topic_name="foo", schema=TYPED_PROTOBUF_SCHEMA, subject_type=subject_type, naming_strategy=strategy)
         == expected_subject
+    )
+
+
+MAP_UNION_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.minimal",
+            "name": "MinimalUnionTest",
+            "type": "record",
+            "fields": [
+                {"name": "id", "type": "string"},
+                {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+            ],
+        }
+    ),
+)
+
+
+def _encode_map_union_message(record: dict) -> bytes:
+    """Encode a record using MAP_UNION_SCHEMA into raw Avro binary (no framing header)."""
+    bio = io.BytesIO()
+    write_value(None, MAP_UNION_SCHEMA, bio, record)  # type: ignore[arg-type]
+    return bio.getvalue()
+
+
+def test_read_value_reuses_datum_reader_for_map_union_schema(karapace_container: KarapaceContainer) -> None:
+    """DatumReader must be constructed once per schema, not once per message.
+
+    DatumReader.__init__ is cheap (stores two references), but constructing a new
+    instance per message causes repeated allocation and GC pressure on large batches.
+    """
+    payload = _encode_map_union_message({"id": "x", "props": {"k": "v"}})
+
+    original_init = avro.io.DatumReader.__init__
+    init_call_count = 0
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal init_call_count
+        init_call_count += 1
+        return original_init(self, *args, **kwargs)
+
+    with patch.object(avro.io.DatumReader, "__init__", counting_init):
+        for _ in range(10):
+            read_value(karapace_container.config(), MAP_UNION_SCHEMA, io.BytesIO(payload))
+
+    assert init_call_count == 1, (
+        f"DatumReader was constructed {init_call_count} times for 10 messages with the same schema; "
+        "expected 1 (cached)."
+    )
+
+
+def test_write_value_reuses_datum_writer_for_map_union_schema(karapace_container: KarapaceContainer) -> None:
+    """DatumWriter must be constructed once per schema, not once per message.
+
+    DatumWriter.__init__ is cheap (stores two references), but constructing a new
+    instance per message causes repeated allocation and GC pressure on large batches.
+    """
+    original_init = avro.io.DatumWriter.__init__
+    init_call_count = 0
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal init_call_count
+        init_call_count += 1
+        return original_init(self, *args, **kwargs)
+
+    with patch.object(avro.io.DatumWriter, "__init__", counting_init):
+        for _ in range(10):
+            write_value(karapace_container.config(), MAP_UNION_SCHEMA, io.BytesIO(), {"id": "x", "props": {"k": "v"}})
+
+    assert init_call_count == 1, (
+        f"DatumWriter was constructed {init_call_count} times for 10 messages with the same schema; "
+        "expected 1 (cached)."
     )


### PR DESCRIPTION
DatumReader and DatumWriter were constructed fresh on every message. For schemas with multi-way union values in maps/arrays, the avro library traverses the full schema graph on each __init__, causing O(messages × schema_complexity) CPU work that blocks the event loop and triggers 504s on large batches.

Cache DatumReader/DatumWriter instances keyed by schema fingerprint so construction cost is paid once per unique schema across all messages and requests.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
