### PR TITLE
tests: performance tests with resource usage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/karapace/version.py
 *.coverage
 *.env
 test-tmp.*
+performance-test/results/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,6 +15,7 @@ RUNNER_UID ?=
 RUNNER_GID ?=
 COVERAGE_FILE ?= .coverage.${PYTHON_VERSION}
 KARAPACE_CLI   ?= $(DOCKER_COMPOSE) -f container/compose.yml run --rm karapace-cli
+KARAPACE_CLI_NO_DEPS ?= $(DOCKER_COMPOSE) -f container/compose.yml run --rm --no-deps karapace-cli
 CERTS_FOLDER ?= /opt/karapace/certs
 
 # Export variables needed by docker compose
@@ -114,7 +115,13 @@ pin-requirements:
 
 .PHONY: stop-karapace-docker-resources
 stop-karapace-docker-resources:
-	COMPOSE_PROFILES=e2e $(DOCKER_COMPOSE) -f container/compose.yml down -v --remove-orphans
+	$(DOCKER_COMPOSE) -f container/compose.yml rm -sfv \
+		karapace-schema-registry-authn-only \
+		karapace-rest-proxy-oidc \
+		karapace-rest-proxy-no-forward \
+		karapace-schema-registry-basic \
+		karapace-rest-proxy-basic || true
+	$(DOCKER_COMPOSE) -f container/compose.yml down -v --remove-orphans
 
 .PHONY: start-karapace-docker-resources
 start-karapace-docker-resources:
@@ -125,53 +132,92 @@ start-karapace-docker-resources:
 	chown -R ${RUNNER_UID}:${RUNNER_GID} test-tmp.${PYTHON_VERSION} 2>/dev/null || sudo chown -R ${RUNNER_UID}:${RUNNER_GID} test-tmp.${PYTHON_VERSION}
 	$(DOCKER_COMPOSE) -f container/compose.yml up -d --build --wait --detach
 
+.PHONY: start-karapace-docker-resources-no-deps
+start-karapace-docker-resources-no-deps:
+	touch .coverage.${PYTHON_VERSION} || sudo touch .coverage.${PYTHON_VERSION}
+	chown ${RUNNER_UID}:${RUNNER_GID} .coverage.${PYTHON_VERSION} 2>/dev/null || sudo chown ${RUNNER_UID}:${RUNNER_GID} .coverage.${PYTHON_VERSION}
+	mkdir -p test-tmp.${PYTHON_VERSION} || sudo mkdir -p test-tmp.${PYTHON_VERSION}
+	chown -R ${RUNNER_UID}:${RUNNER_GID} test-tmp.${PYTHON_VERSION} 2>/dev/null || sudo chown -R ${RUNNER_UID}:${RUNNER_GID} test-tmp.${PYTHON_VERSION}
+	$(DOCKER_COMPOSE) -f container/compose.yml build karapace-cli
+
 .PHONY: smoke-test-schema-registry
-smoke-test-schema-registry: start-karapace-docker-resources
+smoke-test-schema-registry: stop-karapace-docker-resources start-karapace-docker-resources
 	$(KARAPACE_CLI) /opt/karapace/bin/smoke-test-schema-registry.sh
 
 .PHONY: smoke-test-rest-proxy
-smoke-test-rest-proxy: start-karapace-docker-resources
+smoke-test-rest-proxy: stop-karapace-docker-resources start-karapace-docker-resources
 	$(KARAPACE_CLI) /opt/karapace/bin/smoke-test-rest-proxy.sh
 
 .PHONY: performance-test-rest-proxy
 performance-test-rest-proxy: start-karapace-docker-resources
 	cd performance-test && \
+		CLEAN_RESULTS=0 \
+		COLLECT_DOCKER_STATS=1 \
+		LOCUST_GUI=0 LOCUST_AUTOQUIT=0 \
 		BASE_URL=http://localhost:8082 \
+		CONCURRENCY=200 \
+		LOCUST_SPAWN_RATE=50 \
+		CONSUME_TIMEOUT=10 \
+		PRODUCE_TASK_WEIGHT=5 \
+		CONSUME_TASK_WEIGHT=10 \
 		LOCUST_FILE=rest-proxy-produce-consume-test.py \
 		./run-locust-test.sh
 
 .PHONY: performance-test-schema-registry
 performance-test-schema-registry: start-karapace-docker-resources
 	cd performance-test && \
+		CLEAN_RESULTS=0 \
+		COLLECT_DOCKER_STATS=1 \
+		LOCUST_GUI=0 LOCUST_AUTOQUIT=0 \
 		BASE_URL=https://localhost:8081 \
 		AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN=1 \
+		CONCURRENCY=200 \
+		LOCUST_SPAWN_RATE=50 \
+		SCHEMA_REGISTER_NEW_WEIGHT=5 \
+		SCHEMA_CHECK_REGISTERED_WEIGHT=10 \
 		LOCUST_FILE=schema-registry-schema-post.py \
 		./run-locust-test.sh
 
 .PHONY: unit-tests-in-docker
