### PR TITLE
OIDC JWT validation leeway, sub require, typ azp

### DIFF
--- a/.claude/skills/oidc-auth/SKILL.md
+++ b/.claude/skills/oidc-auth/SKILL.md
@@ -194,6 +194,9 @@ return http_authorizer if config.registry_authfile else no_auth_authorizer
 | `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT |
 | `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths |
+| `sasl_oauthbearer_leeway_seconds` | `30` | Clock-skew tolerance for `exp`/`nbf`/`iat` |
+| `sasl_oauthbearer_require_at_jwt_typ` | `False` | RFC 9068: require header `typ: at+jwt` (or `application/at+jwt`) |
+| `sasl_oauthbearer_enforce_azp` | `False` | Require `azp == client_id`; needs `client_id` |
 | `schema_registry_client_cache_maxsize` | `100` | LRU cap on `(subject, version, fp)` |
 | `registry_authfile` | `None` | Selects basic-auth `HTTPAuthorizer` |
 

--- a/.claude/skills/oidc-auth/SKILL.md
+++ b/.claude/skills/oidc-auth/SKILL.md
@@ -194,8 +194,8 @@ return http_authorizer if config.registry_authfile else no_auth_authorizer
 | `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT |
 | `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths |
-| `sasl_oauthbearer_leeway_seconds` | `30` | Clock-skew tolerance for `exp`/`nbf`/`iat` |
-| `sasl_oauthbearer_require_at_jwt_typ` | `False` | RFC 9068: require header `typ: at+jwt` (or `application/at+jwt`) |
+| `sasl_oauthbearer_leeway_seconds` | `0` | Clock-skew tolerance for `exp`/`nbf`/`iat` (must be >= 0) |
+| `sasl_oauthbearer_require_access_token_typ` | `False` | Require header `typ: at+jwt` (or `application/at+jwt`) |
 | `sasl_oauthbearer_enforce_azp` | `False` | Require `azp == client_id`; needs `client_id` |
 | `schema_registry_client_cache_maxsize` | `100` | LRU cap on `(subject, version, fp)` |
 | `registry_authfile` | `None` | Selects basic-auth `HTTPAuthorizer` |

--- a/README.rst
+++ b/README.rst
@@ -131,8 +131,8 @@ verified via JWKS). Authorization (role-based access) is opt-in on top of this w
 
 Optional hardening flags::
 
-   sasl_oauthbearer_leeway_seconds: int = 30          # clock-skew tolerance for exp/nbf/iat
-   sasl_oauthbearer_require_at_jwt_typ: bool = False  # RFC 9068: require typ "at+jwt" header
+   sasl_oauthbearer_leeway_seconds: int = 0           # clock-skew tolerance for exp/nbf/iat (must be >= 0)
+   sasl_oauthbearer_require_access_token_typ: bool = False  # require typ "at+jwt" header
    sasl_oauthbearer_enforce_azp: bool = False         # require azp claim == client_id
 
 ``sasl_oauthbearer_enforce_azp=true`` requires ``sasl_oauthbearer_client_id`` to be set;

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,18 @@ To enable oidc authentication on the karapace, configure oidc jwks url config de
    sasl_oauthbearer_sub_claim_name = "sub",
 
 When ``sasl_oauthbearer_authentication_enabled`` is true, every request must carry a valid
-Bearer token (the JWT signature, issuer and audience are verified via JWKS). Authorization
-(role-based access) is opt-in on top of this with ``sasl_oauthbearer_authorization_enabled``.
+Bearer token (the JWT signature, issuer, audience and the configured subject claim are
+verified via JWKS). Authorization (role-based access) is opt-in on top of this with
+``sasl_oauthbearer_authorization_enabled``.
+
+Optional hardening flags::
+
+   sasl_oauthbearer_leeway_seconds: int = 30          # clock-skew tolerance for exp/nbf/iat
+   sasl_oauthbearer_require_at_jwt_typ: bool = False  # RFC 9068: require typ "at+jwt" header
+   sasl_oauthbearer_enforce_azp: bool = False         # require azp claim == client_id
+
+``sasl_oauthbearer_enforce_azp=true`` requires ``sasl_oauthbearer_client_id`` to be set;
+startup fails otherwise.
 
 There is a detailed section about OAuth2 authentication for karapace below.
 

