### PR TITLE
rest-proxy: forward inbound OIDC bearer to Schema Registry

### DIFF
--- a/container/compose.yml
+++ b/container/compose.yml
@@ -160,8 +160,8 @@ services:
       KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
-  # Schema Registry running with OIDC authentication only (no role-based authorization).
-  # Used to verify the sasl_oauthbearer_authentication_enabled flag in isolation.
+  # OIDC authentication only (no role-based authorization).
+  # Used to isolate the sasl_oauthbearer_authentication_enabled flag in tests.
   karapace-schema-registry-authn-only:
     profiles:
       - e2e
@@ -210,6 +210,151 @@ services:
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
+
+  # REST Proxy with the forwarding gate ON, against the authn-only SR.
+  karapace-rest-proxy-oidc:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-rest-proxy-oidc
+    container_name: karapace-rest-proxy-oidc
+    entrypoint:
+      - python3
+      - -m
+      - karapace.kafka_rest_apis
+    depends_on:
+      - kafka
+      - karapace-schema-registry-authn-only
+    ports:
+      - 8382:8382
+    volumes:
+      - ./certs:/opt/karapace/certs
+    environment:
+      KARAPACE_KARAPACE_REST: true
+      KARAPACE_PORT: 8382
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-rest-proxy-oidc
+      KARAPACE_ADVERTISED_PROTOCOL: http
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_REGISTRY_SCHEME: https
+      KARAPACE_REGISTRY_HOST: karapace-schema-registry-authn-only
+      KARAPACE_REGISTRY_PORT: 8281
+      KARAPACE_ADMIN_METADATA_MAX_AGE: 0
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      # Forwarding gate ON.
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
+
+  # REST Proxy with the forwarding gate OFF — regression guard for flag-False deployments.
+  karapace-rest-proxy-no-forward:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-rest-proxy-no-forward
+    container_name: karapace-rest-proxy-no-forward
+    entrypoint:
+      - python3
+      - -m
+      - karapace.kafka_rest_apis
+    depends_on:
+      - kafka
+      - karapace-schema-registry-authn-only
+    ports:
+      - 8482:8482
+    volumes:
+      - ./certs:/opt/karapace/certs
+    environment:
+      KARAPACE_KARAPACE_REST: true
+      KARAPACE_PORT: 8482
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-rest-proxy-no-forward
+      KARAPACE_ADVERTISED_PROTOCOL: http
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_REGISTRY_SCHEME: https
+      KARAPACE_REGISTRY_HOST: karapace-schema-registry-authn-only
+      KARAPACE_REGISTRY_PORT: 8281
+      KARAPACE_ADMIN_METADATA_MAX_AGE: 0
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      # Forwarding gate OFF (default).
+
+  # Basic SR + Basic proxy + gate OFF — issue #1274 baseline.
+  karapace-schema-registry-basic:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-schema-registry-basic
+    container_name: karapace-schema-registry-basic
+    entrypoint:
+      - python3
+      - -m
+      - karapace
+    depends_on:
+      - kafka
+    ports:
+      - 8581:8581
+    volumes:
+      - ../tests/integration/config/karapace.auth.json:/opt/karapace/karapace.auth.json:ro
+    environment:
+      KARAPACE_KARAPACE_REGISTRY: true
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-schema-registry-basic
+      KARAPACE_ADVERTISED_PROTOCOL: http
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_PORT: 8581
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_CLIENT_ID: karapace-schema-registry-basic
+      KARAPACE_GROUP_ID: karapace-schema-registry-basic
+      KARAPACE_MASTER_ELECTION_STRATEGY: highest
+      KARAPACE_MASTER_ELIGIBILITY: true
+      KARAPACE_TOPIC_NAME: _schemas_basic
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_COMPATIBILITY: FULL
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_REGISTRY_AUTHFILE: /opt/karapace/karapace.auth.json
+
+  karapace-rest-proxy-basic:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-rest-proxy-basic
+    container_name: karapace-rest-proxy-basic
+    entrypoint:
+      - python3
+      - -m
+      - karapace.kafka_rest_apis
+    depends_on:
+      - kafka
+      - karapace-schema-registry-basic
+    ports:
+      - 8682:8682
+    environment:
+      KARAPACE_KARAPACE_REST: true
+      KARAPACE_PORT: 8682
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-rest-proxy-basic
+      KARAPACE_ADVERTISED_PROTOCOL: http
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_REGISTRY_SCHEME: http
+      KARAPACE_REGISTRY_HOST: karapace-schema-registry-basic
+      KARAPACE_REGISTRY_PORT: 8581
+      KARAPACE_REGISTRY_USER: admin
+      KARAPACE_REGISTRY_PASSWORD: admin
+      KARAPACE_ADMIN_METADATA_MAX_AGE: 0
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      # Gate OFF: proxy keeps sending Basic to SR.
 
   karapace-rest-proxy:
     networks:

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -147,6 +147,8 @@ class Config(BaseSettings):
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics"]
+    # LRU cap on (subject, version, token_fingerprint) in the SR client. Raise for multi-tenant.
+    schema_registry_client_cache_maxsize: int = 100
     # Kafka SASL client credentials (used by both services; selected by sasl_mechanism).
     sasl_plain_username: str | None = None
     sasl_plain_password: str | None = None

--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -37,10 +37,32 @@ import asyncio
 import avro
 import avro.schema
 import base64
+import contextvars
+import hashlib
 import io
 import struct
 import threading
 import weakref
+
+# Per-request Authorization header forwarded from the REST Proxy to SR; None falls back to
+# session_auth. Only set in UserRestProxy.publish/fetch — other proxy endpoints don't reach
+# the serializer. Keep this list current if that changes.
+sr_authorization_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar("sr_authorization", default=None)
+
+
+def _authorization_headers() -> dict[str, str] | None:
+    auth = sr_authorization_ctx.get()
+    return {"Authorization": auth} if auth else None
+
+
+def _token_fingerprint() -> str:
+    """Stable cache-key fingerprint for the current Authorization. Empty string when unset."""
+    auth = sr_authorization_ctx.get()
+    if not auth:
+        return ""
+    # SHA-256 truncated to 16 hex chars; never logged, never stores raw bearers in the LRU.
+    return hashlib.sha256(auth.encode("utf-8")).hexdigest()[:16]
+
 
 START_BYTE = 0x0
 HEADER_FORMAT = ">bI"
