### PR TITLE
Fix unauthorized probe on subjects

### DIFF
--- a/src/karapace/api/routers/compatibility.py
+++ b/src/karapace/api/routers/compatibility.py
@@ -7,7 +7,7 @@ from dependency_injector.wiring import inject, Provide
 from fastapi import APIRouter, Depends
 from karapace.api.container import SchemaRegistryContainer
 from karapace.api.controller import KarapaceSchemaRegistryController
-from karapace.api.routers.errors import unauthorized
+from karapace.api.routers.errors import subject_not_found
 from karapace.api.routers.raw_path_router import SchemaRegistryRoute
 from karapace.api.routers.requests import CompatibilityCheckResponse, SchemaRequest
 from karapace.api.user import get_current_user
@@ -37,6 +37,6 @@ async def compatibility_post(
 ) -> CompatibilityCheckResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.compatibility_check(subject=subject, schema_request=schema_request, version=version)

--- a/src/karapace/api/routers/config.py
+++ b/src/karapace/api/routers/config.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from karapace.api.container import SchemaRegistryContainer
 from karapace.api.controller import KarapaceSchemaRegistryController
 from karapace.api.forward_client import ForwardClient
-from karapace.api.routers.errors import no_primary_url_error, unauthorized
+from karapace.api.routers.errors import no_primary_url_error, subject_not_found, unauthorized
 from karapace.api.routers.raw_path_router import SchemaRegistryRoute
 from karapace.api.routers.requests import CompatibilityLevelResponse, CompatibilityRequest, CompatibilityResponse
 from karapace.api.user import get_current_user
@@ -75,7 +75,7 @@ async def config_get_subject(
 ) -> CompatibilityLevelResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.config_subject_get(subject=subject, default_to_global=defaultToGlobal)
 
@@ -94,7 +94,7 @@ async def config_set_subject(
 ) -> CompatibilityResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Write, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     primary_info = await schema_registry.get_master()
     if primary_info.primary:
@@ -119,7 +119,7 @@ async def config_delete_subject(
 ) -> CompatibilityResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Write, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     primary_info = await schema_registry.get_master()
     if primary_info.primary:

--- a/src/karapace/api/routers/errors.py
+++ b/src/karapace/api/routers/errors.py
@@ -71,11 +71,8 @@ def unauthorized() -> HTTPException:
 
 
 def subject_not_found(subject: str) -> HTTPException:
-    # Returned in place of 403 for subject-scoped authorization denials so an
-    # authenticated-but-unauthorized caller cannot distinguish a forbidden
-    # subject from a non-existent one. Body must stay byte-identical to the
-    # 404 raised by the registry when a subject genuinely does not exist
-    # (see KarapaceSchemaRegistryController._subject_get).
+    # Body must match the genuine SubjectNotFoundException 404 so authZ denials
+    # cannot be distinguished from missing subjects.
     return HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail={

--- a/src/karapace/api/routers/errors.py
+++ b/src/karapace/api/routers/errors.py
@@ -68,3 +68,18 @@ def unauthorized() -> HTTPException:
         status_code=status.HTTP_403_FORBIDDEN,
         detail={"message": "Forbidden"},
     )
+
+
+def subject_not_found(subject: str) -> HTTPException:
+    # Returned in place of 403 for subject-scoped authorization denials so an
+    # authenticated-but-unauthorized caller cannot distinguish a forbidden
+    # subject from a non-existent one. Body must stay byte-identical to the
+    # 404 raised by the registry when a subject genuinely does not exist
+    # (see KarapaceSchemaRegistryController._subject_get).
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+            "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=subject),
+        },
+    )

--- a/src/karapace/api/routers/mode.py
+++ b/src/karapace/api/routers/mode.py
@@ -7,7 +7,7 @@ from dependency_injector.wiring import inject, Provide
 from fastapi import APIRouter, Depends
 from karapace.api.container import SchemaRegistryContainer
 from karapace.api.controller import KarapaceSchemaRegistryController
-from karapace.api.routers.errors import unauthorized
+from karapace.api.routers.errors import subject_not_found, unauthorized
 from karapace.api.routers.raw_path_router import SchemaRegistryRoute
 from karapace.api.routers.requests import ModeResponse
 from karapace.api.user import get_current_user