--- a/src/karapace/api/oidc/middleware.py
+++ b/src/karapace/api/oidc/middleware.py
@@ -36,7 +36,7 @@ class OIDCMiddleware:
         self.sasl_oauthbearer_method_roles: dict[str, list[str]] = config.sasl_oauthbearer_method_roles
         self.sasl_oauthbearer_roles_claim_path = config.sasl_oauthbearer_roles_claim_path
         self.leeway_seconds = config.sasl_oauthbearer_leeway_seconds
-        self.require_at_jwt_typ = config.sasl_oauthbearer_require_at_jwt_typ
+        self.require_access_token_typ = config.sasl_oauthbearer_require_access_token_typ
         self.enforce_azp = config.sasl_oauthbearer_enforce_azp
 
         # Hardcoded default algorithms
@@ -109,29 +109,9 @@ class OIDCMiddleware:
             raise AuthenticationError("OIDC not configured: audience missing")
 
         try:
-            if self.require_at_jwt_typ:
-                # Header is unverified, but only gates rejection; signature is still checked below.
-                header_typ = jwt.get_unverified_header(token).get("typ", "")
-                if header_typ.lower() not in ("at+jwt", "application/at+jwt"):
-                    raise InvalidTokenError(f"Invalid token type: expected at+jwt, got {header_typ!r}")
-
-            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
-            audiences = [aud.strip() for aud in self.audience.split(",") if aud.strip()]
-            require = ["exp", "iss", "aud"]
-            if self.claim_name and self.claim_name not in require:
-                require.append(self.claim_name)
-            payload = jwt.decode(
-                token,
-                signing_key.key,
-                algorithms=self.algorithms,
-                audience=audiences,
-                issuer=self.issuer,
-                leeway=self.leeway_seconds,
-                # PyJWT does not require these by default; enforce presence explicitly.
-                options={"require": require},
-            )
-            if self.enforce_azp and payload.get("azp") != self.client_id:
-                raise InvalidTokenError("azp claim does not match configured client_id")
+            self._check_at_jwt_typ(token)
+            payload = self._decode_and_verify(token)
+            self._check_azp(payload)
             return payload
         except ExpiredSignatureError:
             log.warning("JWT validation failed: token expired")
@@ -140,6 +120,38 @@ class OIDCMiddleware:
             # Log the reason for debugging; response body stays opaque.
             log.warning("JWT validation failed: %s", exc)
             raise AuthenticationError("Invalid OIDC token")
+
+    def _check_at_jwt_typ(self, token: str) -> None:
+        if not self.require_access_token_typ:
+            return
+        # Header is unverified, but only gates rejection; signature is still checked at decode.
+        header_typ = jwt.get_unverified_header(token).get("typ", "")
+        if header_typ.lower() not in ("at+jwt", "application/at+jwt"):
+            raise InvalidTokenError(f"Invalid token type: expected at+jwt, got {header_typ!r}")
+
+    def _decode_and_verify(self, token: str) -> dict:
+        assert self._jwks_client is not None and self.audience  # validated by validate_jwt
+        signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+        audiences = {aud.strip() for aud in self.audience.split(",") if aud.strip()}
+        require = {"exp", "iss", "aud"}
+        if self.claim_name:
+            require.add(self.claim_name)
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=self.algorithms,
+            audience=audiences,
+            issuer=self.issuer,
+            leeway=self.leeway_seconds,
+            # PyJWT does not require these by default; enforce presence explicitly.
+            options={"require": list(require)},
+        )
+
+    def _check_azp(self, payload: dict) -> None:
+        if not self.enforce_azp:
+            return
+        if payload.get("azp") != self.client_id:
+            raise InvalidTokenError("azp claim does not match configured client_id")
 
     def authorize_request(self, payload: dict, request_method: str) -> bool:
         if not self.authorization_enabled:

--- a/src/karapace/api/oidc/middleware.py
+++ b/src/karapace/api/oidc/middleware.py
@@ -104,24 +104,21 @@ class OIDCMiddleware:
     def validate_jwt(self, token: str) -> dict:
         if not self._jwks_client:
             raise AuthenticationError("OIDC not configured: JWKS client unavailable")