@@ -122,9 +144,13 @@ class SchemaRegistryClient:
         schema_registry_url: str = "http://localhost:8081",
         server_ca: str | None = None,
         session_auth: BasicAuth | None = None,
+        *,
+        cache_maxsize: int,
     ):
         self.client = Client(server_uri=schema_registry_url, server_ca=server_ca, session_auth=session_auth)
         self.base_url = schema_registry_url
+        # Per-instance decoration so cache_maxsize can come from Config.
+        self._get_schema_cached = alru_cache(maxsize=cache_maxsize)(self._get_schema_cached)
 
     async def post_new_schema(
         self, subject: str, schema: ValidatedTypedSchema, references: Reference | None = None
@@ -136,7 +162,10 @@ class SchemaRegistryClient:
                 payload = {"schema": str(schema), "schemaType": schema.schema_type.value}
         else:
             payload = {"schema": json_encode(schema.to_dict()), "schemaType": schema.schema_type.value}
-        result = await self.client.post(f"subjects/{quote(subject)}/versions", json=payload)
+        # Client.post only injects the vendor Content-Type when headers is falsy; merge so
+        # forwarding Authorization doesn't silently demote the request to application/json.
+        headers = {"Content-Type": "application/vnd.schemaregistry.v1+json", **(_authorization_headers() or {})}
+        result = await self.client.post(f"subjects/{quote(subject)}/versions", json=payload, headers=headers)
         if not result.ok:
             raise SchemaRetrievalError(result.json())
         return SchemaId(result.json()["id"])
@@ -156,7 +185,7 @@ class SchemaRegistryClient:
         explored_schemas = explored_schemas | {(subject, version)}
 
         version_str = str(version) if version is not None else "latest"
-        result = await self.client.get(f"subjects/{quote(subject)}/versions/{version_str}")
+        result = await self.client.get(f"subjects/{quote(subject)}/versions/{version_str}", headers=_authorization_headers())
 
         if not result.ok:
             raise SchemaRetrievalError(result.json())
@@ -192,7 +221,6 @@ class SchemaRegistryClient:
         except InvalidSchema as e:
             raise SchemaRetrievalError(f"Failed to parse schema string from response: {json_result}") from e
 
-    @alru_cache(maxsize=100)
     async def get_schema(
         self,
         subject: Subject,
@@ -212,10 +240,24 @@ class SchemaRegistryClient:
                 - ValidatedTypedSchema: The retrieved schema, validated and typed.
                 - Version: The version of the schema that was retrieved.
         """
+        # Partition the cache by token fingerprint: each principal is validated by SR at
+        # least once per fingerprint per cache lifetime, not per request. Cached entries
+        # outlive server-side token expiry — acceptable for immutable schema bytes, not a
+        # substitute for revocation. Empty fingerprint = the unauthenticated slot.
+        return await self._get_schema_cached(subject, version, _token_fingerprint())
+
+    async def _get_schema_cached(
+        self,
+        subject: Subject,
+        version: Version | None,
+        token_fingerprint: str,
+    ) -> tuple[SchemaId, ValidatedTypedSchema, Version]:
         return await self._get_schema_recursive(subject, set(), version)
 
     async def get_schema_for_id(self, schema_id: SchemaId) -> tuple[TypedSchema, list[Subject]]:
-        result = await self.client.get(f"schemas/ids/{schema_id}", params={"includeSubjects": "True"})
+        result = await self.client.get(
+            f"schemas/ids/{schema_id}", params={"includeSubjects": "True"}, headers=_authorization_headers()
+        )
         if not result.ok:
             raise SchemaRetrievalError(result.json()["message"])
         json_result = result.json()
@@ -299,12 +341,16 @@ class SchemaRegistrySerializer:
         session_auth: BasicAuth | None = None
         if self.config.registry_user and self.config.registry_password:
             session_auth = BasicAuth(self.config.registry_user, self.config.registry_password, encoding="utf8")
+        cache_maxsize = self.config.schema_registry_client_cache_maxsize
         if self.config.registry_ca:
             registry_client = SchemaRegistryClient(
-                registry_url, server_ca=self.config.registry_ca, session_auth=session_auth
+                registry_url,
+                server_ca=self.config.registry_ca,
+                session_auth=session_auth,
+                cache_maxsize=cache_maxsize,
             )
         else:
-            registry_client = SchemaRegistryClient(registry_url, session_auth=session_auth)
+            registry_client = SchemaRegistryClient(registry_url, session_auth=session_auth, cache_maxsize=cache_maxsize)
         self.registry_client: SchemaRegistryClient | None = registry_client
         self.ids_to_schemas: dict[int, TypedSchema] = {}
         self.ids_to_subjects: MutableMapping[int, list[Subject]] = TTLCache(maxsize=10000, ttl=600)

--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -145,7 +145,7 @@ class SchemaRegistryClient:
         server_ca: str | None = None,
         session_auth: BasicAuth | None = None,
         *,
-        cache_maxsize: int,
+        cache_maxsize: int = Config.model_fields["schema_registry_client_cache_maxsize"].default,
     ):
         self.client = Client(server_uri=schema_registry_url, server_ca=server_ca, session_auth=session_auth)
         self.base_url = schema_registry_url

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -33,6 +33,7 @@ from karapace.core.serialization import (
     InvalidPayload,
     SchemaRegistrySerializer,
     SchemaRetrievalError,
+    sr_authorization_ctx,
 )
 from karapace.core.typing import NameStrategy, SchemaId, Subject, SubjectType
 from karapace.core.utils import json_encode
@@ -641,6 +642,8 @@ class UserRestProxy:
         )
 
     async def fetch(self, group_name: str, instance: str, content_type: str, *, request: HTTPRequest) -> None:
+        if self.config.sasl_oauthbearer_authentication_enabled:
+            sr_authorization_ctx.set(request.headers.get("Authorization"))
         await self.consumer_manager.fetch(
             internal_name=ConsumerManager.create_internal_name(group_name, instance),
             content_type=content_type,
@@ -798,6 +801,9 @@ class UserRestProxy:
         """
         formats: dict = request.content_type
         data: dict = request.json
+        # Forward inbound Authorization to SR only when SR-side OIDC is on.
+        if self.config.sasl_oauthbearer_authentication_enabled:
+            sr_authorization_ctx.set(request.headers.get("Authorization"))
         _ = await self.get_topic_info(topic, content_type)
         if partition_id is not None:
             _ = await self.get_partition_info(topic, partition_id, content_type)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -222,11 +222,7 @@ async def registry_async_client_oidc_no_auth_header(
         await client.close()
 
 
-# ---------------------------------------------------------------------------
-# AuthN-only registry fixtures: a separate Schema Registry instance that has
-# sasl_oauthbearer_authentication_enabled=true and authorization_enabled=false.
-# Defined as karapace-schema-registry-authn-only in container/compose.yml.
-# ---------------------------------------------------------------------------
+# OIDC SR with authentication only (karapace-schema-registry-authn-only, profile: e2e).
 
 
 @pytest.fixture(scope="function", name="registry_authn_only_cluster")
@@ -293,6 +289,110 @@ async def fixture_registry_async_client_oidc_authn_only_no_auth_header(
         server_ca=request.config.getoption("server_ca"),
         client_factory=factory,
         session_auth=None,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+# REST Proxy fixtures for OIDC forwarding tests (compose profile: e2e).
+# -oidc has the gate ON; -no-forward has it OFF; both target the authn-only SR.
+
+
+_OIDC_PROXY_URI = "http://karapace-rest-proxy-oidc:8382"
+_NO_FORWARD_PROXY_URI = "http://karapace-rest-proxy-no-forward:8482"
+
+
+def _make_proxy_client(server_uri: str, token: str | None) -> Client:
+    factory_headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+
+    async def factory(auth):
+        return ClientSession(headers=factory_headers)
+
+    return Client(
+        server_uri=server_uri,
+        client_factory=factory,
+        session_auth=None,
+    )
+
+
+@pytest.fixture(scope="function", name="rest_async_client_oidc_proxy")
+async def fixture_rest_async_client_oidc_proxy(
+    loop: asyncio.AbstractEventLoop,
+    oidc_token,
+) -> AsyncGenerator[Client, None]:
+    client = _make_proxy_client(_OIDC_PROXY_URI, oidc_token)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="rest_async_client_oidc_proxy_invalid")
+async def fixture_rest_async_client_oidc_proxy_invalid(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    client = _make_proxy_client(_OIDC_PROXY_URI, "invalid_token")
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="rest_async_client_oidc_proxy_no_auth_header")
+async def fixture_rest_async_client_oidc_proxy_no_auth_header(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    client = _make_proxy_client(_OIDC_PROXY_URI, None)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="rest_async_client_oidc_proxy_no_forward")
+async def fixture_rest_async_client_oidc_proxy_no_forward(
+    loop: asyncio.AbstractEventLoop,
+    oidc_token,
+) -> AsyncGenerator[Client, None]:
+    """Valid Bearer aimed at a proxy with the gate OFF — proxy must not relay it."""
+    client = _make_proxy_client(_NO_FORWARD_PROXY_URI, oidc_token)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+# Basic-auth SR + Basic proxy + gate OFF — issue #1274 baseline.
+
+
+@pytest.fixture(scope="function", name="rest_async_client_basic_proxy")
+async def fixture_rest_async_client_basic_proxy(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    async def factory(auth):
+        return ClientSession(headers={})
+
+    client = Client(
+        server_uri="http://karapace-rest-proxy-basic:8682",
+        client_factory=factory,
+        session_auth=None,
+    )
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="registry_async_client_basic")
+async def fixture_registry_async_client_basic(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    """Direct client to the Basic-auth SR (used to wait for primary election)."""
+    client = Client(
+        server_uri="http://karapace-schema-registry-basic:8581",
+        session_auth=BasicAuth("admin", "admin"),
     )
     try:
         yield client

--- a/tests/e2e/kafka_rest_apis/test_oidc_forwarding.py
+++ b/tests/e2e/kafka_rest_apis/test_oidc_forwarding.py
@@ -1,0 +1,231 @@
+"""
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+
+End-to-end tests for OIDC bearer forwarding from the REST Proxy to the Schema Registry.
+
+Topology (compose profile: e2e):
+- karapace-schema-registry-authn-only:8281  — OIDC SR (forwarding gate target).
+- karapace-rest-proxy-oidc:8382              — REST Proxy with the gate ON.
+- karapace-rest-proxy-no-forward:8482        — REST Proxy with the gate OFF (regression guard).
+- karapace-schema-registry-basic:8581        — Basic-auth SR.
+- karapace-rest-proxy-basic:8682             — Basic-auth proxy paired with it (issue #1274 baseline).
+
+Topics are created up front because the broker has auto-create disabled; otherwise
+publish() short-circuits with 40401 before the SR auth path is exercised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from karapace.core.client import Client
+from karapace.core.kafka.admin import KafkaAdminClient
+from karapace.kafka_rest_apis.error_codes import RESTErrorCodes
+from tests.utils import REST_HEADERS, new_topic, wait_for_topics
+
+NEW_TOPIC_TIMEOUT = 10
+PRIMARY_TIMEOUT = 30.0
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _wait_for_sr_primary(sr_client: Client, timeout: float = PRIMARY_TIMEOUT) -> None:
+    """Wait until SR has elected a primary; otherwise writes hit a non-primary and
+    SR's internal forward_client masks the auth path under test."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        res = await sr_client.get("master_available")
+        if res.status_code == 200 and res.json_result and res.json_result.get("master_available") is True:
+            return
+        await asyncio.sleep(1.0)
+    raise TimeoutError("Schema registry did not elect a primary within timeout")
+
+
+@pytest.fixture(name="oidc_sr_primary_ready")
+async def fixture_oidc_sr_primary_ready(registry_async_client_oidc_authn_only: Client) -> None:
+    await _wait_for_sr_primary(registry_async_client_oidc_authn_only)
+
+
+@pytest.fixture(name="basic_sr_primary_ready")
+async def fixture_basic_sr_primary_ready(registry_async_client_basic: Client) -> None:
+    await _wait_for_sr_primary(registry_async_client_basic)
+
+
+async def _ensure_topic(rest_client: Client, admin_client: KafkaAdminClient) -> str:
+    """Create a fresh topic and wait until the proxy sees it."""
+    topic = new_topic(admin_client)
+    await wait_for_topics(rest_client, topic_names=[topic], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+    return topic
+
+
+# Happy paths: gate ON, valid Bearer reaches SR.
+
+
+async def test_avro_publish_forwards_bearer(
+    rest_async_client_oidc_proxy: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """AVRO produce with a valid Bearer succeeds through the OIDC SR."""
+    topic = await _ensure_topic(rest_async_client_oidc_proxy, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "record", "name": "Simple", "fields": [{"name": "n", "type": "string"}]}),
+        "records": [{"value": {"n": "hello"}}],
+    }
+    res = await rest_async_client_oidc_proxy.post(f"/topics/{topic}", payload, headers=REST_HEADERS["avro"])
+
+    assert res.status_code == 200, res.json()
+    body = res.json()
+    assert "value_schema_id" in body
+    assert "offsets" in body and len(body["offsets"]) == 1
+
+
+async def test_jsonschema_publish_forwards_bearer(
+    rest_async_client_oidc_proxy: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """JSON Schema produce with a valid Bearer succeeds."""
+    topic = await _ensure_topic(rest_async_client_oidc_proxy, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "object", "properties": {"n": {"type": "string"}}}),
+        "records": [{"value": {"n": "hello"}}],
+    }
+    res = await rest_async_client_oidc_proxy.post(f"/topics/{topic}", payload, headers=REST_HEADERS["jsonschema"])
+
+    assert res.status_code == 200, res.json()
+    assert "value_schema_id" in res.json()
+
+
+async def test_consumer_fetch_forwards_bearer(
+    rest_async_client_oidc_proxy: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """Exercises the fetch() gate end-to-end: consumer deserialization pulls the schema
+    from SR under the inbound bearer."""
+    topic = await _ensure_topic(rest_async_client_oidc_proxy, admin_client)
+    group = "group-" + topic
+    instance = "instance-" + topic
+
+    produce = await rest_async_client_oidc_proxy.post(
+        f"/topics/{topic}",
+        {
+            "value_schema": json.dumps({"type": "record", "name": "Simple", "fields": [{"name": "n", "type": "string"}]}),
+            "records": [{"value": {"n": "hi"}}],
+        },
+        headers=REST_HEADERS["avro"],
+    )
+    assert produce.status_code == 200, produce.json()
+
+    create = await rest_async_client_oidc_proxy.post(
+        f"/consumers/{group}",
+        {"name": instance, "format": "avro", "auto.offset.reset": "earliest"},
+        headers=REST_HEADERS["avro"],
+    )
+    assert create.status_code == 200, create.json()
+
+    sub = await rest_async_client_oidc_proxy.post(
+        f"/consumers/{group}/instances/{instance}/subscription",
+        {"topics": [topic]},
+        headers=REST_HEADERS["avro"],
+    )
+    assert sub.status_code == 204, sub.text if hasattr(sub, "text") else sub
+
+    fetch = await rest_async_client_oidc_proxy.get(
+        f"/consumers/{group}/instances/{instance}/records",
+        headers=REST_HEADERS["avro"],
+    )
+    assert fetch.status_code == 200, fetch.json()
+    records = fetch.json()
+    assert any(r.get("value") == {"n": "hi"} for r in records), records
+
+
+# Unhappy paths: gate ON, SR rejects the token; proxy surfaces 40801.
+
+
+async def test_avro_publish_invalid_bearer_is_rejected(
+    rest_async_client_oidc_proxy_invalid: Client,
+    rest_async_client_oidc_proxy: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """Garbage Bearer is rejected by SR; proxy surfaces 40801."""
+    # Topic creation uses a valid-token client so we exercise the SR auth path, not 40401.
+    topic = await _ensure_topic(rest_async_client_oidc_proxy, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "string"}),
+        "records": [{"value": "leak.if.broken"}],
+    }
+    res = await rest_async_client_oidc_proxy_invalid.post(f"/topics/{topic}", payload, headers=REST_HEADERS["avro"])
+
+    assert res.status_code != 200
+    assert res.json().get("error_code") == RESTErrorCodes.SCHEMA_RETRIEVAL_ERROR.value
+
+
+async def test_avro_publish_no_auth_header_is_rejected(
+    rest_async_client_oidc_proxy_no_auth_header: Client,
+    rest_async_client_oidc_proxy: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """Gate ON, no inbound Authorization, no registry_user fallback: SR rejects with 401."""
+    topic = await _ensure_topic(rest_async_client_oidc_proxy, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "string"}),
+        "records": [{"value": "no-token"}],
+    }
+    res = await rest_async_client_oidc_proxy_no_auth_header.post(f"/topics/{topic}", payload, headers=REST_HEADERS["avro"])
+
+    assert res.status_code != 200
+    assert res.json().get("error_code") == RESTErrorCodes.SCHEMA_RETRIEVAL_ERROR.value
+
+
+# Backwards-compat: gate OFF must not forward the inbound Bearer.
+
+
+async def test_avro_publish_with_gate_off_does_not_forward_bearer(
+    rest_async_client_oidc_proxy_no_forward: Client,
+    admin_client: KafkaAdminClient,
+    oidc_sr_primary_ready: None,
+) -> None:
+    """Gate OFF + valid Bearer + OIDC SR: write fails because nothing is forwarded."""
+    topic = await _ensure_topic(rest_async_client_oidc_proxy_no_forward, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "string"}),
+        "records": [{"value": "gate-off"}],
+    }
+    res = await rest_async_client_oidc_proxy_no_forward.post(f"/topics/{topic}", payload, headers=REST_HEADERS["avro"])
+
+    assert res.status_code != 200
+    assert res.json().get("error_code") == RESTErrorCodes.SCHEMA_RETRIEVAL_ERROR.value
+
+
+# Issue #1274 baseline: Basic proxy + Basic SR + gate OFF must keep working.
+
+
+async def test_basic_auth_proxy_to_basic_sr_unchanged_by_contextvar(
+    rest_async_client_basic_proxy: Client,
+    admin_client: KafkaAdminClient,
+    basic_sr_primary_ready: None,
+) -> None:
+    """Gate OFF + registry_user/password + Basic SR: produce still works as before."""
+    topic = await _ensure_topic(rest_async_client_basic_proxy, admin_client)
+
+    payload = {
+        "value_schema": json.dumps({"type": "record", "name": "Simple", "fields": [{"name": "n", "type": "string"}]}),
+        "records": [{"value": {"n": "basic"}}],
+    }
+    res = await rest_async_client_basic_proxy.post(f"/topics/{topic}", payload, headers=REST_HEADERS["avro"])
+
+    assert res.status_code == 200, res.json()
+    assert "value_schema_id" in res.json()

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -4,18 +4,15 @@ See LICENSE for details
 """
 
 from karapace.core.client import Client
-from karapace.core.config import Config
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.core.serialization import SchemaRegistryClient
 from karapace.core.typing import Version
 from tests.utils import new_random_name, schema_avro_json
 
-_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
-
 
 async def test_remote_client(registry_async_client: Client) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
-    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
@@ -30,7 +27,7 @@ async def test_remote_client(registry_async_client: Client) -> None:
 
 async def test_remote_client_tls(registry_async_client_tls: Client, server_ca: str) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
-    reg_cli = SchemaRegistryClient(server_ca=server_ca, cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    reg_cli = SchemaRegistryClient(server_ca=server_ca)
     reg_cli.client = registry_async_client_tls
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -4,15 +4,18 @@ See LICENSE for details
 """
 
 from karapace.core.client import Client