-unit-tests-in-docker: start-karapace-docker-resources
+unit-tests-in-docker: start-karapace-docker-resources-no-deps
 	rm -fr runtime/*
-	$(KARAPACE_CLI) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/unit/
+	$(KARAPACE_CLI_NO_DEPS) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/unit/
 	rm -fr runtime/*
 
 .PHONY: e2e-tests-in-docker
-e2e-tests-in-docker: export COMPOSE_PROFILES = e2e
-e2e-tests-in-docker: stop-karapace-docker-resources start-karapace-docker-resources
+e2e-tests-in-docker:
+	COMPOSE_PROFILES=e2e $(MAKE) stop-karapace-docker-resources
+	COMPOSE_PROFILES=e2e $(MAKE) start-karapace-docker-resources
 	rm -fr runtime/*
 	sleep 10
-	$(KARAPACE_CLI) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/e2e/
+	set +x; \
+	token_file=$$(mktemp) && \
+	for attempt in 1 2 3; do \
+		if COMPOSE_PROFILES=e2e KEYCLOAK_STARTUP_TIMEOUT_SECONDS=180 $(KARAPACE_CLI) /opt/karapace/bin/get_oidc_token.py > "$$token_file"; then \
+			break; \
+		fi; \
+		if [[ $$attempt -eq 3 ]]; then \
+			rm -f "$$token_file"; \
+			exit 1; \
+		fi; \
+		echo "Fetching e2e OIDC token failed, retrying in 10 seconds ..."; \
+		sleep 10; \
+	done && \
+	TOKEN=$$(tr -d '\r\n' < "$$token_file") && \
+	rm -f "$$token_file"; \
+	set -x; \
+	COMPOSE_PROFILES=e2e KARAPACE_E2E_OIDC_TOKEN="$$TOKEN" $(KARAPACE_CLI) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/e2e/
 	rm -fr runtime/*
 
 .PHONY: integration-tests-in-docker
-integration-tests-in-docker: start-karapace-docker-resources
+integration-tests-in-docker: start-karapace-docker-resources-no-deps
 	rm -fr runtime/*
-	sleep 10
-	$(KARAPACE_CLI) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/integration/
+	$(KARAPACE_CLI_NO_DEPS) $(PYTHON) -m pytest -s -vvv $(PYTEST_ARGS) tests/integration/
 	rm -fr runtime/*
 
 .PHONY: type-check-mypy-in-docker
-type-check-mypy-in-docker: start-karapace-docker-resources
-	$(KARAPACE_CLI) $(PYTHON) -m mypy src/karapace
+type-check-mypy-in-docker: start-karapace-docker-resources-no-deps
+	$(KARAPACE_CLI_NO_DEPS) $(PYTHON) -m mypy src/karapace
 
 .PHONY: cli
 cli: start-karapace-docker-resources

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -114,7 +114,7 @@ pin-requirements:
 
 .PHONY: stop-karapace-docker-resources
 stop-karapace-docker-resources:
-	$(DOCKER_COMPOSE) -f container/compose.yml down -v --remove-orphans
+	COMPOSE_PROFILES=e2e $(DOCKER_COMPOSE) -f container/compose.yml down -v --remove-orphans
 
 .PHONY: start-karapace-docker-resources
 start-karapace-docker-resources:
@@ -132,6 +132,21 @@ smoke-test-schema-registry: start-karapace-docker-resources
 .PHONY: smoke-test-rest-proxy
 smoke-test-rest-proxy: start-karapace-docker-resources
 	$(KARAPACE_CLI) /opt/karapace/bin/smoke-test-rest-proxy.sh
+
+.PHONY: performance-test-rest-proxy
+performance-test-rest-proxy: start-karapace-docker-resources
+	cd performance-test && \
+		BASE_URL=http://localhost:8082 \
+		LOCUST_FILE=rest-proxy-produce-consume-test.py \
+		./run-locust-test.sh
+
+.PHONY: performance-test-schema-registry
+performance-test-schema-registry: start-karapace-docker-resources
+	cd performance-test && \
+		BASE_URL=https://localhost:8081 \
+		AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN=1 \
+		LOCUST_FILE=schema-registry-schema-post.py \
+		./run-locust-test.sh
 
 .PHONY: unit-tests-in-docker
 unit-tests-in-docker: start-karapace-docker-resources
@@ -163,7 +178,7 @@ cli: start-karapace-docker-resources
 	$(KARAPACE_CLI) bash
 
 .PHONY: generate-sr-https-certs
- generate-sr-https-certs:
+generate-sr-https-certs:
 	$(info ====> Generating self-signed certificates <====)
 	$(KARAPACE_CLI) mkcert -key-file $(CERTS_FOLDER)/key.pem -cert-file $(CERTS_FOLDER)/cert.pem \
 		localhost \

--- a/bin/get_oidc_token.py
+++ b/bin/get_oidc_token.py
@@ -6,52 +6,62 @@ See LICENSE for details
 
 import os
 import requests
+from urllib.parse import urlsplit, urlunsplit
 
-KEYCLOAK_URL = "http://keycloak:8080"
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080")
+KEYCLOAK_CONNECT_URL = os.environ.get("KEYCLOAK_CONNECT_URL", KEYCLOAK_URL)
 REALM = "karapace"
 CLIENT_ID = "karapace-client"
 ADMIN_USER = os.environ.get("KEYCLOAK_ADMIN", "admin")
 ADMIN_PASS = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
 
 
+def _request(method, path, **kwargs):
+    logical = urlsplit(KEYCLOAK_URL)
+    connect = urlsplit(KEYCLOAK_CONNECT_URL)
+    url = urlunsplit((connect.scheme, connect.netloc, path, "", ""))
+
+    headers = dict(kwargs.pop("headers", {}))
+    if connect.netloc != logical.netloc:
+        headers["Host"] = logical.netloc
+
+    return requests.request(method, url, headers=headers, **kwargs)
+
+
 def get_admin_token():
-    url = f"{KEYCLOAK_URL}/realms/master/protocol/openid-connect/token"
     data = {
         "grant_type": "password",
         "client_id": "admin-cli",
         "username": ADMIN_USER,
         "password": ADMIN_PASS,
     }
-    resp = requests.post(url, data=data)
+    resp = _request("POST", "/realms/master/protocol/openid-connect/token", data=data)
     resp.raise_for_status()
     return resp.json()["access_token"]
 
 
 def get_client_uuid(admin_token):
-    url = f"{KEYCLOAK_URL}/admin/realms/{REALM}/clients?clientId={CLIENT_ID}"
     headers = {"Authorization": f"Bearer {admin_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = _request("GET", f"/admin/realms/{REALM}/clients", headers=headers, params={"clientId": CLIENT_ID})
     resp.raise_for_status()
     return resp.json()[0]["id"]
 
 
 def get_client_secret(client_uuid, admin_token):
-    url = f"{KEYCLOAK_URL}/admin/realms/{REALM}/clients/{client_uuid}/client-secret"
     headers = {"Authorization": f"Bearer {admin_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = _request("GET", f"/admin/realms/{REALM}/clients/{client_uuid}/client-secret", headers=headers)
     resp.raise_for_status()
     return resp.json()["value"]
 
 
 def get_oidc_token(client_secret):
-    url = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token"
     data = {
         "grant_type": "client_credentials",
         "client_id": CLIENT_ID,
         "client_secret": client_secret,
         "scope": "openid",
     }
-    resp = requests.post(url, data=data)
+    resp = _request("POST", f"/realms/{REALM}/protocol/openid-connect/token", data=data)
     resp.raise_for_status()
     return resp.json()["access_token"]
 

--- a/bin/get_oidc_token.py
+++ b/bin/get_oidc_token.py
@@ -5,27 +5,64 @@ See LICENSE for details
 """
 
 import os
+import sys
+import time
 import requests
+from requests.exceptions import RequestException
 from urllib.parse import urlsplit, urlunsplit
 
 KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080")
 KEYCLOAK_CONNECT_URL = os.environ.get("KEYCLOAK_CONNECT_URL", KEYCLOAK_URL)
+KEYCLOAK_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("KEYCLOAK_REQUEST_TIMEOUT_SECONDS", "5"))
+KEYCLOAK_STARTUP_TIMEOUT_SECONDS = float(os.environ.get("KEYCLOAK_STARTUP_TIMEOUT_SECONDS", "60"))
+KEYCLOAK_RETRY_DELAY_SECONDS = float(os.environ.get("KEYCLOAK_RETRY_DELAY_SECONDS", "1"))
+KEYCLOAK_RETRYABLE_STATUS_CODES = {502, 503}
 REALM = "karapace"
 CLIENT_ID = "karapace-client"
 ADMIN_USER = os.environ.get("KEYCLOAK_ADMIN", "admin")
 ADMIN_PASS = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
 
 
+def _build_request_url(path):
+    connect = urlsplit(KEYCLOAK_CONNECT_URL)
+    connect_path = connect.path.rstrip("/")
+    request_path = path if path.startswith("/") else f"/{path}"
+    full_path = f"{connect_path}{request_path}" if connect_path else request_path
+    return urlunsplit((connect.scheme, connect.netloc, full_path, "", ""))
+
+
 def _request(method, path, **kwargs):
     logical = urlsplit(KEYCLOAK_URL)
     connect = urlsplit(KEYCLOAK_CONNECT_URL)
-    url = urlunsplit((connect.scheme, connect.netloc, path, "", ""))
+    url = _build_request_url(path)
 
     headers = dict(kwargs.pop("headers", {}))
     if connect.netloc != logical.netloc:
         headers["Host"] = logical.netloc
 
-    return requests.request(method, url, headers=headers, **kwargs)
+    deadline = time.monotonic() + KEYCLOAK_STARTUP_TIMEOUT_SECONDS
+    last_exception = None
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=headers,
+                timeout=KEYCLOAK_REQUEST_TIMEOUT_SECONDS,
+                **kwargs,
+            )
+            if response.status_code not in KEYCLOAK_RETRYABLE_STATUS_CODES:
+                return response
+            last_exception = RuntimeError(f"Keycloak returned retryable status {response.status_code} for {url}")
+        except RequestException as exc:
+            last_exception = exc
+
+        time.sleep(KEYCLOAK_RETRY_DELAY_SECONDS)
+
+    raise TimeoutError(
+        f"Keycloak did not become ready for {url} within {KEYCLOAK_STARTUP_TIMEOUT_SECONDS} seconds"
+    ) from last_exception
 
 
 def get_admin_token():
@@ -67,8 +104,12 @@ def get_oidc_token(client_secret):
 
 
 if __name__ == "__main__":
-    admin_token = get_admin_token()
-    client_uuid = get_client_uuid(admin_token)
-    client_secret = get_client_secret(client_uuid, admin_token)
-    token = get_oidc_token(client_secret)
-    print(token)
+    try:
+        admin_token = get_admin_token()
+        client_uuid = get_client_uuid(admin_token)
+        client_secret = get_client_secret(client_uuid, admin_token)
+        token = get_oidc_token(client_secret)
+        print(token)
+    except Exception as exc:
+        print(f"get_oidc_token.py: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/bin/smoke-test-schema-registry.sh
+++ b/bin/smoke-test-schema-registry.sh
@@ -1,20 +1,33 @@
 #!/usr/bin/env bash
 
+set -uo pipefail
+
 retries=5
+last_oidc_error=""
 chmod +x /opt/karapace/bin/get_oidc_token.py
-token=$(/opt/karapace/bin/get_oidc_token.py)
 
 for ((i = 0; i <= retries; i++)); do
-    response=$(
-        curl --silent --verbose --fail --request POST \
-            --cacert "$CAROOT/rootCA.pem" \
-            --header "Authorization: Bearer $token" \
-            --header 'Content-Type: application/vnd.schemaregistry.v1+json' \
-            --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
-            "https://karapace-schema-registry:8081/subjects/test-key/versions"
-    )
+    if ! token=$(/opt/karapace/bin/get_oidc_token.py 2>&1); then
+        last_oidc_error="$token"
+        if ((i == retries)); then
+            echo "Still failing to fetch OIDC token after $i retries, giving up."
+            if [[ -n ${last_oidc_error} ]]; then
+                printf '%s\n' "${last_oidc_error}" >&2
+            fi
+            exit 1
+        fi
 
-    if [[ $response == '{"id":1}' ]]; then
+        echo "Fetching OIDC token failed, retrying in 5 seconds ..."
+        sleep 5
+        continue
+    fi
+
+    if curl --silent --show-error --fail --request POST \
+        --cacert "$CAROOT/rootCA.pem" \
+        --header "Authorization: Bearer $token" \
+        --header 'Content-Type: application/vnd.schemaregistry.v1+json' \
+        --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
+        "https://karapace-schema-registry:8081/subjects/test-key/versions"; then
         echo "Ok!"
         break
     fi

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -15,13 +15,14 @@ services:
         RUNNER_UID: $RUNNER_UID
         RUNNER_GID: $RUNNER_GID
     tty: true
-    cpus: 1.0
+    cpus: 2.0
     mem_limit: 1g
     mem_reservation: 512m
     depends_on:
       - kafka
       - karapace-schema-registry
       - karapace-rest-proxy
+      - keycloak
     volumes:
       - ./certs:/opt/karapace/certs
       - ../bin:/opt/karapace/bin
@@ -55,11 +56,12 @@ services:
     depends_on:
       - kafka
       - opentelemetry-collector
+      - keycloak
     ports:
       - 8081:8081
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     volumes:
       - ./certs:/opt/karapace/certs
     environment:
@@ -119,6 +121,7 @@ services:
     depends_on:
       - kafka
       - opentelemetry-collector
+      - keycloak
     ports:
       - 8181:8181
     cpus: 0.25
@@ -186,6 +189,7 @@ services:
     depends_on:
       - kafka
       - opentelemetry-collector
+      - keycloak
     ports:
       - 8281:8281
     cpus: 0.25
@@ -385,7 +389,7 @@ services:
     ports:
       - 8082:8082
     cpus: 0.5
-    mem_limit: 1g
+    mem_limit: 512m
     mem_reservation: 512m
     environment:
       KARAPACE_KARAPACE_REST: true
@@ -457,8 +461,8 @@ services:
     hostname: prometheus
     container_name: prometheus
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     command:
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=1d
@@ -481,8 +485,8 @@ services:
     hostname: grafana
     container_name: grafana
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     environment:
       GF_SECURITY_ADMIN_USER: karapace
       GF_SECURITY_ADMIN_PASSWORD: karapace
@@ -500,8 +504,8 @@ services:
     hostname: statsd-exporter
     container_name: statsd-exporter
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     command: --statsd.listen-udp=:8125 --web.listen-address=:9102
     ports:
       - 9102:9102
@@ -514,8 +518,8 @@ services:
     hostname: opentelemetry-collector
     container_name: opentelemetry-collector
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     command: --config=/etc/collector-config.yaml
     volumes:
       - ./opentelemetry/collector-config.yaml:/etc/collector-config.yaml
@@ -531,8 +535,8 @@ services:
     hostname: jaeger
     container_name: jaeger
     cpus: 0.5
-    mem_limit: 512m
-    mem_reservation: 512m
+    mem_limit: 256m
+    mem_reservation: 256m
     ports:  # 6831=agent | 16686=UI | 14268=spans | 4317=metrics (not exposing, clashes with opentelemetry-collector)
       - 6831:6831/udp
       - 16686:16686
@@ -545,7 +549,7 @@ services:
     hostname: keycloak
     container_name: keycloak
     cpus: 0.5
-    mem_limit: 512m
+    mem_limit: 1g
     mem_reservation: 512m
     environment:
       KEYCLOAK_ADMIN: admin

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -15,6 +15,9 @@ services:
         RUNNER_UID: $RUNNER_UID
         RUNNER_GID: $RUNNER_GID
     tty: true
+    cpus: 1.0
+    mem_limit: 1g
+    mem_reservation: 512m
     depends_on:
       - kafka
       - karapace-schema-registry
@@ -54,6 +57,9 @@ services:
       - opentelemetry-collector
     ports:
       - 8081:8081
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     volumes:
       - ./certs:/opt/karapace/certs
     environment:
@@ -115,6 +121,9 @@ services:
       - opentelemetry-collector
     ports:
       - 8181:8181
+    cpus: 0.25
+    mem_limit: 256m
+    mem_reservation: 256m
     volumes:
       - ./certs:/opt/karapace/certs
     environment:
@@ -179,6 +188,9 @@ services:
       - opentelemetry-collector
     ports:
       - 8281:8281
+    cpus: 0.25
+    mem_limit: 256m
+    mem_reservation: 256m
     volumes:
       - ./certs:/opt/karapace/certs
     environment:
@@ -372,6 +384,9 @@ services:
       - karapace-schema-registry
     ports:
       - 8082:8082
+    cpus: 0.5
+    mem_limit: 1g
+    mem_reservation: 512m
     environment:
       KARAPACE_KARAPACE_REST: true
       KARAPACE_PORT: 8082
@@ -402,6 +417,9 @@ services:
     ports:
       - "9092:9092"
       - "9101:9101"  # JMX
+    cpus: 1.0
+    mem_limit: 1g
+    mem_reservation: 1g
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
@@ -438,6 +456,9 @@ services:
     image: prom/prometheus
     hostname: prometheus
     container_name: prometheus
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     command:
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=1d
@@ -459,6 +480,9 @@ services:
     image: grafana/grafana
     hostname: grafana
     container_name: grafana
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     environment:
       GF_SECURITY_ADMIN_USER: karapace
       GF_SECURITY_ADMIN_PASSWORD: karapace
@@ -475,6 +499,9 @@ services:
     image: prom/statsd-exporter
     hostname: statsd-exporter
     container_name: statsd-exporter
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     command: --statsd.listen-udp=:8125 --web.listen-address=:9102
     ports:
       - 9102:9102
@@ -486,6 +513,9 @@ services:
     image: otel/opentelemetry-collector-contrib:latest
     hostname: opentelemetry-collector
     container_name: opentelemetry-collector
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     command: --config=/etc/collector-config.yaml
     volumes:
       - ./opentelemetry/collector-config.yaml:/etc/collector-config.yaml
@@ -500,6 +530,9 @@ services:
     image: jaegertracing/all-in-one:latest
     hostname: jaeger
     container_name: jaeger
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     ports:  # 6831=agent | 16686=UI | 14268=spans | 4317=metrics (not exposing, clashes with opentelemetry-collector)
       - 6831:6831/udp
       - 16686:16686
@@ -511,6 +544,9 @@ services:
     image: quay.io/keycloak/keycloak:24.0
     hostname: keycloak
     container_name: keycloak
+    cpus: 0.5
+    mem_limit: 512m
+    mem_reservation: 512m
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin

--- a/performance-test/README.rst
+++ b/performance-test/README.rst
@@ -27,7 +27,15 @@ Performance test is run from the shell script::
 
   ./run-locust-test.sh
 
-Or use the dedicated Make targets from the repository root::
+Direct script usage opens the Locust web UI by default and autostarts the run. To force a headless run::
+
+  LOCUST_GUI=0 ./run-locust-test.sh
+
+To run with metrics collection enabled::
+
+  COLLECT_DOCKER_STATS=1 ./run-locust-test.sh
+
+Or use the dedicated Make targets from the repository root (headless by default)::
 
   make performance-test-rest-proxy
   make performance-test-schema-registry
@@ -51,5 +59,40 @@ Script supports some environment variables:
  * `TOPIC` for setting the topic name where data is produced.
  * `DURATION` for setting how long the test runs.
  * `CONCURRENCY` for setting how many concurrent users are emulated.
- * `LOCUST_GUI` for enabling the Locust web user interface.
+ * `CONSUME_TIMEOUT` for setting the REST proxy records-poll timeout in milliseconds. Lower values increase poll
+   frequency and usually raise req/s for consume-heavy runs. The default is `1000`.
+ * `PRODUCE_TASK_WEIGHT` for setting how often each user produces records relative to consume requests. The default is
+   `1`.
+ * `CONSUME_TASK_WEIGHT` for setting how often each user reads records relative to produce requests. The default is
+   `5`, so the test now puts more pressure on the records-consumption path while still keeping many consumer
+   instances alive.
+ * `SCHEMA_REGISTER_NEW_WEIGHT` for setting how often the schema-registry load test registers new schemas. The default
+   is `10`.
+ * `SCHEMA_CHECK_REGISTERED_WEIGHT` for setting how often the schema-registry load test checks already-registered
+   schemas. The default is `10`.
+ * `LOCUST_SPAWN_RATE` for setting how many users per second Locust should add while ramping up. The default is `10`.
+ * `LOCUST_GUI` for enabling the Locust web user interface (`1` by default, `0` to force a headless run).
+ * `LOCUST_AUTOQUIT` for telling Locust how many seconds after a completed GUI run it should shut down the web UI.
+   The default is `0`, which keeps the current behavior of leaving the UI running indefinitely.
  * `LOCUST_FILE` for selecting the Locust test script.
+ * `LOCUST_STOP_TIMEOUT` for setting how many seconds Locust should wait for users to finish their current work and
+   run `on_stop()` cleanup before force-stopping them. The default is `30`.
+ * `COLLECT_DOCKER_STATS` for enabling Docker stats sampling during the run. The default is `0`, so plain load runs do
+   not collect container metrics unless explicitly requested.
+ * `CLEAN_RESULTS` for deleting the selected results subdirectory before a run starts. The default is `0`, so previous
+   artifacts are kept unless you opt in.
+ * `DOCKER_STATS_INTERVAL` for setting the Docker stats sampling interval in seconds.
+ * `DOCKER_STATS_CONTAINERS` for overriding the sampled container list. By default the script tracks
+   `karapace-rest-proxy`, `karapace-schema-registry`, `karapace-schema-registry-follower`, `kafka`, and `keycloak`.
+ * `DOCKER_STATS_POST_RUN_DELAY` for keeping Docker stats collection running a few seconds after Locust stops.
+
+When Docker stats collection is enabled, `run-locust-test.sh` samples container resource usage while Locust is
+running and writes the final CSV and table-formatted log only after the Locust process exits. By default it also
+waits 10 seconds after Locust finishes before stopping Docker stats collection, so the final snapshots show whether
+resource usage returns to idle levels.
+
+The REST proxy load test creates one REST proxy consumer instance per Locust user. Each user both produces and
+consumes, with consume requests weighted more heavily by default. This keeps the many-consumer-instance behavior while
+driving more traffic through the records-consumption path.
+
+Artifacts are written under `performance-test/results/rest-proxy/` or `performance-test/results/schema-registry/`.

--- a/performance-test/README.rst
+++ b/performance-test/README.rst
@@ -27,6 +27,18 @@ Performance test is run from the shell script::
 
   ./run-locust-test.sh
 
+Or use the dedicated Make targets from the repository root::
+
+  make performance-test-rest-proxy
+  make performance-test-schema-registry
+
+For the schema-registry Locust test, the dedicated Make target uses the local HTTPS schema-registry endpoint::
+
+  make performance-test-schema-registry
+
+The script also fetches an OIDC bearer token automatically for `schema-registry-schema-post.py` by calling
+`bin/get_oidc_token.py`, using `KEYCLOAK_CONNECT_URL=http://localhost:8383` by default.
+
 A web interface must be running on http://0.0.0.0:8089/ to run tests
 
 Here is a screenshot of performance tests locally.

--- a/performance-test/collect-docker-stats.sh
+++ b/performance-test/collect-docker-stats.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+output_file=${1:?output file is required}
+interval_seconds=${2:?interval is required}
+shift 2
+containers=("$@")
+parent_pid=${DOCKER_STATS_PARENT_PID-}
+
+if [[ ${#containers[@]} -eq 0 ]]; then
+    echo "At least one container name is required" >&2
+    exit 1
+fi
+
+table_output_file=${output_file%.csv}.table.log
+shutting_down=0
+
+render_table() {
+    [[ -f ${output_file} ]] || return 0
+
+    : >"${table_output_file}"
+
+    /usr/bin/awk -F',' '
+        function flush_snapshot() {
+            if (current_ts == "") {
+                return
+            }
+
+            sep = sprintf("%144s", "")
+            gsub(/ /, "=", sep)
+            print sep
+            printf "Docker stats snapshot at %s\n", current_ts
+            print sep
+            printf "%-34s %-8s %-26s %-8s %-22s %-20s %-5s\n", "container", "cpu", "mem_usage", "mem%", "net_io", "block_io", "pids"
+            print sep
+            printf "%s", snapshot_buffer
+            printf "\n"
+            snapshot_buffer = ""
+        }
+
+        NR == 1 {
+            next
+        }
+
+        {
+            ts = $1
+            if (current_ts != "" && ts != current_ts) {
+                flush_snapshot()
+            }
+            current_ts = ts
+            snapshot_buffer = snapshot_buffer sprintf("%-34s %-8s %-26s %-8s %-22s %-20s %-5s\n", $2, $3, $4, $5, $6, $7, $8)
+        }
+
+        END {
+            flush_snapshot()
+        }
+    ' "${output_file}" >"${table_output_file}"
+}
+
+cleanup() {
+    if [[ ${shutting_down} == "1" ]]; then
+        return
+    fi
+    shutting_down=1
+    render_table
+}
+
+handle_signal() {
+    cleanup
+    exit 0
+}
+
+trap cleanup EXIT
+trap handle_signal INT TERM
+
+mkdir -p "$(dirname "${output_file}")"
+printf 'timestamp,container,cpu_perc,mem_usage,mem_perc,net_io,block_io,pids\n' >"${output_file}"
+
+while true; do
+    if [[ -n ${parent_pid} ]] && ! kill -0 "${parent_pid}" 2>/dev/null; then
+        exit 0
+    fi
+
+    if [[ ! -d $(dirname "${output_file}") ]]; then
+        exit 0
+    fi
+
+    mapfile -t running_containers < <(docker ps --format '{{.Names}}')
+    active_containers=()
+    for container in "${containers[@]}"; do
+        if printf '%s\n' "${running_containers[@]}" | /usr/bin/grep -Fxq "${container}"; then
+            active_containers+=("${container}")
+        fi
+    done
+
+    if [[ ${#active_containers[@]} -eq 0 ]]; then
+        sleep "${interval_seconds}"
+        continue
+    fi
+
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    while IFS= read -r line; do
+        [[ -n ${line} ]] || continue
+        if [[ ! -d $(dirname "${output_file}") ]]; then
+            exit 0
+        fi
+        printf '%s,%s\n' "${timestamp}" "${line}" >>"${output_file}"
+    done < <(
+        docker stats --no-stream --format '{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.MemPerc}},{{.NetIO}},{{.BlockIO}},{{.PIDs}}' "${active_containers[@]}" 2>/dev/null
+    )
+    sleep "${interval_seconds}"
+done

--- a/performance-test/rest-proxy-produce-consume-test.py
+++ b/performance-test/rest-proxy-produce-consume-test.py
@@ -5,9 +5,10 @@ See LICENSE for details
 
 from kafka.admin import KafkaAdminClient, NewTopic
 from kafka.errors import TopicAlreadyExistsError
-from locust import FastHttpUser, task
+from locust import events, FastHttpUser, task
 from locust.contrib.fasthttp import ResponseContextManager
 from locust.env import Environment
+from locust.exception import StopUser
 
 import json
 import logging
@@ -18,6 +19,9 @@ BOOTSTRAP_SERVER = os.environ.get("BOOTSTRAP_SERVER", "localhost:9092")
 TOPIC = os.environ.get("TOPIC", "test-topic")
 CONSUME_TIMEOUT = os.environ.get("CONSUME_TIMEOUT", 1000)
 CONSUME_MAX_BYTES = os.environ.get("CONSUME_MAX_BYTES", 128)
+CONSUMER_GROUP = f"load-tests-cgrp-{uuid.uuid4().hex[:8]}"
+PRODUCE_TASK_WEIGHT = int(os.environ.get("PRODUCE_TASK_WEIGHT", "1"))
+CONSUME_TASK_WEIGHT = int(os.environ.get("CONSUME_TASK_WEIGHT", "5"))
 
 SCHEMA_STR = json.dumps(
     {
@@ -45,93 +49,132 @@ HEADER_ACCEPT = {"Accept": "application/vnd.kafka.json.v2+json"}
 LOG = logging.getLogger(__name__)
 
 
+@events.test_start.add_listener
+def on_test_start(environment: Environment, **_kwargs: object) -> None:
+    admin_client = KafkaAdminClient(bootstrap_servers=BOOTSTRAP_SERVER, client_id="locust-test")
+    try:
+        admin_client.create_topics([NewTopic(name=TOPIC, num_partitions=3, replication_factor=1)])
+    except TopicAlreadyExistsError:
+        pass
+    finally:
+        admin_client.close()
+
+
+def validate_produce_response(response: ResponseContextManager) -> None:
+    try:
+        payload = response.json()
+    except Exception as exc:
+        response.failure(
+            f"REST proxy produce did not return valid JSON: status={response.status_code} exc={exc} body={response.text!r}"
+        )
+        return
+
+    if response.status_code >= 400:
+        response.failure(f"REST proxy produce failed with HTTP {response.status_code}: {payload}")
+        return
+
+    offsets = payload.get("offsets")
+    if not isinstance(offsets, list):
+        response.failure(f"REST proxy produce response missing offsets list: {payload}")
+        return
+
+    error_count = sum(record.get("error") is not None for record in offsets)
+    if error_count > 0:
+        response.failure(f"Response contains {error_count} errors for {INPUT_RECORDS_COUNT} input records.")
+
+
 class RESTProxyPublishAndConsume(FastHttpUser):
     def __init__(self, environment: Environment):
         super().__init__(environment)
-        self.consumer_group = "consumer-group"
+        self.consumer_group = CONSUMER_GROUP
         self.consumer_instance_id = f"consumer_instance_{uuid.uuid4()}"
+        self.consumer_created = False
+        self.subscription_created = False
 
     def on_start(self):
-        # Create topic if needed
-        admin_client = KafkaAdminClient(bootstrap_servers=BOOTSTRAP_SERVER, client_id="locust-test")
-        try:
-            admin_client.create_topics([NewTopic(name=TOPIC, num_partitions=3, replication_factor=1)])
-        except TopicAlreadyExistsError:
-            pass
-        admin_client.close()
-
-        # Register consumer instance
-        self.client.post(
+        with self.client.post(
             f"/consumers/{self.consumer_group}",
             headers=HEADER_CONTENT_TYPE,
             json={"name": self.consumer_instance_id, "format": "json"},
             name="/consumers/[GROUP]",
-        )
+            catch_response=True,
+        ) as response:
+            if response.status_code >= 400:
+                response.failure(
+                    f"Failed to create consumer {self.consumer_group}/{self.consumer_instance_id}: "
+                    f"{response.status_code} {response.text}"
+                )
+                raise StopUser()
+            self.consumer_created = True
 
-        # Subscribe consumer
-        self.client.post(
+        with self.client.post(
             f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}/subscription",
             headers=HEADER_CONTENT_TYPE,
             json={"topics": [TOPIC]},
             name="/consumers/[GROUP]/instances/[ID]/subscription",
-        )
+            catch_response=True,
+        ) as response:
+            if response.status_code >= 400:
+                response.failure(
+                    f"Failed to subscribe consumer {self.consumer_group}/{self.consumer_instance_id}: "
+                    f"{response.status_code} {response.text}"
+                )
+                raise StopUser()
+            self.subscription_created = True
 
     #
     # CLEANUP LOGIC
     #
     def on_stop(self):
-        # 1. DELETE subscription
-        try:
-            with self.client.delete(
-                f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}/subscription",
-                headers=HEADER_ACCEPT,
-                name="/consumers/[GROUP]/instances/[ID]/subscription DELETE",
-                catch_response=True,
-            ) as resp:
-                if resp.status_code >= 400:
-                    msg = (
-                        f"Failed to delete subscription for {self.consumer_group}/{self.consumer_instance_id}: "
-                        f"{resp.status_code} {resp.text}"
-                    )
-                    LOG.warning(msg)
-                    resp.failure(msg)
-        except Exception:
-            LOG.exception(
-                "Exception while deleting subscription for %s/%s",
-                self.consumer_group,
-                self.consumer_instance_id,
-            )
+        if self.subscription_created:
+            try:
+                with self.client.delete(
+                    f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}/subscription",
+                    headers=HEADER_ACCEPT,
+                    name="/consumers/[GROUP]/instances/[ID]/subscription DELETE",
+                    catch_response=True,
+                ) as resp:
+                    if resp.status_code >= 400:
+                        msg = (
+                            f"Failed to delete subscription for {self.consumer_group}/{self.consumer_instance_id}: "
+                            f"{resp.status_code} {resp.text}"
+                        )
+                        LOG.warning(msg)
+                        resp.failure(msg)
+            except Exception:
+                LOG.exception(
+                    "Exception while deleting subscription for %s/%s",
+                    self.consumer_group,
+                    self.consumer_instance_id,
+                )
 
-        # 2. DELETE consumer instance
-        try:
-            with self.client.delete(
-                f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}",
-                headers=HEADER_ACCEPT,
-                name="/consumers/[GROUP]/instances/[ID] DELETE",
-                catch_response=True,
-            ) as resp:
-                if resp.status_code >= 400:
-                    msg = (
-                        f"Failed to delete consumer {self.consumer_group}/{self.consumer_instance_id}: "
-                        f"{resp.status_code} {resp.text}"
-                    )
-                    LOG.warning(msg)
-                    resp.failure(msg)
-        except Exception:
-            LOG.exception("Exception while deleting consumer %s/%s", self.consumer_group, self.consumer_instance_id)
+        if self.consumer_created:
+            try:
+                with self.client.delete(
+                    f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}",
+                    headers=HEADER_ACCEPT,
+                    name="/consumers/[GROUP]/instances/[ID] DELETE",
+                    catch_response=True,
+                ) as resp:
+                    if resp.status_code >= 400:
+                        msg = (
+                            f"Failed to delete consumer {self.consumer_group}/{self.consumer_instance_id}: "
+                            f"{resp.status_code} {resp.text}"
+                        )
+                        LOG.warning(msg)
+                        resp.failure(msg)
+            except Exception:
+                LOG.exception("Exception while deleting consumer %s/%s", self.consumer_group, self.consumer_instance_id)
 
         # No explicit consumer-group delete endpoint exists in your routes.
         # Karapace removes empty groups automatically.
 
-    @task(20)
+    @task(PRODUCE_TASK_WEIGHT)
     def post_rest_proxy(self) -> None:
         with self.client.post(f"/topics/{TOPIC}", json=BODY, catch_response=True) as response:
-            response: ResponseContextManager
-            error_count = sum(record.get("error") is not None for record in response.json()["offsets"])
-            if error_count > 0:
-                response.failure(f"Response contains {error_count} errors for {INPUT_RECORDS_COUNT} input records.")
+            validate_produce_response(response)
 
-    @task(1)
+    @task(CONSUME_TASK_WEIGHT)
     def get_consume(self):
         self.client.get(
             f"/consumers/{self.consumer_group}/instances/{self.consumer_instance_id}/records",

--- a/performance-test/run-locust-test.sh
+++ b/performance-test/run-locust-test.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# The REST proxy address params
+# The target address params
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
 BASE_URL=${BASE_URL:-http://localhost:8082}
+BOOTSTRAP_SERVER=${BOOTSTRAP_SERVER:-localhost:9092}
 TOPIC=${TOPIC:-test-topic}
+KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
+KEYCLOAK_CONNECT_URL=${KEYCLOAK_CONNECT_URL:-http://localhost:8383}
+OIDC_TOKEN_SCRIPT=${OIDC_TOKEN_SCRIPT:-"${SCRIPT_DIR}/../bin/get_oidc_token.py"}
+AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN=${AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN:-0}
 
 DURATION=${DURATION:-1m}
 CONCURRENCY=${CONCURRENCY:-50}
@@ -12,6 +19,14 @@ LOCUST_FILE=${LOCUST_FILE:-"rest-proxy-produce-consume-test.py"}
 GUI_PARAMS=""
 if [[ -n ${LOCUST_GUI-} ]]; then
     GUI_PARAMS="--autostart"
+fi
+
+export BOOTSTRAP_SERVER
+
+if [[ ${AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN} == "1" ]] && [[ -z ${SCHEMA_REGISTRY_OIDC_TOKEN-} ]] && [[ ${LOCUST_FILE} == *"schema-registry"* ]]; then
+    SCHEMA_REGISTRY_OIDC_TOKEN=$(KEYCLOAK_URL="${KEYCLOAK_URL}" KEYCLOAK_CONNECT_URL="${KEYCLOAK_CONNECT_URL}" "${OIDC_TOKEN_SCRIPT}")
+    export SCHEMA_REGISTRY_OIDC_TOKEN
+    echo "Schema registry Locust test using OIDC bearer token"
 fi
 
 locust ${GUI_PARAMS:+${GUI_PARAMS}} \

--- a/performance-test/run-locust-test.sh
+++ b/performance-test/run-locust-test.sh
@@ -11,17 +11,40 @@ KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
 KEYCLOAK_CONNECT_URL=${KEYCLOAK_CONNECT_URL:-http://localhost:8383}
 OIDC_TOKEN_SCRIPT=${OIDC_TOKEN_SCRIPT:-"${SCRIPT_DIR}/../bin/get_oidc_token.py"}
 AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN=${AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN:-0}
+COLLECT_DOCKER_STATS=${COLLECT_DOCKER_STATS:-0}
+DOCKER_STATS_INTERVAL=${DOCKER_STATS_INTERVAL:-1}
+DOCKER_STATS_SCRIPT=${DOCKER_STATS_SCRIPT:-"${SCRIPT_DIR}/collect-docker-stats.sh"}
+DOCKER_STATS_CONTAINERS=${DOCKER_STATS_CONTAINERS-}
+DOCKER_STATS_POST_RUN_DELAY=${DOCKER_STATS_POST_RUN_DELAY:-10}
+CLEAN_RESULTS=${CLEAN_RESULTS:-0}
 
 DURATION=${DURATION:-1m}
 CONCURRENCY=${CONCURRENCY:-50}
+LOCUST_SPAWN_RATE=${LOCUST_SPAWN_RATE:-10}
 LOCUST_FILE=${LOCUST_FILE:-"rest-proxy-produce-consume-test.py"}
+LOCUST_GUI=${LOCUST_GUI:-1}
+LOCUST_AUTOQUIT_SECONDS=${LOCUST_AUTOQUIT:-${LOCUST_AUTOQUIT_SECONDS:-0}}
+LOCUST_STOP_TIMEOUT=${LOCUST_STOP_TIMEOUT:-30}
+
+RESULTS_ROOT=${SCRIPT_DIR}/results
+DOCKER_STATS_PID=""
+SHUTTING_DOWN=0
+DEFAULT_DOCKER_STATS_CONTAINERS=(karapace-rest-proxy karapace-schema-registry karapace-schema-registry-follower kafka keycloak)
 
 GUI_PARAMS=""
-if [[ -n ${LOCUST_GUI-} ]]; then
+HEADLESS_PARAMS="--headless"
+if [[ ${LOCUST_GUI} == "1" ]]; then
     GUI_PARAMS="--autostart"
+    if [[ ${LOCUST_AUTOQUIT_SECONDS} != "0" ]]; then
+        GUI_PARAMS+=" --autoquit ${LOCUST_AUTOQUIT_SECONDS}"
+    fi
+    HEADLESS_PARAMS=""
 fi
 
 export BOOTSTRAP_SERVER
+export PYTHONDONTWRITEBYTECODE=1
+unset LOCUST_AUTOQUIT
+unset LOCUST_AUTOQUIT_SECONDS
 
 if [[ ${AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN} == "1" ]] && [[ -z ${SCHEMA_REGISTRY_OIDC_TOKEN-} ]] && [[ ${LOCUST_FILE} == *"schema-registry"* ]]; then
     SCHEMA_REGISTRY_OIDC_TOKEN=$(KEYCLOAK_URL="${KEYCLOAK_URL}" KEYCLOAK_CONNECT_URL="${KEYCLOAK_CONNECT_URL}" "${OIDC_TOKEN_SCRIPT}")
@@ -29,10 +52,68 @@ if [[ ${AUTO_GET_SCHEMA_REGISTRY_OIDC_TOKEN} == "1" ]] && [[ -z ${SCHEMA_REGISTR
     echo "Schema registry Locust test using OIDC bearer token"
 fi
 
+if [[ ${LOCUST_FILE} == *"schema-registry"* ]]; then
+    RESULTS_SUBDIR="schema-registry"
+else
+    RESULTS_SUBDIR="rest-proxy"
+fi
+
+if [[ ${CLEAN_RESULTS} == "1" ]]; then
+    rm -rf "${RESULTS_ROOT:?}/${RESULTS_SUBDIR:?}"
+fi
+
+# shellcheck disable=SC2317
+cleanup() {
+    if [[ ${SHUTTING_DOWN} == "1" ]]; then
+        return
+    fi
+    SHUTTING_DOWN=1
+
+    if [[ -n ${DOCKER_STATS_PID} ]]; then
+        kill "${DOCKER_STATS_PID}" 2>/dev/null || true
+        wait "${DOCKER_STATS_PID}" 2>/dev/null || true
+        DOCKER_STATS_PID=""
+    fi
+}
+
+# shellcheck disable=SC2317
+handle_signal() {
+    cleanup
+    exit 130
+}
+
+trap cleanup EXIT
+trap handle_signal INT TERM
+
+if [[ ${COLLECT_DOCKER_STATS} == "1" ]]; then
+    mkdir -p "${RESULTS_ROOT}/${RESULTS_SUBDIR}"
+    timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+    docker_stats_file="${RESULTS_ROOT}/${RESULTS_SUBDIR}/docker-stats-${timestamp}.csv"
+
+    if [[ -n ${DOCKER_STATS_CONTAINERS} ]]; then
+        read -r -a docker_stats_containers <<<"${DOCKER_STATS_CONTAINERS}"
+    else
+        docker_stats_containers=("${DEFAULT_DOCKER_STATS_CONTAINERS[@]}")
+    fi
+
+    DOCKER_STATS_PARENT_PID=$$ bash "${DOCKER_STATS_SCRIPT}" "${docker_stats_file}" "${DOCKER_STATS_INTERVAL}" "${docker_stats_containers[@]}" &
+    DOCKER_STATS_PID=$!
+    echo "Collecting Docker stats into ${docker_stats_file}"
+fi
+
+LOCUST_EXIT_CODE=0
 locust ${GUI_PARAMS:+${GUI_PARAMS}} \
+    ${HEADLESS_PARAMS:+${HEADLESS_PARAMS}} \
     --run-time "${DURATION}" \
     --users "${CONCURRENCY}" \
     -H "${BASE_URL}" \
-    --spawn-rate 0.50 \
-    --stop-timeout 5 \
-    --locustfile "${LOCUST_FILE}"
+    --spawn-rate "${LOCUST_SPAWN_RATE}" \
+    --stop-timeout "${LOCUST_STOP_TIMEOUT}" \
+    --locustfile "${LOCUST_FILE}" || LOCUST_EXIT_CODE=$?
+
+if [[ ${COLLECT_DOCKER_STATS} == "1" ]] && [[ ${DOCKER_STATS_POST_RUN_DELAY} != "0" ]]; then
+    echo "Waiting ${DOCKER_STATS_POST_RUN_DELAY}s before stopping Docker stats collection"
+    sleep "${DOCKER_STATS_POST_RUN_DELAY}"
+fi
+
+exit "${LOCUST_EXIT_CODE}"

--- a/performance-test/schema-registry-schema-post.py
+++ b/performance-test/schema-registry-schema-post.py
@@ -8,6 +8,7 @@ from locust import FastHttpUser, task
 from locust.contrib.fasthttp import ResponseContextManager
 
 import json
+import os
 import random
 import uuid
 
@@ -22,6 +23,14 @@ class TestData:
 
 SUBJECTS = ["test-subject-1", "test-subject-2"]
 SUBJECT_TEST_DATA = {subject: TestData() for subject in SUBJECTS}
+
+SCHEMA_REGISTRY_HEADERS = {
+    "Content-Type": "application/vnd.schemaregistry.v1+json",
+    "Accept": "application/vnd.schemaregistry.v1+json, application/json, */*",
+}
+OIDC_TOKEN = os.environ.get("SCHEMA_REGISTRY_OIDC_TOKEN")
+if OIDC_TOKEN:
+    SCHEMA_REGISTRY_HEADERS["Authorization"] = f"Bearer {OIDC_TOKEN}"
 
 NO_SCHEMAS_TO_REGISTER = 4000
 SCHEMAS_PER_SUBJECT = NO_SCHEMAS_TO_REGISTER / len(SUBJECTS)