-        # Defense-in-depth: __init__ enforces audience when JWKS is set, but a misconfigured
-        # validator should fail closed rather than disable aud checks via audience=None.
+        # Fail closed if audience is somehow unset at decode time; __init__ already enforces it.
         if not self.audience:
             raise AuthenticationError("OIDC not configured: audience missing")
 
         try:
             if self.require_at_jwt_typ:
-                # RFC 9068: access tokens carry `typ: at+jwt`. Reject ID tokens or other
-                # JWT shapes being misused as access tokens. Header is unverified bytes,
-                # but it's only used to gate; the signature is still checked below.
+                # Header is unverified, but only gates rejection; signature is still checked below.
                 header_typ = jwt.get_unverified_header(token).get("typ", "")
-                if header_typ.lower() != "at+jwt":
+                if header_typ.lower() not in ("at+jwt", "application/at+jwt"):
                     raise InvalidTokenError(f"Invalid token type: expected at+jwt, got {header_typ!r}")
 
             signing_key = self._jwks_client.get_signing_key_from_jwt(token)
             audiences = [aud.strip() for aud in self.audience.split(",") if aud.strip()]
             require = ["exp", "iss", "aud"]
-            if self.claim_name:
+            if self.claim_name and self.claim_name not in require:
                 require.append(self.claim_name)
             payload = jwt.decode(
                 token,
@@ -130,20 +127,17 @@ class OIDCMiddleware:
                 audience=audiences,
                 issuer=self.issuer,
                 leeway=self.leeway_seconds,
-                # Require exp/iss/aud (and the configured subject claim) so a token missing
-                # any of these is rejected — PyJWT does not require them by default.
+                # PyJWT does not require these by default; enforce presence explicitly.
                 options={"require": require},
             )
             if self.enforce_azp and payload.get("azp") != self.client_id:
                 raise InvalidTokenError("azp claim does not match configured client_id")
             return payload
         except ExpiredSignatureError:
-            # Surface expiry distinctly so callers can return a clearer 401 reason
-            # and operators can debug clock-skew vs. real-auth failures.
             log.warning("JWT validation failed: token expired")
             raise TokenExpiredError("OIDC token expired")
         except InvalidTokenError as exc:
-            # Log the underlying reason for operator debugging; keep the response opaque.
+            # Log the reason for debugging; response body stays opaque.
             log.warning("JWT validation failed: %s", exc)
             raise AuthenticationError("Invalid OIDC token")
 

--- a/src/karapace/api/oidc/middleware.py
+++ b/src/karapace/api/oidc/middleware.py
@@ -35,6 +35,9 @@ class OIDCMiddleware:
         self.client_id = config.sasl_oauthbearer_client_id
         self.sasl_oauthbearer_method_roles: dict[str, list[str]] = config.sasl_oauthbearer_method_roles
         self.sasl_oauthbearer_roles_claim_path = config.sasl_oauthbearer_roles_claim_path
+        self.leeway_seconds = config.sasl_oauthbearer_leeway_seconds
+        self.require_at_jwt_typ = config.sasl_oauthbearer_require_at_jwt_typ
+        self.enforce_azp = config.sasl_oauthbearer_enforce_azp
 
         # Hardcoded default algorithms
         self.algorithms = ["RS256", "RS384", "RS512"]
@@ -57,6 +60,8 @@ class OIDCMiddleware:
                 raise ValueError(
                     "OIDC config error: 'issuer' and 'audience' must be set if 'jwks_endpoint_url' is provided."
                 )