+from karapace.core.config import Config
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.core.serialization import SchemaRegistryClient
 from karapace.core.typing import Version
 from tests.utils import new_random_name, schema_avro_json
 
+_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
+
 
 async def test_remote_client(registry_async_client: Client) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
-    reg_cli = SchemaRegistryClient()
+    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)
@@ -27,7 +30,7 @@ async def test_remote_client(registry_async_client: Client) -> None:
 
 async def test_remote_client_tls(registry_async_client_tls: Client, server_ca: str) -> None:
     schema_avro = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
-    reg_cli = SchemaRegistryClient(server_ca=server_ca)
+    reg_cli = SchemaRegistryClient(server_ca=server_ca, cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
     reg_cli.client = registry_async_client_tls
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_avro)

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -3,19 +3,16 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 
-from karapace.core.config import Config
 from karapace.core.protobuf.kotlin_wrapper import trim_margin
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.core.serialization import SchemaRegistryClient
 from tests.schemas.protobuf import schema_protobuf_order_after, schema_protobuf_order_before, schema_protobuf_plain
 from tests.utils import new_random_name
 
-_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
-
 
 async def test_remote_client_protobuf(registry_async_client):
     schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
-    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)
@@ -36,7 +33,7 @@ async def test_remote_client_protobuf(registry_async_client):
 async def test_remote_client_protobuf2(registry_async_client):
     schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_before))
     schema_protobuf_after = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_after))