@@ -52,32 +61,74 @@ class NewSchemaCreateUser(FastHttpUser):
                 test_data.count += 1
                 alias = str(uuid.uuid4())
                 new_schema = _get_new_schema(alias)
-                path = f"/subjects/{subject}/versions?NEW"
-                with self.client.post(path, json=new_schema, catch_response=True) as response:
-                    schema_id = int(response.json()["id"])
+                path = f"/subjects/{subject}/versions"
+                with self.client.post(
+                    path,
+                    headers=SCHEMA_REGISTRY_HEADERS,
+                    json=new_schema,
+                    name="/subjects/[subject]/versions NEW",
+                    catch_response=True,
+                ) as response:
+                    try:
+                        payload = response.json()
+                    except Exception as exc:
+                        response.failure(f"Schema registration did not return valid JSON: {exc}; body={response.text!r}")
+                        continue
+                    if response.status_code >= 400:
+                        response.failure(f"Schema registration failed with HTTP {response.status_code}: {payload}")
+                        continue
+                    if "id" not in payload:
+                        response.failure(f"Schema registration response missing id: {payload}")
+                        continue
+
+                    schema_id = int(payload["id"])
                     test_data.schemas[alias] = schema_id
-                added = True
+                    added = True
         if not added:
-            subject = random.choice(SUBJECTS)
+            subjects_with_schemas = [subject for subject, test_data in SUBJECT_TEST_DATA.items() if test_data.schemas]
+            if not subjects_with_schemas:
+                return
+
+            subject = random.choice(subjects_with_schemas)
             test_data = SUBJECT_TEST_DATA[subject]
             alias = random.choice(list(test_data.schemas.keys()))
             new_schema = _get_new_schema(alias)
