### PR TITLE
Move main entrypoint to a main() function

### DIFF
--- a/src/karapace/__main__.py
+++ b/src/karapace/__main__.py
@@ -29,7 +29,7 @@ import uvicorn
 
 from karapace.core.metrics_container import MetricsContainer
 
-if __name__ == "__main__":
+def main():
     karapace_container = KarapaceContainer()
     karapace_container.wire(
         modules=[
@@ -119,3 +119,6 @@ if __name__ == "__main__":
         ssl_ca_certs=config.server_tls_cafile,
         ssl_cert_reqs=ssl_cert_reqs,
     )
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
pyproject.toml's `[project.scripts]` section states that karapace script should run the main function, so I create it.

# Why this way

Because of https://github.com/Aiven-Open/karapace/blob/main/pyproject.toml#L68