-    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    reg_cli = SchemaRegistryClient()
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)

--- a/tests/integration/test_client_protobuf.py
+++ b/tests/integration/test_client_protobuf.py
@@ -3,16 +3,19 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 
+from karapace.core.config import Config
 from karapace.core.protobuf.kotlin_wrapper import trim_margin
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema
 from karapace.core.serialization import SchemaRegistryClient
 from tests.schemas.protobuf import schema_protobuf_order_after, schema_protobuf_order_before, schema_protobuf_plain
 from tests.utils import new_random_name
 
+_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
+
 
 async def test_remote_client_protobuf(registry_async_client):
     schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, schema_protobuf_plain)
-    reg_cli = SchemaRegistryClient()
+    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)
@@ -33,7 +36,7 @@ async def test_remote_client_protobuf(registry_async_client):
 async def test_remote_client_protobuf2(registry_async_client):
     schema_protobuf = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_before))
     schema_protobuf_after = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, trim_margin(schema_protobuf_order_after))
-    reg_cli = SchemaRegistryClient()
+    reg_cli = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
     reg_cli.client = registry_async_client
     subject = new_random_name("subject")
     sc_id = await reg_cli.post_new_schema(subject, schema_protobuf, None)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,18 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+import pytest
+
+from karapace.core.serialization import sr_authorization_ctx
+
+
+@pytest.fixture
+def reset_sr_authorization_ctx():
+    """Reset the contextvar between tests."""
+    token = sr_authorization_ctx.set(None)
+    try:
+        yield
+    finally:
+        sr_authorization_ctx.reset(token)