@@ -48,6 +48,6 @@ async def mode_get_subject(
 ) -> ModeResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.get_subject_mode(subject=subject)

--- a/src/karapace/api/routers/subjects.py
+++ b/src/karapace/api/routers/subjects.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from karapace.api.container import SchemaRegistryContainer
 from karapace.api.controller import KarapaceSchemaRegistryController
 from karapace.api.forward_client import ForwardClient
-from karapace.api.routers.errors import no_primary_url_error, unauthorized
+from karapace.api.routers.errors import no_primary_url_error, subject_not_found
 from karapace.api.routers.raw_path_router import SchemaRegistryRoute
 from karapace.api.routers.requests import SchemaIdResponse, SchemaRequest, SchemaResponse, SubjectSchemaVersionResponse
 from karapace.api.user import get_current_user
@@ -60,7 +60,7 @@ async def subjects_subject_post(
 ) -> SchemaResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.subjects_schema_post(
         subject=subject,
@@ -84,7 +84,7 @@ async def subjects_subject_delete(
 ) -> list[int]:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Write, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     primary_info = await schema_registry.get_master()
     if primary_info.primary:
@@ -110,7 +110,7 @@ async def subjects_subject_versions_post(
 ) -> SchemaIdResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Write, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     # TODO: split the functionality so primary error and forwarding can be handled here
     # and local/primary write is in controller.
@@ -134,7 +134,7 @@ async def subjects_subject_versions_list(
 ) -> list[int]:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.subject_versions_list(subject=subject, deleted=deleted)
 
@@ -151,7 +151,7 @@ async def subjects_subject_version_get(
 ) -> SubjectSchemaVersionResponse:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.subject_version_get(subject=subject, version=version, deleted=deleted)
 
@@ -171,7 +171,7 @@ async def subjects_subject_version_delete(
 ) -> int:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Write, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     primary_info = await schema_registry.get_master()
     if primary_info.primary:
@@ -194,7 +194,7 @@ async def subjects_subject_version_schema_get(
 ) -> dict:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.subject_version_schema_get(subject=subject, version=version)
 
@@ -210,6 +210,6 @@ async def subjects_subject_version_referenced_by(
 ) -> list[int]:
     subject = Subject(unquote_plus(subject))
     if authorizer and not authorizer.check_authorization(user, Operation.Read, f"Subject:{subject}"):
-        raise unauthorized()
+        raise subject_not_found(subject)
 
     return await controller.subject_version_referencedby_get(subject=subject, version=version)

--- a/tests/e2e/schema_registry/test_oidc.py
+++ b/tests/e2e/schema_registry/test_oidc.py
@@ -151,3 +151,34 @@ async def test_schema_registry_oidc_authn_only_skip_paths(
 
     res = await registry_async_client_oidc_authn_only_no_auth_header.get("metrics", json_response=False)
     assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Subject probing protection: the canonical 404 body for a missing subject
+# must be returned through the OIDC bearer-auth path so it is byte-identical
+# to the 404 used to mask subject-scoped authorization denials.
+#
+# The full forbidden-vs-missing indistinguishability contract is exercised in
+# the basic-auth integration suite (test_sr_unauthorized_subject_indistinguishable_from_missing
+# in tests/integration/test_schema_registry_auth.py). The fix lives in the
+# routers, which are auth-mechanism-agnostic — once the response shape is
+# confirmed identical on both code paths, the security property holds for
+# OIDC callers as well. This e2e test pins the OIDC half of that contract.
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_registry_oidc_missing_subject_returns_canonical_404(
+    registry_async_client_oidc: Client,
+) -> None:
+    """Probing a non-existent subject under OIDC must return the canonical
+    SUBJECT_NOT_FOUND body — same shape an authenticated-but-unauthorized
+    caller will see for forbidden subjects."""
+    subject = new_random_name("missing-")
+    await _wait_for_primary(registry_async_client_oidc)
+
+    res = await registry_async_client_oidc.get(f"subjects/{subject}/versions")
+    assert res.status_code == 404
+    assert res.json_result == {
+        "error_code": 40401,
+        "message": f"Subject '{subject}' not found.",
+    }

--- a/tests/e2e/schema_registry/test_oidc.py
+++ b/tests/e2e/schema_registry/test_oidc.py
@@ -153,26 +153,13 @@ async def test_schema_registry_oidc_authn_only_skip_paths(
     assert res.status_code == 200
 
 
-# ---------------------------------------------------------------------------
-# Subject probing protection: the canonical 404 body for a missing subject
-# must be returned through the OIDC bearer-auth path so it is byte-identical
-# to the 404 used to mask subject-scoped authorization denials.
-#
-# The full forbidden-vs-missing indistinguishability contract is exercised in
-# the basic-auth integration suite (test_sr_unauthorized_subject_indistinguishable_from_missing
-# in tests/integration/test_schema_registry_auth.py). The fix lives in the
-# routers, which are auth-mechanism-agnostic — once the response shape is
-# confirmed identical on both code paths, the security property holds for
-# OIDC callers as well. This e2e test pins the OIDC half of that contract.
-# ---------------------------------------------------------------------------
+# Pins the OIDC-side 404 body shape; full forbidden-vs-missing parity is
+# exercised in tests/integration/test_schema_registry_auth.py.
 
 
 async def test_schema_registry_oidc_missing_subject_returns_canonical_404(
     registry_async_client_oidc: Client,
 ) -> None:
-    """Probing a non-existent subject under OIDC must return the canonical
-    SUBJECT_NOT_FOUND body — same shape an authenticated-but-unauthorized
-    caller will see for forbidden subjects."""
     subject = new_random_name("missing-")
     await _wait_for_primary(registry_async_client_oidc)
 

--- a/tests/integration/test_schema_registry_auth.py
+++ b/tests/integration/test_schema_registry_auth.py
@@ -154,10 +154,17 @@ async def test_sr_list_subjects(registry_async_retry_client_auth: RetryRestClien
     assert res.status_code == 200
     assert [cavesubject] == res.json()
 
+    # Subject-scoped authZ denials respond with the same 404 body as
+    # genuinely-missing subjects so an authenticated caller cannot probe for
+    # the existence of subjects they are not allowed to read.
     res = await registry_async_retry_client_auth.get(
-        f"subjects/{quote(carpetsubject)}/versions", auth=aladdin, expected_response_code=403
+        f"subjects/{quote(carpetsubject)}/versions", auth=aladdin, expected_response_code=404
     )
-    assert res.status_code == 403
+    assert res.status_code == 404
+    assert res.json() == {
+        "error_code": 40401,
+        "message": f"Subject '{carpetsubject}' not found.",
+    }
 
     res = await registry_async_retry_client_auth.get("subjects", auth=reader)
     assert res.status_code == 200
@@ -166,6 +173,81 @@ async def test_sr_list_subjects(registry_async_retry_client_auth: RetryRestClien
     res = await registry_async_retry_client_auth.get(f"subjects/{quote(carpetsubject)}/versions", auth=reader)
     assert res.status_code == 200
     assert [1] == res.json()
+
+
+async def test_sr_unauthorized_subject_indistinguishable_from_missing(
+    registry_async_retry_client_auth: RetryRestClient,
+) -> None:
+    """An authenticated caller probing a forbidden subject must get the same
+    404 response as for a non-existent subject — same status, same body.
+
+    aladdin's ACL only covers 'Subject:cave-.*'. Hitting a 'carpet-' subject
+    that exists (created by admin) and a 'carpet-' subject that does not
+    exist must be indistinguishable to aladdin.
+    """
+    existing_forbidden = new_random_name("carpet-")
+    nonexistent = new_random_name("carpet-")
+
+    # admin creates the existing forbidden subject.
+    res = await registry_async_retry_client_auth.post(
+        f"subjects/{quote(existing_forbidden)}/versions", json={"schema": schema_avro_json}, auth=admin
+    )
+    assert res.status_code == 200
+
+    # Iterate every subject-scoped endpoint hit by an unauthorized caller.
+    # For each, the existing-but-forbidden response must match the
+    # genuinely-missing response byte-for-byte (status, body, content-type).
+    probes = [
+        ("GET", "subjects/{s}/versions", None),
+        ("GET", "subjects/{s}/versions/latest", None),
+        ("GET", "subjects/{s}/versions/1/schema", None),
+        ("GET", "subjects/{s}/versions/1/referencedby", None),
+        ("POST", "subjects/{s}", {"schema": schema_avro_json}),
+        ("POST", "subjects/{s}/versions", {"schema": schema_avro_json}),
+        ("DELETE", "subjects/{s}", None),
+        ("DELETE", "subjects/{s}/versions/1", None),
+        ("GET", "config/{s}", None),
+        ("PUT", "config/{s}", {"compatibility": "NONE"}),
+        ("DELETE", "config/{s}", None),
+        ("GET", "mode/{s}", None),
+        ("POST", "compatibility/subjects/{s}/versions/latest", {"schema": schema_avro_json}),
+    ]
+
+    for method, path_tpl, body in probes:
+        forbidden_path = path_tpl.format(s=quote(existing_forbidden))
+        missing_path = path_tpl.format(s=quote(nonexistent))
+
+        kwargs: dict = {"auth": aladdin, "expected_response_code": 404}
+        if body is not None:
+            kwargs["json"] = body
+
+        if method == "GET":
+            forbidden_res = await registry_async_retry_client_auth.get(forbidden_path, **kwargs)
+            missing_res = await registry_async_retry_client_auth.get(missing_path, **kwargs)
+        elif method == "POST":
+            forbidden_res = await registry_async_retry_client_auth.post(forbidden_path, **kwargs)
+            missing_res = await registry_async_retry_client_auth.post(missing_path, **kwargs)
+        elif method == "PUT":
+            forbidden_res = await registry_async_retry_client_auth.put(forbidden_path, **kwargs)
+            missing_res = await registry_async_retry_client_auth.put(missing_path, **kwargs)
+        else:  # DELETE
+            forbidden_res = await registry_async_retry_client_auth.delete(forbidden_path, **kwargs)
+            missing_res = await registry_async_retry_client_auth.delete(missing_path, **kwargs)
+
+        assert forbidden_res.status_code == 404, f"{method} {path_tpl} forbidden: {forbidden_res.status_code}"
+        assert missing_res.status_code == 404, f"{method} {path_tpl} missing: {missing_res.status_code}"
+
+        # Bodies are not strictly identical (subject name differs), but the
+        # error_code and message template must match — that is what removes
+        # the existence signal.
+        assert forbidden_res.json() == {
+            "error_code": 40401,
+            "message": f"Subject '{existing_forbidden}' not found.",
+        }, f"{method} {path_tpl} forbidden body mismatch"
+        assert missing_res.json() == {
+            "error_code": 40401,
+            "message": f"Subject '{nonexistent}' not found.",
+        }, f"{method} {path_tpl} missing body mismatch"
 
 
 async def test_sr_ids(registry_async_retry_client_auth: RetryRestClient) -> None:

--- a/tests/integration/test_schema_registry_auth.py
+++ b/tests/integration/test_schema_registry_auth.py
@@ -154,9 +154,7 @@ async def test_sr_list_subjects(registry_async_retry_client_auth: RetryRestClien
     assert res.status_code == 200
     assert [cavesubject] == res.json()
 
-    # Subject-scoped authZ denials respond with the same 404 body as
-    # genuinely-missing subjects so an authenticated caller cannot probe for
-    # the existence of subjects they are not allowed to read.
+    # AuthZ denial returns 404 to hide subject existence from an unauthorized caller.
     res = await registry_async_retry_client_auth.get(
         f"subjects/{quote(carpetsubject)}/versions", auth=aladdin, expected_response_code=404
     )
@@ -178,25 +176,16 @@ async def test_sr_list_subjects(registry_async_retry_client_auth: RetryRestClien
 async def test_sr_unauthorized_subject_indistinguishable_from_missing(
     registry_async_retry_client_auth: RetryRestClient,
 ) -> None:
-    """An authenticated caller probing a forbidden subject must get the same
-    404 response as for a non-existent subject — same status, same body.
-
-    aladdin's ACL only covers 'Subject:cave-.*'. Hitting a 'carpet-' subject
-    that exists (created by admin) and a 'carpet-' subject that does not
-    exist must be indistinguishable to aladdin.
-    """
+    """aladdin can only access Subject:cave-*; a carpet-* subject must look
+    identical whether it exists (admin-created) or not."""
     existing_forbidden = new_random_name("carpet-")
     nonexistent = new_random_name("carpet-")
 
-    # admin creates the existing forbidden subject.
     res = await registry_async_retry_client_auth.post(
         f"subjects/{quote(existing_forbidden)}/versions", json={"schema": schema_avro_json}, auth=admin
     )
     assert res.status_code == 200
 
-    # Iterate every subject-scoped endpoint hit by an unauthorized caller.
-    # For each, the existing-but-forbidden response must match the
-    # genuinely-missing response byte-for-byte (status, body, content-type).
     probes = [
         ("GET", "subjects/{s}/versions", None),
         ("GET", "subjects/{s}/versions/latest", None),
@@ -237,9 +226,6 @@ async def test_sr_unauthorized_subject_indistinguishable_from_missing(
         assert forbidden_res.status_code == 404, f"{method} {path_tpl} forbidden: {forbidden_res.status_code}"
         assert missing_res.status_code == 404, f"{method} {path_tpl} missing: {missing_res.status_code}"
 
-        # Bodies are not strictly identical (subject name differs), but the
-        # error_code and message template must match — that is what removes
-        # the existence signal.
         assert forbidden_res.json() == {
             "error_code": 40401,
             "message": f"Subject '{existing_forbidden}' not found.",

--- a/tests/unit/api/test_subject_authz_probing.py
+++ b/tests/unit/api/test_subject_authz_probing.py
@@ -1,10 +1,6 @@
 """
-Unit tests for the subject probing protection.
-
-When an authenticated caller is denied access to a subject-scoped resource,
-the response must be byte-identical to the response for a genuinely-missing
-subject (status 404 with the canonical 40401 body). Otherwise an attacker can
-enumerate which subjects exist by comparing 403 vs 404.
+Subject-scoped authZ denials must return the canonical 40401 404 so callers
+cannot distinguish forbidden subjects from missing ones.
 
 Copyright (c) 2026 Aiven Ltd
 See LICENSE for details
@@ -39,12 +35,6 @@ from karapace.core.typing import Subject
 SUBJECT = Subject("secret-subject")
 
 
-# ---------------------------------------------------------------------------
-# subject_not_found helper: body must match the genuine "subject does not exist"
-# response raised by KarapaceSchemaRegistryController._subject_get.
-# ---------------------------------------------------------------------------
-
-
 def test_subject_not_found_returns_404_with_canonical_body() -> None:
     exc = subject_not_found(SUBJECT)
     assert exc.status_code == status.HTTP_404_NOT_FOUND
@@ -55,10 +45,7 @@ def test_subject_not_found_returns_404_with_canonical_body() -> None:
 
 
 def test_subject_not_found_body_matches_genuine_missing_response() -> None:
-    """The probing-protection 404 must be indistinguishable from a real not-found 404."""
     forbidden = subject_not_found(SUBJECT)
-    # Build the same shape KarapaceSchemaRegistryController._subject_get raises
-    # for a SubjectNotFoundException (see src/karapace/api/controller.py).
     genuine = HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail={
@@ -71,17 +58,9 @@ def test_subject_not_found_body_matches_genuine_missing_response() -> None:
 
 
 def test_unauthorized_helper_still_returns_403() -> None:
-    """The 403 helper must remain available for non-subject scopes (Config:, method-level OIDC)."""
     exc = unauthorized()
     assert exc.status_code == status.HTTP_403_FORBIDDEN
     assert exc.detail == {"message": "Forbidden"}
-
-
-# ---------------------------------------------------------------------------
-# Per-route assertions: a denying authorizer must produce the 404 helper, not
-# the legacy 403. Calling the route function directly with a MagicMock
-# authorizer is enough — we are only exercising the early authZ branch.
-# ---------------------------------------------------------------------------
 
 
 def _denying_authorizer() -> MagicMock:
@@ -96,9 +75,6 @@ def _assert_subject_not_found(exc_info: pytest.ExceptionInfo[HTTPException]) -> 
         "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
         "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=SUBJECT),
     }
-
-
-# subjects.py
 
 
 async def test_subjects_subject_post_denied_returns_404() -> None:
@@ -210,9 +186,6 @@ async def test_subjects_subject_version_referenced_by_denied_returns_404() -> No
     _assert_subject_not_found(exc_info)
 
 
-# config.py — only the subject-scoped routes; global Config: stays 403 elsewhere.
-
-
 async def test_config_get_subject_denied_returns_404() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await config_get_subject(
@@ -254,9 +227,6 @@ async def test_config_delete_subject_denied_returns_404() -> None:
     _assert_subject_not_found(exc_info)
 
 
-# mode.py
-
-
 async def test_mode_get_subject_denied_returns_404() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await mode_get_subject(
@@ -266,9 +236,6 @@ async def test_mode_get_subject_denied_returns_404() -> None:
             controller=MagicMock(),
         )
     _assert_subject_not_found(exc_info)
-
-
-# compatibility.py
 
 
 async def test_compatibility_post_denied_returns_404() -> None:
@@ -282,12 +249,6 @@ async def test_compatibility_post_denied_returns_404() -> None:
             controller=MagicMock(),
         )
     _assert_subject_not_found(exc_info)
-
-
-# ---------------------------------------------------------------------------
-# Cross-check: the authZ resource must be the Subject:* form. Confirms we did
-# not accidentally swap a Config: site to subject_not_found().
-# ---------------------------------------------------------------------------
 
 
 async def test_subject_scoped_authz_uses_subject_resource_form() -> None:

--- a/tests/unit/api/test_subject_authz_probing.py
+++ b/tests/unit/api/test_subject_authz_probing.py
@@ -1,0 +1,306 @@
+"""
+Unit tests for the subject probing protection.
+
+When an authenticated caller is denied access to a subject-scoped resource,
+the response must be byte-identical to the response for a genuinely-missing
+subject (status 404 with the canonical 40401 body). Otherwise an attacker can
+enumerate which subjects exist by comparing 403 vs 404.
+
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from karapace.api.routers.compatibility import compatibility_post
+from karapace.api.routers.config import config_delete_subject, config_get_subject, config_set_subject
+from karapace.api.routers.errors import SchemaErrorCodes, SchemaErrorMessages, subject_not_found, unauthorized
+from karapace.api.routers.mode import mode_get_subject
+from karapace.api.routers.requests import CompatibilityRequest, SchemaRequest
+from karapace.api.routers.subjects import (
+    subjects_subject_delete,
+    subjects_subject_post,
+    subjects_subject_version_delete,
+    subjects_subject_version_get,
+    subjects_subject_version_referenced_by,
+    subjects_subject_version_schema_get,
+    subjects_subject_versions_list,
+    subjects_subject_versions_post,
+)
+from karapace.core.auth import Operation
+from karapace.core.typing import Subject
+
+
+SUBJECT = Subject("secret-subject")
+
+
+# ---------------------------------------------------------------------------
+# subject_not_found helper: body must match the genuine "subject does not exist"
+# response raised by KarapaceSchemaRegistryController._subject_get.
+# ---------------------------------------------------------------------------
+
+
+def test_subject_not_found_returns_404_with_canonical_body() -> None:
+    exc = subject_not_found(SUBJECT)
+    assert exc.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.detail == {
+        "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+        "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=SUBJECT),
+    }
+
+
+def test_subject_not_found_body_matches_genuine_missing_response() -> None:
+    """The probing-protection 404 must be indistinguishable from a real not-found 404."""
+    forbidden = subject_not_found(SUBJECT)
+    # Build the same shape KarapaceSchemaRegistryController._subject_get raises
+    # for a SubjectNotFoundException (see src/karapace/api/controller.py).
+    genuine = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+            "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=SUBJECT),
+        },
+    )
+    assert forbidden.status_code == genuine.status_code
+    assert forbidden.detail == genuine.detail
+
+
+def test_unauthorized_helper_still_returns_403() -> None:
+    """The 403 helper must remain available for non-subject scopes (Config:, method-level OIDC)."""
+    exc = unauthorized()
+    assert exc.status_code == status.HTTP_403_FORBIDDEN
+    assert exc.detail == {"message": "Forbidden"}
+
+
+# ---------------------------------------------------------------------------
+# Per-route assertions: a denying authorizer must produce the 404 helper, not
+# the legacy 403. Calling the route function directly with a MagicMock
+# authorizer is enough — we are only exercising the early authZ branch.
+# ---------------------------------------------------------------------------
+
+
+def _denying_authorizer() -> MagicMock:
+    authorizer = MagicMock()
+    authorizer.check_authorization.return_value = False
+    return authorizer
+
+
+def _assert_subject_not_found(exc_info: pytest.ExceptionInfo[HTTPException]) -> None:
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == {
+        "error_code": SchemaErrorCodes.SUBJECT_NOT_FOUND.value,
+        "message": SchemaErrorMessages.SUBJECT_NOT_FOUND_FMT.value.format(subject=SUBJECT),
+    }
+
+
+# subjects.py
+
+
+async def test_subjects_subject_post_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_post(
+            subject=SUBJECT,
+            user=None,
+            schema_request=SchemaRequest(schema="{}"),
+            deleted=False,
+            normalize=False,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_delete_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_delete(
+            request=MagicMock(),
+            subject=SUBJECT,
+            user=None,
+            permanent=False,
+            forward_client=MagicMock(),
+            authorizer=_denying_authorizer(),
+            schema_registry=MagicMock(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_versions_post_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_versions_post(
+            request=MagicMock(),
+            subject=SUBJECT,
+            schema_request=SchemaRequest(schema="{}"),
+            user=None,
+            forward_client=MagicMock(),
+            authorizer=_denying_authorizer(),
+            normalize=False,
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_versions_list_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_versions_list(
+            subject=SUBJECT,
+            user=None,
+            deleted=False,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_version_get_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_version_get(
+            subject=SUBJECT,
+            version="latest",
+            user=None,
+            deleted=False,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_version_delete_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_version_delete(
+            request=MagicMock(),
+            subject=SUBJECT,
+            version="1",
+            user=None,
+            permanent=False,
+            forward_client=MagicMock(),
+            authorizer=_denying_authorizer(),
+            schema_registry=MagicMock(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_version_schema_get_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_version_schema_get(
+            subject=SUBJECT,
+            version="latest",
+            user=None,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_subjects_subject_version_referenced_by_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await subjects_subject_version_referenced_by(
+            subject=SUBJECT,
+            version="latest",
+            user=None,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+# config.py — only the subject-scoped routes; global Config: stays 403 elsewhere.
+
+
+async def test_config_get_subject_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await config_get_subject(
+            subject=SUBJECT,
+            user=None,
+            defaultToGlobal=False,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_config_set_subject_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await config_set_subject(
+            request=MagicMock(),
+            subject=SUBJECT,
+            compatibility_level_request=CompatibilityRequest(compatibility="NONE"),
+            user=None,
+            schema_registry=MagicMock(),
+            forward_client=MagicMock(),
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+async def test_config_delete_subject_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await config_delete_subject(
+            request=MagicMock(),
+            subject=SUBJECT,
+            user=None,
+            schema_registry=MagicMock(),
+            forward_client=MagicMock(),
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+# mode.py
+
+
+async def test_mode_get_subject_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await mode_get_subject(
+            subject=SUBJECT,
+            user=None,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+# compatibility.py
+
+
+async def test_compatibility_post_denied_returns_404() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await compatibility_post(
+            subject=SUBJECT,
+            version="1",
+            schema_request=SchemaRequest(schema="{}"),
+            user=None,
+            authorizer=_denying_authorizer(),
+            controller=MagicMock(),
+        )
+    _assert_subject_not_found(exc_info)
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: the authZ resource must be the Subject:* form. Confirms we did
+# not accidentally swap a Config: site to subject_not_found().
+# ---------------------------------------------------------------------------
+
+
+async def test_subject_scoped_authz_uses_subject_resource_form() -> None:
+    authorizer = _denying_authorizer()
+    with pytest.raises(HTTPException):
+        await subjects_subject_versions_list(
+            subject=SUBJECT,
+            user=None,
+            deleted=False,
+            authorizer=authorizer,
+            controller=MagicMock(),
+        )
+    args, _kwargs = authorizer.check_authorization.call_args
+    user_arg, op_arg, resource_arg = args
+    assert op_arg == Operation.Read
+    assert resource_arg == f"Subject:{SUBJECT}"


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Issue : 
If a user is authenticated but not authorized to access a particular subject, they still can probe the subject names via endpoints such as POST /{subject}. This is happening because the the 403 Forbidden is returned. The correct error from the security point of view is 404 Not Found. This will prevent probing as the potential attacked won’t be able to tell the difference between non-existing subjects and subjects they aren’t allowed to see.

Fix : prevent subject-name probing by returning 404 instead of 403 --- BREAKING CHANGE

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