-            path = f"/subjects/{subject}/versions?EXISTING"
-            self.client.post(path, json=new_schema)
+            path = f"/subjects/{subject}/versions"
+            self.client.post(
+                path, headers=SCHEMA_REGISTRY_HEADERS, json=new_schema, name="/subjects/[subject]/versions EXISTING"
+            )
 
     @task
     def check_schema_registered(self) -> None:
         subject = random.choice(SUBJECTS)
         test_data = SUBJECT_TEST_DATA.get(subject, None)
-        if test_data is None:
+        if test_data is None or not test_data.schemas:
             return
 
         alias = random.choice(list(test_data.schemas.keys()))
         new_schema = _get_new_schema(alias)
-        path = f"/subjects/{subject}?CHECK_REGISTERED"
-        with self.client.post(path, json=new_schema, catch_response=True) as response:
+        path = f"/subjects/{subject}"
+        with self.client.post(
+            path,
+            headers=SCHEMA_REGISTRY_HEADERS,
+            json=new_schema,
+            name="/subjects/[subject] CHECK_REGISTERED",
+            catch_response=True,
+        ) as response:
             response: ResponseContextManager
-            schema_id = int(response.json()["id"])
+            try:
+                payload = response.json()
+            except Exception as exc:
+                response.failure(f"Schema lookup did not return valid JSON: {exc}; body={response.text!r}")
+                return
+            if response.status_code >= 400:
+                response.failure(f"Schema lookup failed with HTTP {response.status_code}: {payload}")
+                return
+            if "id" not in payload:
+                response.failure(f"Schema lookup response missing id: {payload}")
+                return
+
+            schema_id = int(payload["id"])
             expected_id = test_data.schemas.get(alias)
             if expected_id != schema_id:
                 response.failure(f"Schema with alias {alias} has ID {expected_id}, check returned {schema_id}")

