### PR TITLE
serializer,avro,rest-proxy: event loop improvements

### DIFF
--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -36,8 +36,11 @@ from urllib.parse import quote
 import asyncio
 import avro
 import avro.schema
+import base64
 import io
 import struct
+import threading
+import weakref
 
 START_BYTE = 0x0
 HEADER_FORMAT = ">bI"
@@ -306,6 +309,10 @@ class SchemaRegistrySerializer:
         self.ids_to_schemas: dict[int, TypedSchema] = {}
         self.ids_to_subjects: MutableMapping[int, list[Subject]] = TTLCache(maxsize=10000, ttl=600)
         self.schemas_to_ids: dict[str, SchemaId] = {}
+        self._avro_readers_lock = threading.Lock()
+        self._avro_readers_by_thread: weakref.WeakKeyDictionary[threading.Thread, TTLCache[SchemaId, DatumReader]] = (
+            weakref.WeakKeyDictionary()
+        )
 
     async def close(self) -> None:
         if self.registry_client:
@@ -380,12 +387,48 @@ class SchemaRegistrySerializer:
                 schema, _ = await self.get_schema_for_id(schema_id)
                 if schema is None:
                     raise InvalidPayload("No schema with ID from payload")
-                ret_val = read_value(self.config, schema, bio)
+                if schema.schema_type is SchemaType.AVRO:
+                    ret_val = await asyncio.to_thread(self._read_avro_value, SchemaId(schema_id), schema, bio)
+                else:
+                    ret_val = read_value(self.config, schema, bio)
                 return ret_val
             except (UnicodeDecodeError, TypeError, avro.errors.InvalidAvroBinaryEncoding) as e:
                 raise InvalidPayload("Data does not contain a valid message") from e
             except avro.errors.SchemaResolutionException as e:
                 raise InvalidPayload("Data cannot be decoded with provided schema") from e
