### PR TITLE
Fix 500 when registering protobuf schema with non-ASCII characters

### DIFF
--- a/src/karapace/core/protobuf/schema.py
+++ b/src/karapace/core/protobuf/schema.py
@@ -28,8 +28,6 @@ from karapace.core.protobuf.type_tree import SourceFileReference, TypeTree
 from karapace.core.protobuf.utils import append_documentation, append_indented
 from karapace.core.schema_references import Reference
 
-import binascii
-
 
 def add_slashes(text: str) -> str:
     escape_dict = {
@@ -184,7 +182,8 @@ class ProtobufSchema:
         else:
             try:
                 self.proto_file_element = deserialize(schema)
-            except binascii.Error:  # If not base64 formatted
+            # binascii.Error (bad b64) and plain ValueError (non-ASCII) both mean "not base64"; DecodeError propagates
+            except ValueError:
                 self.proto_file_element = ProtoParser.parse(DEFAULT_LOCATION, schema)
 
         self.references = references

--- a/tests/unit/protobuf/test_protobuf_schema.py
+++ b/tests/unit/protobuf/test_protobuf_schema.py
@@ -28,6 +28,22 @@ def test_protobuf_schema_simple():
     assert result == proto
 
 
+def test_protobuf_schema_non_ascii_comment():
+    proto = """\
+syntax = "proto3";
+
+// Пользователь
+message User {
+  string name = 1;
+  int32 age = 2;
+}
+"""
+    protobuf_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto)
+    result = str(protobuf_schema)
+
+    assert result == proto
+
+
 def test_protobuf_schema_sort():
     proto = trim_margin(schema_protobuf_order_before)
     protobuf_schema = ValidatedTypedSchema.parse(SchemaType.PROTOBUF, proto)


### PR DESCRIPTION
# About this change - What it does

Registering a protobuf schema containing non-ASCII characters (for example Cyrillic comments) returned a 500 instead of registering the schema.

`ProtobufSchema.__init__` tries `deserialize()` first, treating the input as a base64-encoded `FileDescriptorProto`, and falls back to the text parser on failure. It only caught `binascii.Error`, but `base64.b64decode` raises a plain `ValueError` ("string argument should contain only ASCII characters") for non-ASCII input, so the schema never reached the text parser and the `ValueError` propagated as a 500.

This broadens the `except` to `ValueError` so non-ASCII input falls through to `ProtoParser.parse`, and adds a unit test covering a schema with a non-ASCII comment.

References: #1171

# Why this way

`binascii.Error` is a subclass of `ValueError`, so malformed base64 is still handled by the same branch. Protobuf `DecodeError` is not a `ValueError`, so a valid base64 descriptor that fails to parse still propagates as before rather than being silently routed to the text parser. A short comment on the `except` records this so the catch is not narrowed back.