--- a/performance-test/schema-registry-schema-post.py
+++ b/performance-test/schema-registry-schema-post.py
@@ -32,6 +32,9 @@ OIDC_TOKEN = os.environ.get("SCHEMA_REGISTRY_OIDC_TOKEN")
 if OIDC_TOKEN:
     SCHEMA_REGISTRY_HEADERS["Authorization"] = f"Bearer {OIDC_TOKEN}"
 
+SCHEMA_REGISTER_NEW_WEIGHT = int(os.environ.get("SCHEMA_REGISTER_NEW_WEIGHT", "10"))
+SCHEMA_CHECK_REGISTERED_WEIGHT = int(os.environ.get("SCHEMA_CHECK_REGISTERED_WEIGHT", "10"))
+
 NO_SCHEMAS_TO_REGISTER = 4000
 SCHEMAS_PER_SUBJECT = NO_SCHEMAS_TO_REGISTER / len(SUBJECTS)
 
@@ -52,7 +55,7 @@ def _get_new_schema(alias: uuid.UUID):
 
 
 class NewSchemaCreateUser(FastHttpUser):
-    @task
+    @task(SCHEMA_REGISTER_NEW_WEIGHT)
     def post_new_schema(self) -> None:
         added = False
         for subject in SUBJECTS:
@@ -98,7 +101,7 @@ class NewSchemaCreateUser(FastHttpUser):
                 path, headers=SCHEMA_REGISTRY_HEADERS, json=new_schema, name="/subjects/[subject]/versions EXISTING"
             )
 
-    @task
+    @task(SCHEMA_CHECK_REGISTERED_WEIGHT)
     def check_schema_registered(self) -> None:
         subject = random.choice(SUBJECTS)
         test_data = SUBJECT_TEST_DATA.get(subject, None)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,8 +16,9 @@ import pytest
 from _pytest.fixtures import SubRequest
 from aiohttp import BasicAuth, ClientSession
 from confluent_kafka.admin import NewTopic
-import requests
 import os
+import requests
+from requests.exceptions import RequestException
 
 from karapace.core.client import Client
 from karapace.core.container import KarapaceContainer
@@ -26,6 +27,34 @@ from karapace.core.kafka.consumer import AsyncKafkaConsumer, KafkaConsumer
 from karapace.core.kafka.producer import AsyncKafkaProducer, KafkaProducer
 from tests.integration.utils.cluster import RegistryDescription, RegistryEndpoint
 from tests.integration.utils.kafka_server import KafkaServers
+
+
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080")
+KEYCLOAK_REQUEST_TIMEOUT_SECONDS = 5.0
+KEYCLOAK_STARTUP_TIMEOUT_SECONDS = 60.0
+KEYCLOAK_RETRY_DELAY_SECONDS = 1.0
+KEYCLOAK_RETRYABLE_STATUS_CODES = {502, 503}
+
+
+def _keycloak_request(method: str, path: str, **kwargs) -> requests.Response:
+    deadline = time.monotonic() + KEYCLOAK_STARTUP_TIMEOUT_SECONDS
+    last_exception: Exception | None = None
+    url = f"{KEYCLOAK_URL}{path}"
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.request(method, url, timeout=KEYCLOAK_REQUEST_TIMEOUT_SECONDS, **kwargs)
+            if response.status_code not in KEYCLOAK_RETRYABLE_STATUS_CODES:
+                return response
+            last_exception = RuntimeError(f"Keycloak returned retryable status {response.status_code} for {url}")
+        except RequestException as exc:
+            last_exception = exc
+
+        time.sleep(KEYCLOAK_RETRY_DELAY_SECONDS)
+
+    raise TimeoutError(
+        f"Keycloak did not become ready for {url} within {KEYCLOAK_STARTUP_TIMEOUT_SECONDS} seconds"
+    ) from last_exception
 
 
 @pytest.fixture(scope="session", name="basic_auth")