+
+    def _get_avro_reader(self, schema_id: SchemaId, schema: TypedSchema) -> DatumReader:
+        current_thread = threading.current_thread()
+        with self._avro_readers_lock:
+            reader_cache = self._avro_readers_by_thread.get(current_thread)
+            if reader_cache is None:
+                reader_cache = TTLCache(maxsize=10000, ttl=600)
+                self._avro_readers_by_thread[current_thread] = reader_cache
+
+        reader = reader_cache.get(schema_id)
+        if reader is None:
+            reader = DatumReader(writers_schema=schema.schema)
+            reader_cache[schema_id] = reader
+        return reader
+
+    def _read_avro_value(self, schema_id: SchemaId, schema: TypedSchema, bio: io.BytesIO) -> Any:
+        return read_value(self.config, schema, bio, avro_reader=self._get_avro_reader(schema_id, schema))
+
+
+def _jsonify_avro_payload(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+
+    if isinstance(value, bytearray):
+        return base64.b64encode(bytes(value)).decode("ascii")
+
+    if isinstance(value, list):
+        return [_jsonify_avro_payload(item) for item in value]
+
+    if isinstance(value, dict):
+        return {key: _jsonify_avro_payload(item) for key, item in value.items()}
+
+    return value
 
 
 def flatten_unions(schema: avro.schema.Schema, value: Any) -> Any:
@@ -450,10 +493,10 @@ def flatten_unions(schema: avro.schema.Schema, value: Any) -> Any:
     return value
 
 
-def read_value(config: Config, schema: TypedSchema, bio: io.BytesIO):
+def read_value(config: Config, schema: TypedSchema, bio: io.BytesIO, avro_reader: DatumReader | None = None):
     if schema.schema_type is SchemaType.AVRO:
-        reader = DatumReader(writers_schema=schema.schema)
-        return reader.read(BinaryDecoder(bio))
+        reader = avro_reader if avro_reader is not None else DatumReader(writers_schema=schema.schema)
+        return _jsonify_avro_payload(reader.read(BinaryDecoder(bio)))
     if schema.schema_type is SchemaType.JSONSCHEMA:
         value = json_decode(bio)
         try:

--- a/src/karapace/kafka_rest_apis/consumer_manager.py
+++ b/src/karapace/kafka_rest_apis/consumer_manager.py
@@ -23,7 +23,13 @@ from karapace.core.config import Config
 from karapace.core.kafka.common import translate_from_kafkaerror
 from karapace.core.kafka.consumer import AsyncKafkaConsumer
 from karapace.core.kafka.types import DEFAULT_REQUEST_TIMEOUT_MS, Timestamp
-from karapace.core.serialization import DeserializationError, InvalidMessageHeader, InvalidPayload, SchemaRegistrySerializer
+from karapace.core.serialization import (
+    DeserializationError,
+    InvalidMessageHeader,
+    InvalidPayload,
+    SchemaRegistrySerializer,
+    SchemaRetrievalError,
+)
 from karapace.core.utils import json_decode, JSONDecodeError
 from karapace.kafka_rest_apis.convert_to_int import convert_to_int
 from karapace.kafka_rest_apis.authentication import get_kafka_client_auth_parameters_from_config
@@ -682,7 +688,14 @@ class ConsumerManager:
                 return None
             try:
                 return await self.deserializer.deserialize(bytes_)
-            except (UnpackError, InvalidMessageHeader, InvalidPayload, JSONDecodeError, UnicodeDecodeError) as e:
+            except (
+                UnpackError,
+                InvalidMessageHeader,
+                InvalidPayload,
+                SchemaRetrievalError,
+                JSONDecodeError,
+                UnicodeDecodeError,
+            ) as e:
                 raise DeserializationError(e) from e
 
         return deserialize_strict

--- a/tests/e2e/schema_registry/test_serialization.py
+++ b/tests/e2e/schema_registry/test_serialization.py
@@ -1,0 +1,232 @@
+"""
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+import asyncio
+import base64
+import json
+from typing import Any
+
+from confluent_kafka.admin import NewTopic
+
+from karapace.core.client import Client
+from karapace.core.container import KarapaceContainer
+from karapace.core.kafka.consumer import KafkaConsumer
+from karapace.core.kafka.producer import KafkaProducer
+from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
+from karapace.core.serialization import SchemaRegistrySerializer
+from karapace.core.typing import Subject
+
+COMPLEX_UNION_AVRO_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.minimal",
+            "name": "MinimalUnionTest",
+            "type": "record",
+            "fields": [
+                {"name": "id", "type": "string"},
+                {
+                    "name": "attrs",
+                    "type": {
+                        "type": "array",
+                        "items": {
+                            "type": "record",
+                            "name": "Attr",
+                            "fields": [
+                                {"name": "k", "type": "string"},
+                                {"name": "v", "type": ["null", "string", "long", "double", "boolean"]},
+                            ],
+                        },
+                    },
+                },
+                {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+            ],
+        }
+    ),
+)
+
+COMPLEX_UNION_AVRO_RECORD = {
+    "id": "one",
+    "attrs": [
+        {"k": "text", "v": "value"},
+        {"k": "count", "v": 5},
+        {"k": "ratio", "v": 1.5},
+        {"k": "flag", "v": True},
+        {"k": "empty", "v": None},
+    ],
+    "props": {"present": "yes", "missing": None},
+}
+
+MAP_UNION_AVRO_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.minimal",
+            "name": "MapUnionTest",
+            "type": "record",
+            "fields": [
+                {"name": "id", "type": "string"},
+                {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+            ],
+        }
+    ),
+)
+
+MAP_UNION_AVRO_RECORD = {
+    "id": "one",
+    "props": {"present": "yes", "missing": None},
+}
+
+AVRO_BYTES_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.bytes",
+            "name": "BytesEnvelope",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "payload",
+                    "type": {
+                        "type": "record",
+                        "name": "Payload",
+                        "fields": [
+                            {"name": "raw", "type": "bytes"},
+                            {"name": "items", "type": {"type": "array", "items": "bytes"}},
+                        ],
+                    },
+                }
+            ],
+        }
+    ),
+)
+
+AVRO_BYTES_RECORD = {
+    "payload": {
+        "raw": b"\x01\x02",
+        "items": [b"\x03\x04", b"\x05\x06"],
+    }
+}
+
+
+async def _wait_for_primary(client: Client, timeout: float = 30.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        res = await client.get("master_available")
+        if res.status_code == 200 and res.json_result and res.json_result.get("master_available") is True:
+            return
+        await asyncio.sleep(1.0)
+    raise TimeoutError("Schema registry did not elect a primary within timeout")
+
+
+def _build_oidc_serializer(
+    karapace_container: KarapaceContainer, registry_async_client_oidc: Client
+) -> tuple[SchemaRegistrySerializer, Client]:
+    serializer = SchemaRegistrySerializer(config=karapace_container.config())
+    original_client = serializer.registry_client.client
+    serializer.registry_client.client = registry_async_client_oidc
+    return serializer, original_client
+
+
+def _poll_for_value(consumer: KafkaConsumer, timeout_s: float = 10.0) -> Any:
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        message = consumer.poll(timeout=1.0)
+        if message is not None and message.error() is None:
+            return message.value()
+    raise TimeoutError("Timed out waiting for Kafka message")
+
+
+async def test_schema_registry_serializer_round_trip_complex_union_avro(
+    karapace_container: KarapaceContainer,
+    registry_async_client_oidc: Client,
+    producer: KafkaProducer,
+    consumer: KafkaConsumer,
+    new_topic: NewTopic,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc)
+
+    serializer, original_client = _build_oidc_serializer(karapace_container, registry_async_client_oidc)
+    try:
+        subject = Subject(f"{new_topic.topic}-value")
+        await serializer.upsert_id_for_schema(COMPLEX_UNION_AVRO_SCHEMA, str(subject))
+        payload = await serializer.serialize(COMPLEX_UNION_AVRO_SCHEMA, COMPLEX_UNION_AVRO_RECORD)
+
+        producer.send(new_topic.topic, value=payload)
+        producer.flush()
+
+        consumer.subscribe([new_topic.topic])
+        kafka_value = _poll_for_value(consumer)
+
+        assert await serializer.deserialize(kafka_value) == COMPLEX_UNION_AVRO_RECORD
+        assert await serializer.deserialize(payload) == COMPLEX_UNION_AVRO_RECORD
+    finally:
+        serializer.registry_client.client = original_client
+        await serializer.close()
+
+
+async def test_schema_registry_serializer_round_trip_map_union_avro(
+    karapace_container: KarapaceContainer,
+    registry_async_client_oidc: Client,
+    producer: KafkaProducer,
+    consumer: KafkaConsumer,
+    new_topic: NewTopic,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc)
+
+    serializer, original_client = _build_oidc_serializer(karapace_container, registry_async_client_oidc)
+    try:
+        subject = Subject(f"{new_topic.topic}-value")
+        await serializer.upsert_id_for_schema(MAP_UNION_AVRO_SCHEMA, str(subject))
+        payload = await serializer.serialize(MAP_UNION_AVRO_SCHEMA, MAP_UNION_AVRO_RECORD)
+
+        producer.send(new_topic.topic, value=payload)
+        producer.flush()
+
+        consumer.subscribe([new_topic.topic])
+        kafka_value = _poll_for_value(consumer)
+
+        assert await serializer.deserialize(kafka_value) == MAP_UNION_AVRO_RECORD
+        assert await serializer.deserialize(payload) == MAP_UNION_AVRO_RECORD
+    finally:
+        serializer.registry_client.client = original_client
+        await serializer.close()
+
+
+async def test_schema_registry_serializer_round_trip_avro_bytes_as_base64_strings(
+    karapace_container: KarapaceContainer,
+    registry_async_client_oidc: Client,
+    producer: KafkaProducer,
+    consumer: KafkaConsumer,
+    new_topic: NewTopic,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc)
+
+    serializer, original_client = _build_oidc_serializer(karapace_container, registry_async_client_oidc)
+    try:
+        subject = Subject(f"{new_topic.topic}-value")
+        await serializer.upsert_id_for_schema(AVRO_BYTES_SCHEMA, str(subject))
+        payload = await serializer.serialize(AVRO_BYTES_SCHEMA, AVRO_BYTES_RECORD)
+
+        producer.send(new_topic.topic, value=payload)
+        producer.flush()
+
+        consumer.subscribe([new_topic.topic])
+        kafka_value = _poll_for_value(consumer)
+
+        expected = {
+            "payload": {
+                "raw": base64.b64encode(b"\x01\x02").decode("ascii"),
+                "items": [
+                    base64.b64encode(b"\x03\x04").decode("ascii"),
+                    base64.b64encode(b"\x05\x06").decode("ascii"),
+                ],
+            }
+        }
+        assert await serializer.deserialize(kafka_value) == expected
+        assert await serializer.deserialize(payload) == expected
+    finally:
+        serializer.registry_client.client = original_client
+        await serializer.close()

--- a/tests/integration/kafka_rest_apis/test_data/debezium_decimal_bytes_envelope.avsc
+++ b/tests/integration/kafka_rest_apis/test_data/debezium_decimal_bytes_envelope.avsc
@@ -1,0 +1,320 @@
+{
+  "connect.name": "fixture_5f3a2c1d.envelope",
+  "connect.version": 2,
+  "fields": [
+    {
+      "default": null,
+      "name": "before",
+      "type": [
+        "null",
+        {
+          "connect.name": "fixture_5f3a2c1d.value",
+          "fields": [
+            {
+              "default": 0,
+              "name": "id",
+              "type": {
+                "connect.default": 0,
+                "type": "long"
+              }
+            },
+            {
+              "name": "uuid",
+              "type": {
+                "connect.name": "io.debezium.data.Uuid",
+                "connect.version": 1,
+                "type": "string"
+              }
+            },
+            {
+              "name": "rate_table_id",
+              "type": "long"
+            },
+            {
+              "name": "prediction_log_id",
+              "type": "long"
+            },
+            {
+              "name": "probability",
+              "type": {
+                "connect.doc": "Variable scaled decimal",
+                "connect.name": "io.debezium.data.VariableScaleDecimal",
+                "connect.version": 1,
+                "fields": [
+                  {
+                    "name": "scale",
+                    "type": "int"
+                  },
+                  {
+                    "name": "value",
+                    "type": "bytes"
+                  }
+                ],
+                "name": "VariableScaleDecimal",
+                "namespace": "io.debezium.data",
+                "type": "record"
+              }
+            },
+            {
+              "name": "prediction",
+              "type": "string"
+            },
+            {
+              "default": 0,
+              "name": "created_at",
+              "type": {
+                "connect.default": 0,
+                "connect.name": "io.debezium.time.MicroTimestamp",
+                "connect.version": 1,
+                "type": "long"
+              }
+            },
+            {
+              "name": "created_by",
+              "type": {
+                "connect.name": "io.debezium.data.Uuid",
+                "connect.version": 1,
+                "type": "string"
+              }
+            },
+            {
+              "default": 0,
+              "name": "updated_at",
+              "type": {
+                "connect.default": 0,
+                "connect.name": "io.debezium.time.MicroTimestamp",
+                "connect.version": 1,
+                "type": "long"
+              }
+            },
+            {
+              "name": "updated_by",
+              "type": {
+                "connect.name": "io.debezium.data.Uuid",
+                "connect.version": 1,
+                "type": "string"
+              }
+            },
+            {
+              "default": null,
+              "name": "deleted_at",
+              "type": [
+                "null",
+                {
+                  "connect.name": "io.debezium.time.MicroTimestamp",
+                  "connect.version": 1,
+                  "type": "long"
+                }
+              ]
+            },
+            {
+              "default": null,
+              "name": "deleted_by",
+              "type": [
+                "null",
+                {
+                  "connect.name": "io.debezium.data.Uuid",
+                  "connect.version": 1,
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "default": null,
+              "name": "demand_sub_account_id",
+              "type": [
+                "null",
+                "long"
+              ]
+            },
+            {
+              "default": null,
+              "name": "db_updated_at",
+              "type": [
+                "null",
+                {
+                  "connect.name": "io.debezium.time.ZonedTimestamp",
+                  "connect.version": 1,
+                  "type": "string"
+                }
+              ]
+            }
+          ],
+          "name": "Value",
+          "type": "record"
+        }
+      ]
+    },
+    {
+      "default": null,
+      "name": "after",
+      "type": [
+        "null",
+        "Value"
+      ]
+    },
+    {
+      "name": "source",
+      "type": {
+        "connect.name": "io.debezium.connector.postgresql.Source",
+        "connect.version": 1,
+        "fields": [
+          {
+            "name": "version",
+            "type": "string"
+          },
+          {
+            "name": "connector",
+            "type": "string"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "ts_ms",
+            "type": "long"
+          },
+          {
+            "default": "false",
+            "name": "snapshot",
+            "type": [
+              {
+                "connect.default": "false",
+                "connect.name": "io.debezium.data.Enum",
+                "connect.parameters": {
+                  "allowed": "true,first,first_in_data_collection,last_in_data_collection,last,false,incremental"
+                },
+                "connect.version": 1,
+                "type": "string"
+              },
+              "null"
+            ]
+          },
+          {
+            "name": "db",
+            "type": "string"
+          },
+          {
+            "default": null,
+            "name": "sequence",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "default": null,
+            "name": "ts_us",
+            "type": [
+              "null",
+              "long"
+            ]
+          },
+          {
+            "default": null,
+            "name": "ts_ns",
+            "type": [
+              "null",
+              "long"
+            ]
+          },
+          {
+            "name": "schema",
+            "type": "string"
+          },
+          {
+            "name": "table",
+            "type": "string"
+          },
+          {
+            "default": null,
+            "name": "txId",
+            "type": [
+              "null",
+              "long"
+            ]
+          },
+          {
+            "default": null,
+            "name": "lsn",
+            "type": [
+              "null",
+              "long"
+            ]
+          },
+          {
+            "default": null,
+            "name": "xmin",
+            "type": [
+              "null",
+              "long"
+            ]
+          }
+        ],
+        "name": "Source",
+        "namespace": "io.debezium.connector.postgresql",
+        "type": "record"
+      }
+    },
+    {
+      "default": null,
+      "name": "transaction",
+      "type": [
+        "null",
+        {
+          "connect.name": "event.block",
+          "connect.version": 1,
+          "fields": [
+            {
+              "name": "id",
+              "type": "string"
+            },
+            {
+              "name": "total_order",
+              "type": "long"
+            },
+            {
+              "name": "data_collection_order",
+              "type": "long"
+            }
+          ],
+          "name": "block",
+          "namespace": "event",
+          "type": "record"
+        }
+      ]
+    },
+    {
+      "name": "op",
+      "type": "string"
+    },
+    {
+      "default": null,
+      "name": "ts_ms",
+      "type": [
+        "null",
+        "long"
+      ]
+    },
+    {
+      "default": null,
+      "name": "ts_us",
+      "type": [
+        "null",
+        "long"
+      ]
+    },
+    {
+      "default": null,
+      "name": "ts_ns",
+      "type": [
+        "null",
+        "long"
+      ]
+    }
+  ],
+  "name": "Envelope",
+  "namespace": "fixture_5f3a2c1d",
+  "type": "record"
+}

--- a/tests/integration/kafka_rest_apis/test_rest_consumer.py
+++ b/tests/integration/kafka_rest_apis/test_rest_consumer.py
@@ -6,14 +6,20 @@ See LICENSE for details
 import asyncio
 import base64
 import copy
+import io
 import json
 import logging
 import random
+import struct
 import time
+from pathlib import Path
 
 import pytest
 from pytest import LogCaptureFixture
 
+from karapace.core.config import Config
+from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
+from karapace.core.serialization import HEADER_FORMAT, START_BYTE, write_value
 from karapace.kafka_rest_apis.consumer_manager import KNOWN_FORMATS
 from tests.integration.kafka_rest_apis.test_rest import NEW_TOPIC_TIMEOUT
 from tests.utils import (
@@ -26,6 +32,91 @@ from tests.utils import (
     schema_data,
     wait_for_topics,
 )
+
+COMPLEX_UNION_AVRO_SCHEMA_JSON = json.dumps(
+    {
+        "namespace": "io.aiven.minimal",
+        "name": "MinimalUnionTest",
+        "type": "record",
+        "fields": [
+            {"name": "id", "type": "string"},
+            {
+                "name": "attrs",
+                "type": {
+                    "type": "array",
+                    "items": {
+                        "type": "record",
+                        "name": "Attr",
+                        "fields": [
+                            {"name": "k", "type": "string"},
+                            {"name": "v", "type": ["null", "string", "long", "double", "boolean"]},
+                        ],
+                    },
+                },
+            },
+            {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+        ],
+    }
+)
+
+COMPLEX_UNION_AVRO_RECORDS = [
+    {
+        "id": "one",
+        "attrs": [
+            {"k": "text", "v": "value"},
+            {"k": "count", "v": 5},
+            {"k": "ratio", "v": 1.5},
+            {"k": "flag", "v": True},
+            {"k": "empty", "v": None},
+        ],
+        "props": {"present": "yes", "missing": None},
+    }
+]
+
+DEBEZIUM_BYTES_SCHEMA_JSON = (
+    Path(__file__).resolve().parent / "test_data" / "debezium_decimal_bytes_envelope.avsc"
+).read_text()
+DEBEZIUM_BYTES_TYPED_SCHEMA = ValidatedTypedSchema.parse(SchemaType.AVRO, DEBEZIUM_BYTES_SCHEMA_JSON)
+DEBEZIUM_BYTES_RECORD = {
+    "before": None,
+    "after": {
+        "id": 1,
+        "uuid": "11111111-1111-1111-1111-111111111111",
+        "rate_table_id": 100,
+        "prediction_log_id": 200,
+        "probability": {"scale": 2, "value": b"\x01\x02"},
+        "prediction": "match",
+        "created_at": 1700000000000000,
+        "created_by": "22222222-2222-2222-2222-222222222222",
+        "updated_at": 1700000000000001,
+        "updated_by": "33333333-3333-3333-3333-333333333333",
+        "deleted_at": None,
+        "deleted_by": None,
+        "demand_sub_account_id": None,
+        "db_updated_at": None,
+    },
+    "source": {
+        "version": "2.5.0.Final",
+        "connector": "postgresql",
+        "name": "fixture_source",
+        "ts_ms": 1700000000000,
+        "snapshot": None,
+        "db": "fixture_db",
+        "sequence": None,
+        "ts_us": None,
+        "ts_ns": None,
+        "schema": "fixture_schema",
+        "table": "fixture_table",
+        "txId": None,
+        "lsn": None,
+        "xmin": None,
+    },
+    "transaction": None,
+    "op": "c",
+    "ts_ms": None,
+    "ts_us": None,
+    "ts_ns": None,
+}
 
 
 def produce_messages_from_list(producer, topic_name: str, values: list[bytes]) -> None:
@@ -84,6 +175,13 @@ def produce_json_messages(producer, topic_name: str, num_messages: int) -> None:
     """
     values = [json.dumps({"id": i, "data": f"item{i}"}).encode() for i in range(num_messages)]
     produce_messages_from_list(producer, topic_name, values)
+
+
+def encode_schema_registry_message(schema_id: int, schema: ValidatedTypedSchema, record: dict) -> bytes:
+    with io.BytesIO() as bio:
+        bio.write(struct.pack(HEADER_FORMAT, START_BYTE, schema_id))
+        write_value(Config(), schema, bio, record)
+        return bio.getvalue()
 
 
 async def assign_and_seek_to_beginning(
@@ -575,6 +673,71 @@ async def test_publish_consume_avro(rest_async_client, admin_client, trail, sche
     data_values = [x["value"] for x in data]
     for expected, actual in zip(publish_payload, data_values):
         assert expected == actual, f"Expecting {actual} to be {expected}"
+
+
+async def test_consume_complex_union_avro_schema_does_not_500(rest_async_client, admin_client):
+    header = REST_HEADERS["avro"]
+    group_name = "complex_union_group"
+    topic_name = new_topic(admin_client, prefix="complex_union")
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    await repeat_until_successful_request(
+        rest_async_client.post,
+        f"topics/{topic_name}",
+        json_data={
+            "value_schema": COMPLEX_UNION_AVRO_SCHEMA_JSON,
+            "records": [{"value": o} for o in COMPLEX_UNION_AVRO_RECORDS],
+        },
+        headers=header,
+        error_msg="Unexpected response status for complex union Avro publish",
+        timeout=10,
+        sleep=1,
+    )
+
+    instance_id = await new_consumer(rest_async_client, group_name, fmt="avro")
+    await assign_and_seek_to_beginning(rest_async_client, group_name, instance_id, topic_name, header)
+
+    resp = await rest_async_client.get(
+        f"/consumers/{group_name}/instances/{instance_id}/records?timeout=5000", headers=header
+    )
+    assert resp.ok, f"Expected a successful response: {resp}"
+    assert [item["value"] for item in resp.json()] == COMPLEX_UNION_AVRO_RECORDS
+
+
+async def test_consume_debezium_bytes_schema_does_not_500(
+    rest_async_client,
+    registry_async_client,
+    admin_client,
+    producer,
+):
+    header = REST_HEADERS["avro"]
+    group_name = "debezium_bytes_group"
+    topic_name = new_topic(admin_client, prefix="debezium_bytes")
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    subject = f"{topic_name}-value"
+    register_response = await registry_async_client.post(
+        f"subjects/{subject}/versions", json={"schema": DEBEZIUM_BYTES_SCHEMA_JSON}
+    )
+    assert register_response.ok, f"Expected schema registration to succeed: {register_response}"
+    schema_id = register_response.json()["id"]
+
+    producer.send(
+        topic_name,
+        value=encode_schema_registry_message(schema_id, DEBEZIUM_BYTES_TYPED_SCHEMA, DEBEZIUM_BYTES_RECORD),
+    )
+    producer.flush()
+
+    instance_id = await new_consumer(rest_async_client, group_name, fmt="avro")
+    await assign_and_seek_to_beginning(rest_async_client, group_name, instance_id, topic_name, header)
+
+    resp = await rest_async_client.get(
+        f"/consumers/{group_name}/instances/{instance_id}/records?timeout=5000", headers=header
+    )
+    assert resp.ok, f"Expected a successful response: {resp}"
+
+    [message] = resp.json()
+    assert message["value"]["after"]["probability"]["value"] == base64.b64encode(b"\x01\x02").decode("ascii")
 
 
 @pytest.mark.parametrize("fmt", ["avro"])

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -4,12 +4,13 @@ See LICENSE for details
 """
 
 import asyncio
+import base64
 import copy
 import io
 import json
 import logging
 import struct
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import avro
 import pytest
@@ -22,6 +23,7 @@ from karapace.core.serialization import (
     InvalidMessageHeader,
     InvalidMessageSchema,
     InvalidPayload,
+    SchemaRetrievalError,
     SchemaRegistryClient,
     SchemaRegistrySerializer,
     flatten_unions,
@@ -108,6 +110,74 @@ TYPED_PROTOBUF_SCHEMA = ValidatedTypedSchema.parse(
         string attr2 = 2;
     }\
     """,
+)
+
+MAP_UNION_AVRO_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.minimal",
+            "name": "MapUnionTest",
+            "type": "record",
+            "fields": [
+                {"name": "id", "type": "string"},
+                {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+            ],
+        }
+    ),
+)
+
+AVRO_BYTES_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.bytes",
+            "name": "BytesEnvelope",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "payload",
+                    "type": {
+                        "type": "record",
+                        "name": "Payload",
+                        "fields": [
+                            {"name": "raw", "type": "bytes"},
+                            {"name": "items", "type": {"type": "array", "items": "bytes"}},
+                        ],
+                    },
+                }
+            ],
+        }
+    ),
+)
+
+COMPLEX_UNION_AVRO_SCHEMA = ValidatedTypedSchema.parse(
+    SchemaType.AVRO,
+    json.dumps(
+        {
+            "namespace": "io.aiven.minimal",
+            "name": "MinimalUnionTest",
+            "type": "record",
+            "fields": [
+                {"name": "id", "type": "string"},
+                {
+                    "name": "attrs",
+                    "type": {
+                        "type": "array",
+                        "items": {
+                            "type": "record",
+                            "name": "Attr",
+                            "fields": [
+                                {"name": "k", "type": "string"},
+                                {"name": "v", "type": ["null", "string", "long", "double", "boolean"]},
+                            ],
+                        },
+                    },
+                },
+                {"name": "props", "type": {"type": "map", "values": ["null", "string"]}},
+            ],
+        }
+    ),
 )
 
 