+            if self.enforce_azp and not self.client_id:
+                raise ValueError("OIDC config error: client_id is required when sasl_oauthbearer_enforce_azp is enabled.")
             log.info(
                 "OIDC middleware initialized — Bearer token validation enabled. " "jwks_url=%s issuer=%s audience=%s",
                 self.jwks_url,
@@ -99,32 +104,47 @@ class OIDCMiddleware:
     def validate_jwt(self, token: str) -> dict:
         if not self._jwks_client:
             raise AuthenticationError("OIDC not configured: JWKS client unavailable")
+        # Defense-in-depth: __init__ enforces audience when JWKS is set, but a misconfigured
+        # validator should fail closed rather than disable aud checks via audience=None.
+        if not self.audience:
+            raise AuthenticationError("OIDC not configured: audience missing")
 
         try:
+            if self.require_at_jwt_typ:
+                # RFC 9068: access tokens carry `typ: at+jwt`. Reject ID tokens or other
+                # JWT shapes being misused as access tokens. Header is unverified bytes,
+                # but it's only used to gate; the signature is still checked below.
+                header_typ = jwt.get_unverified_header(token).get("typ", "")
+                if header_typ.lower() != "at+jwt":
+                    raise InvalidTokenError(f"Invalid token type: expected at+jwt, got {header_typ!r}")
+
             signing_key = self._jwks_client.get_signing_key_from_jwt(token)
-            # Split the comma-separated audience string into a list and strip whitespace
-            if self.audience:
-                audiences = [aud.strip() for aud in self.audience.split(",") if aud.strip()]
-            else:
-                audiences = None  # or leave it out
+            audiences = [aud.strip() for aud in self.audience.split(",") if aud.strip()]
+            require = ["exp", "iss", "aud"]
+            if self.claim_name:
+                require.append(self.claim_name)
             payload = jwt.decode(
                 token,
                 signing_key.key,
                 algorithms=self.algorithms,
                 audience=audiences,
                 issuer=self.issuer,
-                # Require exp/iss/aud so a token missing any of these is rejected,
-                # not silently accepted (PyJWT does not require them by default).
-                options={"require": ["exp", "iss", "aud"]},
+                leeway=self.leeway_seconds,
+                # Require exp/iss/aud (and the configured subject claim) so a token missing
+                # any of these is rejected — PyJWT does not require them by default.
+                options={"require": require},
             )
+            if self.enforce_azp and payload.get("azp") != self.client_id:
+                raise InvalidTokenError("azp claim does not match configured client_id")
             return payload
         except ExpiredSignatureError:
             # Surface expiry distinctly so callers can return a clearer 401 reason
             # and operators can debug clock-skew vs. real-auth failures.
             log.warning("JWT validation failed: token expired")
             raise TokenExpiredError("OIDC token expired")
-        except InvalidTokenError:
-            log.error("JWT validation failed")
+        except InvalidTokenError as exc:
+            # Log the underlying reason for operator debugging; keep the response opaque.
+            log.warning("JWT validation failed: %s", exc)
             raise AuthenticationError("Invalid OIDC token")
 
     def authorize_request(self, payload: dict, request_method: str) -> bool:

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -147,6 +147,15 @@ class Config(BaseSettings):
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics"]
+    # Clock-skew tolerance for exp/nbf/iat (seconds). Small drift between IdP and Karapace
+    # is normal; default 30s prevents spurious 401s without meaningfully extending token life.
+    sasl_oauthbearer_leeway_seconds: int = 30
+    # RFC 9068: require access tokens to carry header `typ: at+jwt`. Off by default since
+    # not all IdPs emit it. Turning this on rejects ID tokens being misused as access tokens.
+    sasl_oauthbearer_require_at_jwt_typ: bool = False
+    # OIDC `azp` (authorized party) binding: enforce that the token was issued for this
+    # client_id. Recommended when the IdP issues multi-audience tokens. Requires client_id.
+    sasl_oauthbearer_enforce_azp: bool = False
     # LRU cap on (subject, version, token_fingerprint) in the SR client. Raise for multi-tenant.
     schema_registry_client_cache_maxsize: int = 100
     # Kafka SASL client credentials (used by both services; selected by sasl_mechanism).

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -15,7 +15,7 @@ from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRO
 from karapace.core.typing import ElectionStrategy, NameStrategy
 from karapace.core.utils import json_encode
 from pathlib import Path
-from pydantic import BaseModel, ImportString, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, Field, ImportString, PrivateAttr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 import enum
@@ -147,10 +147,10 @@ class Config(BaseSettings):
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics"]
-    # Clock-skew tolerance for exp/nbf/iat (seconds).
-    sasl_oauthbearer_leeway_seconds: int = 30
-    # RFC 9068: require header `typ: at+jwt` on access tokens.
-    sasl_oauthbearer_require_at_jwt_typ: bool = False
+    # Clock-skew tolerance for exp/nbf/iat (seconds). 0 preserves prior strict behavior.
+    sasl_oauthbearer_leeway_seconds: int = Field(default=0, ge=0)
+    # Require header `typ: at+jwt` on access tokens.
+    sasl_oauthbearer_require_access_token_typ: bool = False
     # Enforce `azp == client_id`. Requires client_id.
     sasl_oauthbearer_enforce_azp: bool = False
     # LRU cap on (subject, version, token_fingerprint) in the SR client. Raise for multi-tenant.

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -147,14 +147,11 @@ class Config(BaseSettings):
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics"]
-    # Clock-skew tolerance for exp/nbf/iat (seconds). Small drift between IdP and Karapace
-    # is normal; default 30s prevents spurious 401s without meaningfully extending token life.
+    # Clock-skew tolerance for exp/nbf/iat (seconds).
     sasl_oauthbearer_leeway_seconds: int = 30
-    # RFC 9068: require access tokens to carry header `typ: at+jwt`. Off by default since
-    # not all IdPs emit it. Turning this on rejects ID tokens being misused as access tokens.
+    # RFC 9068: require header `typ: at+jwt` on access tokens.
     sasl_oauthbearer_require_at_jwt_typ: bool = False
-    # OIDC `azp` (authorized party) binding: enforce that the token was issued for this
-    # client_id. Recommended when the IdP issues multi-audience tokens. Requires client_id.
+    # Enforce `azp == client_id`. Requires client_id.
     sasl_oauthbearer_enforce_azp: bool = False
     # LRU cap on (subject, version, token_fingerprint) in the SR client. Raise for multi-tenant.
     schema_registry_client_cache_maxsize: int = 100
@@ -233,6 +230,17 @@ class Config(BaseSettings):
                 "Auto-enabling authentication for backwards compatibility."
             )
             self.sasl_oauthbearer_authentication_enabled = True