@@ -139,6 +168,10 @@ def fixture_new_topic(admin_client: KafkaAdminClient) -> NewTopic:
 
 @pytest.fixture(scope="session")
 def oidc_token():
+    precomputed_token = os.environ.get("KARAPACE_E2E_OIDC_TOKEN")
+    if precomputed_token:
+        return precomputed_token
+
     # --- Step 1: Get admin token ---
     admin_token = get_admin_token()
 
@@ -151,9 +184,8 @@ def oidc_token():
     client_secret = get_client_secret(realm, client_uuid, admin_token)
 
     # --- Step 4: Get OIDC token for the client ---
-    token_url = f"http://keycloak:8080/realms/{realm}/protocol/openid-connect/token"
     data = {"grant_type": "client_credentials", "client_id": client_id, "client_secret": client_secret, "scope": "openid"}
-    response = requests.post(token_url, data=data)
+    response = _keycloak_request("POST", f"/realms/{realm}/protocol/openid-connect/token", data=data)
     response.raise_for_status()
     return response.json()["access_token"]
 
@@ -414,30 +446,27 @@ class TokenProvider:
 
 # --- Helper functions for Keycloak admin API ---
 def get_admin_token():
-    url = "http://keycloak:8080/realms/master/protocol/openid-connect/token"
     data = {
         "grant_type": "password",
         "client_id": "admin-cli",
         "username": os.environ.get("KEYCLOAK_ADMIN", "admin"),
         "password": os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin"),
     }