@@ -372,6 +442,187 @@ async def test_deserialization_fails(karapace_container: KarapaceContainer):
         await deserializer.deserialize(enc_bytes)
 
     assert mock_registry_client.method_calls == [call.get_schema_for_id(1)]
+
+
+async def test_deserialization_propagates_schema_retrieval_error(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    mock_registry_client.get_schema_for_id.side_effect = SchemaRetrievalError("schema registry unavailable")
+
+    deserializer = await make_ser_deser(karapace_container, mock_registry_client)
+    payload = struct.pack(">bI", START_BYTE, 1)
+
+    with pytest.raises(SchemaRetrievalError, match="schema registry unavailable"):
+        await deserializer.deserialize(payload)
+
+    assert mock_registry_client.method_calls == [call.get_schema_for_id(1)]
+
+
+async def test_deserialize_offloads_avro_read_to_thread(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, COMPLEX_UNION_AVRO_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((COMPLEX_UNION_AVRO_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {
+        "id": "one",
+        "attrs": [
+            {"k": "text", "v": "value"},
+            {"k": "count", "v": 5},
+            {"k": "ratio", "v": 1.5},
+            {"k": "flag", "v": True},
+            {"k": "empty", "v": None},
+        ],
+        "props": {"present": "yes", "missing": None},
+    }
+    payload = await serializer.serialize(schema, record)
+
+    to_thread_calls: list[str] = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    with patch("karapace.core.serialization.asyncio.to_thread", side_effect=fake_to_thread):
+        assert await serializer.deserialize(payload) == record
+
+    assert to_thread_calls == ["_read_avro_value"]
+
+
+async def test_deserialize_reuses_datum_reader_for_map_union_schema(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, MAP_UNION_AVRO_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((MAP_UNION_AVRO_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {"id": "one", "props": {"present": "yes", "missing": None}}
+    payload = await serializer.serialize(schema, record)
+    original_datum_reader = avro.io.DatumReader
+    datum_reader_init_count = 0
+
+    class CountingDatumReader:
+        def __init__(self, writers_schema):
+            nonlocal datum_reader_init_count
+            datum_reader_init_count += 1
+            self._delegate = original_datum_reader(writers_schema=writers_schema)
+
+        def read(self, decoder):
+            return self._delegate.read(decoder)
+
+    with patch("karapace.core.serialization.DatumReader", CountingDatumReader):
+        assert await serializer.deserialize(payload) == record
+        assert await serializer.deserialize(payload) == record
+
+    assert datum_reader_init_count == 1
+
+
+async def test_deserialize_reuses_datum_reader_for_complex_avro_schema(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, COMPLEX_UNION_AVRO_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((COMPLEX_UNION_AVRO_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {
+        "id": "one",
+        "attrs": [
+            {"k": "text", "v": "value"},
+            {"k": "count", "v": 5},
+            {"k": "ratio", "v": 1.5},
+            {"k": "flag", "v": True},
+        ],
+        "props": {"present": "yes", "missing": None},
+    }
+    payload = await serializer.serialize(schema, record)
+    original_datum_reader = avro.io.DatumReader
+    datum_reader_init_count = 0
+
+    class CountingDatumReader:
+        def __init__(self, writers_schema):
+            nonlocal datum_reader_init_count
+            datum_reader_init_count += 1
+            self._delegate = original_datum_reader(writers_schema=writers_schema)
+
+        def read(self, decoder):
+            return self._delegate.read(decoder)
+
+    with patch("karapace.core.serialization.DatumReader", CountingDatumReader):
+        assert await serializer.deserialize(payload) == record
+        assert await serializer.deserialize(payload) == record
+
+    assert datum_reader_init_count == 1
+
+
+async def test_deserialize_converts_avro_bytes_to_base64_strings(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, AVRO_BYTES_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((AVRO_BYTES_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {
+        "payload": {
+            "raw": b"\x01\x02",
+            "items": [b"\x03\x04", b"\x05\x06"],
+        }
+    }
+    payload = await serializer.serialize(schema, record)
+
+    assert await serializer.deserialize(payload) == {
+        "payload": {
+            "raw": base64.b64encode(b"\x01\x02").decode("ascii"),
+            "items": [
+                base64.b64encode(b"\x03\x04").decode("ascii"),
+                base64.b64encode(b"\x05\x06").decode("ascii"),
+            ],
+        }
+    }
+
+
+async def test_deserialize_converts_empty_avro_bytes_to_empty_base64_strings(
+    karapace_container: KarapaceContainer,
+) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, AVRO_BYTES_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((AVRO_BYTES_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {
+        "payload": {
+            "raw": b"",
+            "items": [b"", b""],
+        }
+    }
+    payload = await serializer.serialize(schema, record)
+
+    assert await serializer.deserialize(payload) == {
+        "payload": {
+            "raw": "",
+            "items": ["", ""],
+        }
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This PR improves Avro deserialization behavior in the schema registry serializer and REST proxy consumer path by caching Avro datum readers, offloading Avro reads from the event loop, and ensuring Avro bytes fields can be returned safely as JSON-compatible base64 strings.

### Changes

- Added per-thread cached Avro DatumReader usage and offloaded Avro reads via asyncio.to_thread.
- Converted Avro bytes/bytearray values to base64 strings during deserialization.
- Added unit, integration, and e2e coverage for complex Avro unions, map unions, and bytes-heavy Debezium-style schemas.

### Performance 

There is a significant improvement to the memory usage while running the performance tests for rest-proxy, all with 0 failures. 

IT/e2e tests were added, It would be nice to test this further with load. 