### PR TITLE
CI jobs for test suite run in parallel with fail-fast false

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.12', '3.13', '3.14' ]
     steps:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Currently if one Test suite for 3.12 fails for some reason, the remaining jobs 3.13 and 3.14 fail. This could be due to flaky tests or for a valid reason they might fail.
I would like change this behaviour and set the fail-fast to False. This will continue with the rest of the jobs.
With this change - if there is a valid reason for failure, all 3 will fail. If there is a flaky test, one might fail and others can continue.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