-    resp = requests.post(url, data=data)
+    resp = _keycloak_request("POST", "/realms/master/protocol/openid-connect/token", data=data)
     resp.raise_for_status()
     return resp.json()["access_token"]
 
 
 def get_client_uuid(realm, client_id, admin_token):
-    url = f"http://keycloak:8080/admin/realms/{realm}/clients?clientId={client_id}"
     headers = {"Authorization": f"Bearer {admin_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = _keycloak_request("GET", f"/admin/realms/{realm}/clients", headers=headers, params={"clientId": client_id})
     resp.raise_for_status()
     clients = resp.json()
     return clients[0]["id"]
 
 
 def get_client_secret(realm, client_uuid, admin_token):
-    url = f"http://keycloak:8080/admin/realms/{realm}/clients/{client_uuid}/client-secret"
     headers = {"Authorization": f"Bearer {admin_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = _keycloak_request("GET", f"/admin/realms/{realm}/clients/{client_uuid}/client-secret", headers=headers)
     resp.raise_for_status()
     return resp.json()["value"]


### PR DESCRIPTION
### Summary
This PR improves the local performance-test workflow for REST Proxy and Schema Registry, and makes Keycloak/OIDC startup failures clearer.

### Changes
- added resource limits to docker-compose services.
- output resource usage during performance tests in `karapace/performance-test/results/[rest-proxy | schema-registry]`, collects both the csv and outputs a table format, i.e. `karapace/performance-test/results/schema-registry/docker-stats-20260519T111108Z.table.log` & `karapace/performance-test/results/rest-proxy/docker-stats-20260519T124609Z.table.log`
```bash
.
.
.

================================================================================================================================================
Docker stats snapshot at 2026-05-19T11:12:16Z
================================================================================================================================================
container                          cpu      mem_usage                  mem%     net_io                 block_io             pids 
================================================================================================================================================
karapace-rest-proxy                0.02%    299.9MiB / 512MiB          58.58%   45.8MB / 36.7MB        0B / 0B              22   
karapace-schema-registry           1.00%    144.4MiB / 256MiB          56.42%   34.9MB / 29.2MB        0B / 0B              66   
karapace-schema-registry-follower  0.80%    112.4MiB / 256MiB          43.89%   14MB / 13MB            0B / 0B              35   
kafka                              3.16%    576.3MiB / 1GiB            56.27%   32.4MB / 51.4MB        0B / 33.8MB          97   
keycloak                           0.09%    452.4MiB / 1GiB            44.18%   25.8kB / 43.3kB        0B / 185MB           31   

================================================================================================================================================
Docker stats snapshot at 2026-05-19T11:12:19Z
================================================================================================================================================
container                          cpu      mem_usage                  mem%     net_io                 block_io             pids 
================================================================================================================================================
karapace-rest-proxy                0.02%    300MiB / 512MiB            58.59%   45.8MB / 36.7MB        0B / 0B              22   
karapace-schema-registry           1.19%    144.4MiB / 256MiB          56.42%   34.9MB / 29.2MB        0B / 0B              66   
karapace-schema-registry-follower  15.22%   129.7MiB / 256MiB          50.66%   14MB / 13MB            0B / 0B              37   
kafka                              2.55%    574.6MiB / 1GiB            56.11%   32.4MB / 51.4MB        0B / 33.9MB          97   
keycloak                           0.09%    452.4MiB / 1GiB            44.18%   25.8kB / 43.3kB        0B / 185MB           31   

.
.
.
```
- updated the Locust runner to support configurable spawn rate and stop timeout.
- made direct script usage open the Locust UI by default.
- added `make performance-test-schema-registry` and `make performance-test-rest-proxy`, headless by default, but can also open the gui using `LOCUST_GUI=1` and close or not using `LOCUST_AUTOQUIT=1`.
- made Docker stats optional for direct runs, but enabled for performance make targets.
- hardened REST Proxy Locust response handling and cleanup.
- added configurable task weights for REST Proxy and Schema Registry load tests.
- improved and documented performance-test tuning options.
- removed 404 from generic Keycloak retryable status codes in e2e and token helpers so real config errors fail fast.
- fix schema-registry performance tests with OIDC token.

### Why
These changes make the load tests easier to run and tune, reduce noisy failures, and avoid masking real Keycloak configuration issues behind long retries.

### Notes
Most changes are limited to test and developer workflow code:

- performance-test scripts
- performance-test Locust scenarios
- make targets
- Keycloak test/token retry
- we can put this in the CI at some point, pre-release or on merge to main. 