+        return self
+
+    @model_validator(mode="after")
+    def _enforce_azp_requires_client_id(self) -> Config:
+        # Catch misconfig at config-parse time, not just middleware construction.
+        # OIDCMiddleware also enforces this defensively for the case where Config is built
+        # directly (e.g. tests) bypassing this validator's failure path.
+        if self.sasl_oauthbearer_enforce_azp and not self.sasl_oauthbearer_client_id:
+            raise ValueError(
+                "OIDC config error: sasl_oauthbearer_client_id is required when " "sasl_oauthbearer_enforce_azp is enabled."
+            )
         return self
 
     def get_rest_base_uri(self) -> str:

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -686,7 +686,51 @@ def test_validate_jwt_azp_check_skipped_when_flag_off(mock_jwt_decode, mock_pyjw
     assert middleware.validate_jwt("good.jwt.token")["azp"] == "anything-goes"
 
 
+def test_config_rejects_enforce_azp_without_client_id():
+    """Config-level validator catches the misconfig at parse time (before middleware construction)."""
+    with pytest.raises(ValueError, match="client_id is required"):
+        _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_enforce_azp=True)
+
+
 def test_oidc_middleware_requires_client_id_when_azp_enforced():
-    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_enforce_azp=True)
+    """Middleware-level guard: catches the misconfig when Config is constructed bypassing the
+    Pydantic validator (e.g. by mutating fields directly, as tests can do)."""
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
+        sasl_oauthbearer_enforce_azp=True,
+        sasl_oauthbearer_client_id="client-id",
+    )
+    config.sasl_oauthbearer_client_id = None  # bypass Pydantic validator
     with pytest.raises(ValueError, match="client_id is required"):
         OIDCMiddleware(app=MagicMock(), config=config)
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_default_leeway_is_30(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware.validate_jwt("good.jwt.token")
+
+    assert mock_jwt_decode.call_args.kwargs["leeway"] == 30
+
+
+@pytest.mark.parametrize("typ_value", ["AT+JWT", "at+jwt", "application/at+jwt", "Application/AT+JWT"])
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_at_jwt_typ_accepts_case_insensitive_and_long_form(
+    mock_jwt_decode, mock_unverified_header, mock_pyjwks_client, typ_value
+):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_unverified_header.return_value = {"typ": typ_value}
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -43,7 +43,7 @@ class DummyConfig:
         default_factory=lambda: {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     )
     sasl_oauthbearer_leeway_seconds: int = 30
-    sasl_oauthbearer_require_at_jwt_typ: bool = False
+    sasl_oauthbearer_require_access_token_typ: bool = False
     sasl_oauthbearer_enforce_azp: bool = False
 
 
@@ -606,7 +606,7 @@ def test_validate_jwt_at_jwt_typ_enforced_accepts(mock_jwt_decode, mock_unverifi
     mock_unverified_header.return_value = {"typ": "at+jwt"}
     mock_jwt_decode.return_value = {"sub": "u"}
 
-    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
     assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}
 
@@ -620,7 +620,7 @@ def test_validate_jwt_at_jwt_typ_enforced_rejects_id_token(mock_jwt_decode, mock
     mock_unverified_header.return_value = {"typ": "JWT"}
     mock_jwt_decode.return_value = {"sub": "u"}
 
-    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
     with pytest.raises(AuthenticationError, match="Invalid OIDC token"):
         middleware.validate_jwt("idtoken.jwt.token")
@@ -707,7 +707,8 @@ def test_oidc_middleware_requires_client_id_when_azp_enforced():
 
 @patch("karapace.api.oidc.middleware.PyJWKClient")
 @patch("karapace.api.oidc.middleware.jwt.decode")
-def test_validate_jwt_default_leeway_is_30(mock_jwt_decode, mock_pyjwks_client):
+def test_validate_jwt_default_leeway_is_zero(mock_jwt_decode, mock_pyjwks_client):
+    """Default leeway is 0 — preserves prior strict behavior. Operators opt into skew tolerance."""
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.return_value = {"sub": "u"}
@@ -716,7 +717,15 @@ def test_validate_jwt_default_leeway_is_30(mock_jwt_decode, mock_pyjwks_client):
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
     middleware.validate_jwt("good.jwt.token")
 
-    assert mock_jwt_decode.call_args.kwargs["leeway"] == 30
+    assert mock_jwt_decode.call_args.kwargs["leeway"] == 0
+
+
+def test_config_rejects_negative_leeway():
+    """Pydantic Field(ge=0) rejects negative values at config-parse time."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Config(sasl_oauthbearer_leeway_seconds=-1)
 
 
 @pytest.mark.parametrize("typ_value", ["AT+JWT", "at+jwt", "application/at+jwt", "Application/AT+JWT"])
@@ -731,6 +740,6 @@ def test_validate_jwt_at_jwt_typ_accepts_case_insensitive_and_long_form(
     mock_unverified_header.return_value = {"typ": typ_value}
     mock_jwt_decode.return_value = {"sub": "u"}
 
-    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
     assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -42,6 +42,9 @@ class DummyConfig:
     sasl_oauthbearer_method_roles: dict[str, list[str]] = field(
         default_factory=lambda: {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     )
+    sasl_oauthbearer_leeway_seconds: int = 30
+    sasl_oauthbearer_require_at_jwt_typ: bool = False
+    sasl_oauthbearer_enforce_azp: bool = False
 
 
 valid_configs = [
@@ -526,3 +529,164 @@ def test_middleware_invalid_token_still_returns_invalid_reason(monkeypatch):
     r = client.get("/subjects", headers={"Authorization": "Bearer bogus.token"})
     assert r.status_code == 401
     assert r.json()["reason"] == "Invalid token/payload"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: leeway, require sub, log reason, audience guard, typ:at+jwt, azp.
+# ---------------------------------------------------------------------------
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_passes_leeway_and_require_sub_to_decode(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_leeway_seconds=42)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware.validate_jwt("good.jwt.token")
+
+    kwargs = mock_jwt_decode.call_args.kwargs
+    assert kwargs["leeway"] == 42
+    assert "sub" in kwargs["options"]["require"]
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_require_uses_configured_sub_claim(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"user_id": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_sub_claim_name="user_id")
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware.validate_jwt("good.jwt.token")
+
+    require = mock_jwt_decode.call_args.kwargs["options"]["require"]
+    assert "user_id" in require
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_logs_reason_on_invalid_token(mock_jwt_decode, mock_pyjwks_client, caplog):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.side_effect = InvalidTokenError("missing required claim sub")
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+
+    with caplog.at_level(logging.WARNING, logger="karapace.api.oidc.middleware"):
+        with pytest.raises(AuthenticationError):
+            middleware.validate_jwt("bad.jwt.token")
+
+    assert any("missing required claim sub" in rec.message for rec in caplog.records)
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+def test_validate_jwt_audience_missing_raises(mock_pyjwks_client):
+    """Defense-in-depth: if audience is somehow None at decode time, fail closed."""
+    mock_pyjwks_client.return_value = MagicMock()
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware.audience = None  # bypass __init__ guard
+
+    with pytest.raises(AuthenticationError, match="audience missing"):
+        middleware.validate_jwt("any.jwt.token")
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_at_jwt_typ_enforced_accepts(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_unverified_header.return_value = {"typ": "at+jwt"}
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_at_jwt_typ_enforced_rejects_id_token(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_unverified_header.return_value = {"typ": "JWT"}
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_at_jwt_typ=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    with pytest.raises(AuthenticationError, match="Invalid OIDC token"):
+        middleware.validate_jwt("idtoken.jwt.token")
+    mock_jwt_decode.assert_not_called()
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_typ_check_skipped_when_flag_off(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware.validate_jwt("good.jwt.token")
+    mock_unverified_header.assert_not_called()
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_azp_enforced_accepts(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u", "azp": "client-id"}
+
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
+        sasl_oauthbearer_enforce_azp=True,
+        sasl_oauthbearer_client_id="client-id",
+    )
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    assert middleware.validate_jwt("good.jwt.token")["azp"] == "client-id"
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_azp_enforced_rejects_mismatch(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u", "azp": "other-client"}
+
+    config = _oidc_config(
+        sasl_oauthbearer_authentication_enabled=True,
+        sasl_oauthbearer_enforce_azp=True,
+        sasl_oauthbearer_client_id="client-id",
+    )
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    with pytest.raises(AuthenticationError, match="Invalid OIDC token"):
+        middleware.validate_jwt("good.jwt.token")
+
+
+@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.middleware.jwt.decode")
+def test_validate_jwt_azp_check_skipped_when_flag_off(mock_jwt_decode, mock_pyjwks_client):
+    mock_pyjwks_client.return_value = MagicMock()
+    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
+    mock_jwt_decode.return_value = {"sub": "u", "azp": "anything-goes"}
+
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_client_id="client-id")
+    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    assert middleware.validate_jwt("good.jwt.token")["azp"] == "anything-goes"
+
+
+def test_oidc_middleware_requires_client_id_when_azp_enforced():
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_enforce_azp=True)
+    with pytest.raises(ValueError, match="client_id is required"):
+        OIDCMiddleware(app=MagicMock(), config=config)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

3 new configs
```
sasl_oauthbearer_leeway_seconds
sasl_oauthbearer_require_at_jwt_typ
sasl_oauthbearer_enforce_azp
```

- Add `leeway` for clock skew (default 30s, configurable via sasl_oauthbearer_leeway_seconds) so minor IdP/Karapace drift no longer produces spurious 401s.
- Require the configured subject claim (default `sub`) in PyJWT's `require` list. Tokens missing the subject are now rejected with 401 rather than silently producing `request.state.user = None`.
- Drop the `audiences=None` fallback in validate_jwt; raise AuthenticationError("audience missing") as defense-in-depth alongside the existing __init__ guard.
- Surface the underlying InvalidTokenError detail in logs (`log.warning("JWT validation failed: %s", exc)`) so operators can debug misconfigurations. The 401 response body stays opaque.
- Add opt-in `sasl_oauthbearer_require_at_jwt_typ` (RFC 9068): rejects ID tokens being used as access tokens by checking `typ: at+jwt` on the unverified header before signature validation.
- Add opt-in `sasl_oauthbearer_enforce_azp`: enforces `azp == client_id` for OIDC authorized-party binding. Fail-closed at startup if enabled without client_id.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