--- a/tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py
+++ b/tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py
@@ -1,0 +1,175 @@
+"""
+Copyright (c) 2025 Aiven Ltd
+See LICENSE for details
+
+Tests for the REST Proxy → Schema Registry Authorization-header forwarding gate.
+The gate lives in `UserRestProxy.publish` and `UserRestProxy.fetch`: the inbound
+Authorization header is copied into `sr_authorization_ctx` only when
+`sasl_oauthbearer_authentication_enabled` is true.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from karapace.core.config import Config
+from karapace.core.serialization import sr_authorization_ctx
+from karapace.kafka_rest_apis import UserRestProxy
+
+
+@pytest.fixture
+def reset_sr_authorization_ctx():
+    """Reset the contextvar between tests."""
+    token = sr_authorization_ctx.set(None)
+    try:
+        yield
+    finally:
+        sr_authorization_ctx.reset(token)
+
+
+def _make_proxy(*, sasl_oauthbearer_authentication_enabled: bool) -> UserRestProxy:
+    """Build a UserRestProxy stub via __new__ to skip __init__ (needs live Kafka).
+    The gate only reads self.config; downstream calls are stubbed per-test."""
+    proxy = UserRestProxy.__new__(UserRestProxy)
+    proxy.config = Config(sasl_oauthbearer_authentication_enabled=sasl_oauthbearer_authentication_enabled)
+    return proxy
+
+
+def _make_request(*, headers: dict[str, str] | None = None) -> Mock:
+    request = Mock()
+    request.headers = headers or {}
+    request.query = {}
+    request.accepts = {"embedded_format": "binary"}
+    request.content_type = {"embedded_format": "binary"}
+    request.json = {"records": []}
+    return request
+
+
+# fetch() gate.
+
+
+async def test_fetch_does_not_set_ctxvar_when_flag_disabled(reset_sr_authorization_ctx) -> None:
+    """Flag off: inbound bearer must not propagate; SR client keeps its session_auth."""
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=False)
+
+    captured: list[str | None] = []
+
+    async def fake_consumer_fetch(**_kwargs) -> None:
+        captured.append(sr_authorization_ctx.get())
+
+    proxy.consumer_manager = Mock()
+    proxy.consumer_manager.fetch = fake_consumer_fetch
+
+    request = _make_request(headers={"Authorization": "Bearer leak.if.broken"})
+    await proxy.fetch("group", "instance", "application/json", request=request)
+
+    assert captured == [None]
+
+
+async def test_fetch_sets_ctxvar_to_inbound_bearer_when_flag_enabled(reset_sr_authorization_ctx) -> None:
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=True)
+
+    captured: list[str | None] = []
+
+    async def fake_consumer_fetch(**_kwargs) -> None:
+        captured.append(sr_authorization_ctx.get())
+
+    proxy.consumer_manager = Mock()
+    proxy.consumer_manager.fetch = fake_consumer_fetch
+
+    request = _make_request(headers={"Authorization": "Bearer good.token"})
+    await proxy.fetch("group", "instance", "application/json", request=request)
+
+    assert captured == ["Bearer good.token"]
+
+
+async def test_fetch_sets_ctxvar_to_none_when_flag_enabled_but_no_header(reset_sr_authorization_ctx) -> None:
+    """Flag on, no inbound Authorization: contextvar is None so SR client falls back to session_auth."""
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=True)
+
+    captured: list[str | None] = []
+
+    async def fake_consumer_fetch(**_kwargs) -> None:
+        captured.append(sr_authorization_ctx.get())
+
+    proxy.consumer_manager = Mock()
+    proxy.consumer_manager.fetch = fake_consumer_fetch
+
+    request = _make_request(headers={})  # no Authorization
+    await proxy.fetch("group", "instance", "application/json", request=request)
+
+    assert captured == [None]
+
+
+# publish() gate — stub get_topic_info to short-circuit right after the gate.
+
+
+class _StopAfterGate(Exception):
+    """Sentinel raised by stubbed get_topic_info to short-circuit publish."""
+
+
+async def _drive_publish_capture_ctx(proxy: UserRestProxy, request: Mock) -> str | None:
+    captured: list[str | None] = []
+
+    async def fake_get_topic_info(_topic: str, _content_type: str) -> dict:
+        captured.append(sr_authorization_ctx.get())
+        raise _StopAfterGate()
+
+    proxy.get_topic_info = fake_get_topic_info
+
+    with pytest.raises(_StopAfterGate):
+        await proxy.publish(topic="t", partition_id=None, content_type="application/json", request=request)
+
+    assert captured
+    return captured[0]
+
+
+async def test_publish_does_not_set_ctxvar_when_flag_disabled(reset_sr_authorization_ctx) -> None:
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=False)
+    request = _make_request(headers={"Authorization": "Bearer leak.if.broken"})
+
+    observed = await _drive_publish_capture_ctx(proxy, request)
+    assert observed is None
+
+
+async def test_publish_sets_ctxvar_to_inbound_bearer_when_flag_enabled(reset_sr_authorization_ctx) -> None:
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=True)
+    request = _make_request(headers={"Authorization": "Bearer publish.token"})
+
+    observed = await _drive_publish_capture_ctx(proxy, request)
+    assert observed == "Bearer publish.token"
+
+
+async def test_publish_sets_ctxvar_to_none_when_flag_enabled_but_no_header(reset_sr_authorization_ctx) -> None:
+    proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=True)
+    request = _make_request(headers={})
+
+    observed = await _drive_publish_capture_ctx(proxy, request)
+    assert observed is None
+
+
+# Concurrent requests must not bleed tokens — asyncio copies context per coroutine.
+
+
+async def test_concurrent_requests_isolate_ctxvar(reset_sr_authorization_ctx) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def fake_get_topic_info(topic: str, _content_type: str) -> dict:
+        # Yield so the two coroutines interleave before reading the contextvar.
+        await asyncio.sleep(0)
+        captured[topic] = sr_authorization_ctx.get()
+        raise _StopAfterGate()
+
+    async def drive(topic: str, token: str) -> None:
+        proxy = _make_proxy(sasl_oauthbearer_authentication_enabled=True)
+        proxy.get_topic_info = fake_get_topic_info
+        request = _make_request(headers={"Authorization": token})
+        with pytest.raises(_StopAfterGate):
+            await proxy.publish(topic=topic, partition_id=None, content_type="application/json", request=request)
+
+    await asyncio.gather(drive("topic-a", "Bearer A"), drive("topic-b", "Bearer B"))
+
+    assert captured == {"topic-a": "Bearer A", "topic-b": "Bearer B"}

--- a/tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py
+++ b/tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 Aiven Ltd
+Copyright (c) 2026 Aiven Ltd
 See LICENSE for details
 
 Tests for the REST Proxy → Schema Registry Authorization-header forwarding gate.
@@ -18,16 +18,6 @@ import pytest
 from karapace.core.config import Config
 from karapace.core.serialization import sr_authorization_ctx
 from karapace.kafka_rest_apis import UserRestProxy
-
-
-@pytest.fixture
-def reset_sr_authorization_ctx():
-    """Reset the contextvar between tests."""
-    token = sr_authorization_ctx.set(None)
-    try:
-        yield
-    finally:
-        sr_authorization_ctx.reset(token)
 
 
 def _make_proxy(*, sasl_oauthbearer_authentication_enabled: bool) -> UserRestProxy:

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -10,11 +10,12 @@ import io
 import json
 import logging
 import struct
-from unittest.mock import Mock, call, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import avro
 import pytest
 
+from karapace.core.config import Config
 from karapace.core.container import KarapaceContainer
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema, Versioner
 from karapace.core.serialization import (
@@ -28,6 +29,7 @@ from karapace.core.serialization import (
     SchemaRegistrySerializer,
     flatten_unions,
     get_subject_name,
+    sr_authorization_ctx,
     write_value,
 )
 from karapace.core.typing import NameStrategy, Subject, SubjectType
@@ -693,3 +695,177 @@ def test_name_strategy_for_protobuf(expected_subject: Subject, strategy: NameStr
         get_subject_name(topic_name="foo", schema=TYPED_PROTOBUF_SCHEMA, subject_type=subject_type, naming_strategy=strategy)
         == expected_subject
     )
+
+
+# Authorization forwarding via sr_authorization_ctx. Tested through observed headers
+# on the mocked Client — covers post_new_schema, _get_schema_recursive, get_schema_for_id,
+# and the @alru_cache partitioning on get_schema.
+
+
+@pytest.fixture
+def reset_sr_authorization_ctx():
+    """Reset the contextvar between tests."""
+    token = sr_authorization_ctx.set(None)
+    try:
+        yield
+    finally:
+        sr_authorization_ctx.reset(token)
+
+
+# Track the production default so tests don't drift.
+_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
+
+
+def _make_result(json_result: dict, status: int = 200) -> Mock:
+    result = Mock()
+    result.ok = 200 <= status < 300
+    result.status_code = status
+    result.json = Mock(return_value=json_result)
+    return result
+
+
+async def test_post_new_schema_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    post_future = asyncio.Future()
+    post_future.set_result(_make_result({"id": 42}))
+    sr_client.client.post = Mock(return_value=post_future)
+
+    sr_authorization_ctx.set("Bearer fwd.token")
+    schema = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+    schema_id = await sr_client.post_new_schema("subj", schema)
+
+    assert schema_id == 42
+    _, kwargs = sr_client.client.post.call_args
+    # Authorization is forwarded; SR vendor Content-Type is preserved.
+    assert kwargs["headers"] == {
+        "Content-Type": "application/vnd.schemaregistry.v1+json",
+        "Authorization": "Bearer fwd.token",
+    }
+
+
+async def test_post_new_schema_no_authorization_header_when_ctx_unset(reset_sr_authorization_ctx) -> None:
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    post_future = asyncio.Future()
+    post_future.set_result(_make_result({"id": 42}))
+    sr_client.client.post = Mock(return_value=post_future)
+
+    schema = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+    await sr_client.post_new_schema("subj", schema)
+
+    _, kwargs = sr_client.client.post.call_args
+    # Ctx unset → no Authorization; vendor Content-Type stays.
+    assert kwargs["headers"] == {"Content-Type": "application/vnd.schemaregistry.v1+json"}
+
+
+async def test_post_new_schema_treats_empty_token_as_unset(reset_sr_authorization_ctx) -> None:
+    """Empty contextvar string must not produce an `Authorization: ` header."""
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    post_future = asyncio.Future()
+    post_future.set_result(_make_result({"id": 42}))
+    sr_client.client.post = Mock(return_value=post_future)
+
+    sr_authorization_ctx.set("")
+    schema = ValidatedTypedSchema.parse(SchemaType.AVRO, schema_avro_json)
+    await sr_client.post_new_schema("subj", schema)
+
+    _, kwargs = sr_client.client.post.call_args
+    assert "Authorization" not in kwargs["headers"]
+    assert kwargs["headers"] == {"Content-Type": "application/vnd.schemaregistry.v1+json"}
+
+
+async def test_get_schema_for_id_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    get_future = asyncio.Future()
+    get_future.set_result(
+        _make_result(
+            {
+                "schema": schema_avro_json,
+                "subjects": ["subj"],
+                "schemaType": SchemaType.AVRO.value,
+            }
+        )
+    )
+    sr_client.client.get = Mock(return_value=get_future)
+
+    sr_authorization_ctx.set("Bearer xyz")
+    await sr_client.get_schema_for_id(1)
+
+    _, kwargs = sr_client.client.get.call_args
+    assert kwargs["headers"] == {"Authorization": "Bearer xyz"}
+
+
+async def test_get_schema_recursive_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    get_future = asyncio.Future()
+    get_future.set_result(
+        _make_result(
+            {
+                "id": 7,
+                "schema": schema_avro_json,
+                "version": 1,
+                "schemaType": SchemaType.AVRO.value,
+            }
+        )
+    )
+    sr_client.client.get = Mock(return_value=get_future)
+
+    sr_authorization_ctx.set("Bearer recursive")
+    # Bypass @alru_cache on get_schema.
+    schema_id, _, _ = await sr_client._get_schema_recursive(Subject("subj"), set(), None)
+
+    assert schema_id == 7
+    _, kwargs = sr_client.client.get.call_args
+    assert kwargs["headers"] == {"Authorization": "Bearer recursive"}
+
+
+async def test_get_schema_cache_partitions_by_token(reset_sr_authorization_ctx) -> None:
+    """Cache key includes the token fingerprint: same token hits cache, different token misses."""
+
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client.client.get = AsyncMock(
+        return_value=_make_result(
+            {
+                "id": 11,
+                "schema": schema_avro_json,
+                "version": 1,
+                "schemaType": SchemaType.AVRO.value,
+            }
+        )
+    )
+
+    subject = Subject("uniq-subject-for-cache-partition-test")
+
+    sr_authorization_ctx.set("Bearer first")
+    await sr_client.get_schema(subject)
+    await sr_client.get_schema(subject)  # same token — cache hit
+    assert sr_client.client.get.call_count == 1
+
+    sr_authorization_ctx.set("Bearer second")
+    await sr_client.get_schema(subject)  # different token — cache miss, SR is consulted again
+    assert sr_client.client.get.call_count == 2
+
+    sr_authorization_ctx.set("Bearer first")
+    await sr_client.get_schema(subject)  # back to first token — cache hit
+    assert sr_client.client.get.call_count == 2
+
+
+async def test_get_schema_cache_unauthenticated_path_unchanged(reset_sr_authorization_ctx) -> None:
+    """Unauthenticated path: empty fingerprint, back-to-back calls still hit cache."""
+    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    get_future = asyncio.Future()
+    get_future.set_result(
+        _make_result(
+            {
+                "id": 12,
+                "schema": schema_avro_json,
+                "version": 1,
+                "schemaType": SchemaType.AVRO.value,
+            }
+        )
+    )
+    sr_client.client.get = Mock(return_value=get_future)
+
+    subject = Subject("uniq-subject-for-cache-unauth-test")
+    await sr_client.get_schema(subject)
+    await sr_client.get_schema(subject)
+    assert sr_client.client.get.call_count == 1

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, Mock, call, patch
 import avro
 import pytest
 
-from karapace.core.config import Config
 from karapace.core.container import KarapaceContainer
 from karapace.core.schema_models import SchemaType, ValidatedTypedSchema, Versioner
 from karapace.core.serialization import (
@@ -702,20 +701,6 @@ def test_name_strategy_for_protobuf(expected_subject: Subject, strategy: NameStr
 # and the @alru_cache partitioning on get_schema.
 
 
-@pytest.fixture
-def reset_sr_authorization_ctx():
-    """Reset the contextvar between tests."""
-    token = sr_authorization_ctx.set(None)
-    try:
-        yield
-    finally:
-        sr_authorization_ctx.reset(token)
-
-
-# Track the production default so tests don't drift.
-_DEFAULT_CACHE_MAXSIZE = Config.model_fields["schema_registry_client_cache_maxsize"].default
-
-
 def _make_result(json_result: dict, status: int = 200) -> Mock:
     result = Mock()
     result.ok = 200 <= status < 300
@@ -725,7 +710,7 @@ def _make_result(json_result: dict, status: int = 200) -> Mock:
 
 
 async def test_post_new_schema_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     post_future = asyncio.Future()
     post_future.set_result(_make_result({"id": 42}))
     sr_client.client.post = Mock(return_value=post_future)
@@ -744,7 +729,7 @@ async def test_post_new_schema_forwards_authorization_header(reset_sr_authorizat
 
 
 async def test_post_new_schema_no_authorization_header_when_ctx_unset(reset_sr_authorization_ctx) -> None:
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     post_future = asyncio.Future()
     post_future.set_result(_make_result({"id": 42}))
     sr_client.client.post = Mock(return_value=post_future)
@@ -759,7 +744,7 @@ async def test_post_new_schema_no_authorization_header_when_ctx_unset(reset_sr_a
 
 async def test_post_new_schema_treats_empty_token_as_unset(reset_sr_authorization_ctx) -> None:
     """Empty contextvar string must not produce an `Authorization: ` header."""
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     post_future = asyncio.Future()
     post_future.set_result(_make_result({"id": 42}))
     sr_client.client.post = Mock(return_value=post_future)
@@ -774,7 +759,7 @@ async def test_post_new_schema_treats_empty_token_as_unset(reset_sr_authorizatio
 
 
 async def test_get_schema_for_id_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     get_future = asyncio.Future()
     get_future.set_result(
         _make_result(
@@ -795,7 +780,7 @@ async def test_get_schema_for_id_forwards_authorization_header(reset_sr_authoriz
 
 
 async def test_get_schema_recursive_forwards_authorization_header(reset_sr_authorization_ctx) -> None:
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     get_future = asyncio.Future()
     get_future.set_result(
         _make_result(
@@ -821,7 +806,7 @@ async def test_get_schema_recursive_forwards_authorization_header(reset_sr_autho
 async def test_get_schema_cache_partitions_by_token(reset_sr_authorization_ctx) -> None:
     """Cache key includes the token fingerprint: same token hits cache, different token misses."""
 
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     sr_client.client.get = AsyncMock(
         return_value=_make_result(
             {
@@ -851,7 +836,7 @@ async def test_get_schema_cache_partitions_by_token(reset_sr_authorization_ctx) 
 
 async def test_get_schema_cache_unauthenticated_path_unchanged(reset_sr_authorization_ctx) -> None:
     """Unauthenticated path: empty fingerprint, back-to-back calls still hit cache."""
-    sr_client = SchemaRegistryClient(cache_maxsize=_DEFAULT_CACHE_MAXSIZE)
+    sr_client = SchemaRegistryClient()
     get_future = asyncio.Future()
     get_future.set_result(
         _make_result(


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

When the Schema Registry has `sasl_oauthbearer_authentication_enabled=true`, the REST Proxy was calling SR with its static `BasicAuth` (or nothing) and getting back 401s, surfaced to clients as the generic `40801 "Error when registering schema"`. This PR threads the inbound caller's `Authorization` header through to SR for the duration of the request, gated by the same flag that already turns on SR's `OIDCMiddleware`.                                                                                                                                  
                                                                                                                                                                   
The forwarding is implemented with a module-level `contextvars.ContextVar` (`sr_authorization_ctx`) rather than a kwarg threaded through ~10 method signatures across the produce/consume path. asyncio copies the context across `await` boundaries and per task in `asyncio.gather`, so per-request isolation is automatic.                                                                                                                                                       
                                                                                                                                                               
## Behavior matrix                    
                                                        
Forwarding is gated by `config.sasl_oauthbearer_authentication_enabled`. When `False` (the default and every existing deployment), behavior is byte-identical to before.                            
                                                        
| flag | inbound `Authorization` | `registry_user`/`password` | outgoing to SR |                                                                                 
|------|--------------------------|----------------------------|----------------|
| `False` | any | any | unchanged — Basic if creds set, else nothing |                                                                                           
| `True`  | `Bearer …` | any | `Authorization: Bearer …` (overrides Basic for the call) |                                                                        
| `True`  | `Basic …`  | any | forwarded as-is |                                                                                                                 
| `True`  | none       | yes | Basic (existing fallback) |                                                                                                       
| `True`  | none       | no  | unauthenticated → SR 401 | 

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #1274 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
