### PR TITLE
fix(protobuf): preserve map_entry through binary deserialize/serialize and restore map<K,V> shorthand on normalisation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -817,7 +817,12 @@ Karapace uses a schema normalization algorithm to ensure that the schema is stor
 This normalization process is done so that schemas semantically equivalent are stored in the same way and should be considered equal.
 
 Normalization is currently only supported for Protobuf schemas. Karapace does not support all normalization features implemented by Confluent Schema Registry.
-Currently the normalization process is done only for the ordering of the optional fields in the schema.
+Currently the normalization process covers:
+
+- Ordering of optional fields in the schema.
+- Restoration of map field shorthand: binary-registered schemas that contain the expanded entry-message
+  form (a ``repeated`` field pointing to a synthetic nested message with ``option map_entry = true``)
+  are converted back to ``map<K, V>`` syntax, matching Confluent Schema Registry behaviour.
 Use the feature with the assumption that it will be extended in the future and so two schemas that are semantically equivalent could be considered
 different by the normalization process in different future versions of Karapace.
 The safe choice, when using a normalization process, is always to consider as different two schemas that are semantically equivalent while the problem is when two semantically different schemas are considered equivalent.

--- a/README.rst
+++ b/README.rst
@@ -823,6 +823,7 @@ Currently the normalization process covers:
 - Restoration of map field shorthand: binary-registered schemas that contain the expanded entry-message
   form (a ``repeated`` field pointing to a synthetic nested message with ``option map_entry = true``)
   are converted back to ``map<K, V>`` syntax, matching Confluent Schema Registry behaviour.
+
 Use the feature with the assumption that it will be extended in the future and so two schemas that are semantically equivalent could be considered
 different by the normalization process in different future versions of Karapace.
 The safe choice, when using a normalization process, is always to consider as different two schemas that are semantically equivalent while the problem is when two semantically different schemas are considered equivalent.

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 from karapace.core.protobuf.enum_constant_element import EnumConstantElement
 from karapace.core.protobuf.enum_element import EnumElement
 from karapace.core.protobuf.extend_element import ExtendElement
+from karapace.core.protobuf.field import Field
 from karapace.core.protobuf.field_element import FieldElement
 from karapace.core.protobuf.group_element import GroupElement
 from karapace.core.protobuf.known_dependency import KnownDependency
@@ -27,6 +28,60 @@ import abc
 
 def sort_by_name(element: OptionElement) -> str:
     return element.name
+
+
+def _is_map_entry(message: MessageElement) -> bool:
+    """Return True if this message has option map_entry = true."""
+    return any(opt.name == "map_entry" and (opt.value is True or opt.value == "true") for opt in message.options)
+
+
+def _restore_map_shorthand(
+    message_element: MessageElement,
+) -> tuple[list[FieldElement], list[TypeElement]]:
+    """Convert binary-deserialized map fields back to map<K,V> shorthand syntax during normalisation.
+
+    A binary FileDescriptorProto expands map<K,V> into a synthetic nested entry
+    message (with option map_entry = true) plus a repeated field pointing to it.
+    This function replaces the repeated field with a map<K,V> field and removes the
+    synthetic entry message, matching Confluent SR's ?normalize=true behaviour.
+    """
+    entry_messages: dict[str, MessageElement] = {
+        nt.name: nt
+        for nt in message_element.nested_types
+        if isinstance(nt, MessageElement) and _is_map_entry(nt)
+    }
+    if not entry_messages:
+        return list(message_element.fields), list(message_element.nested_types)
+
+    new_fields: list[FieldElement] = []
+    for field in message_element.fields:
+        entry_name = field.element_type.split(".")[-1]
+        entry = entry_messages.get(entry_name)
+        if entry is not None and field.label == Field.Label.REPEATED:
+            entry_fields = {f.name: f for f in entry.fields}
+            key_field = entry_fields.get("key")
+            value_field = entry_fields.get("value")
+            if key_field is not None and value_field is not None:
+                new_fields.append(
+                    NormalizedFieldElement(
+                        location=field.location,
+                        label=None,  # map fields carry no label in .proto syntax
+                        element_type=f"map<{key_field.element_type}, {value_field.element_type}>",
+                        name=field.name,
+                        default_value=field.default_value,
+                        json_name=field.json_name,
+                        tag=field.tag,
+                        documentation=field.documentation,
+                        options=field.options,
+                    )
+                )
+                continue
+        new_fields.append(field)
+
+    new_nested_types: list[TypeElement] = [
+        nt for nt in message_element.nested_types if not (isinstance(nt, MessageElement) and nt.name in entry_messages)
+    ]
+    return new_fields, new_nested_types
 
 
 class NormalizedRpcElement(RpcElement):
@@ -178,10 +233,13 @@ def message_element_with_sorted_options(
     message_element: MessageElement, package: str, type_tree: TypeTree
 ) -> NormalizedMessageElement:
     sorted_options = None if message_element.options is None else list(sorted(message_element.options, key=sort_by_name))
+
+    shorthand_fields, shorthand_nested_types = _restore_map_shorthand(message_element)
+
     sorted_nested_types = [
-        type_element_with_sorted_options(nested_type, package, type_tree) for nested_type in message_element.nested_types
+        type_element_with_sorted_options(nested_type, package, type_tree) for nested_type in shorthand_nested_types
     ]
-    sorted_fields = [normalize_type_field_element(field, package, type_tree) for field in message_element.fields]
+    sorted_fields = [normalize_type_field_element(field, package, type_tree) for field in shorthand_fields]
     sorted_one_ofs = [one_ofs_with_sorted_options(one_of, package, type_tree) for one_of in message_element.one_ofs]
 
     return NormalizedMessageElement(

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -51,14 +51,9 @@ def _restore_map_shorthand(
     if not entry_messages:
         return list(message_element.fields), list(message_element.nested_types)
 
-    # Track entry messages that were actually collapsed into map<K,V> fields.
-    # Only these are safe to remove from nested_types — removing an entry message
-    # whose field was not rewritten would leave a dangling type reference.
     collapsed_entry_names: set[str] = set()
     new_fields: list[FieldElement] = []
     for field in message_element.fields:
-        # Match on the full type path suffix, not just the last segment, to avoid
-        # false matches when two entry messages in different scopes share a simple name.
         matched_name = next(
             (name for name in entry_messages if field.element_type == name or field.element_type.endswith(f".{name}")),
             None,

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -51,10 +51,19 @@ def _restore_map_shorthand(
     if not entry_messages:
         return list(message_element.fields), list(message_element.nested_types)
 
+    # Track entry messages that were actually collapsed into map<K,V> fields.
+    # Only these are safe to remove from nested_types — removing an entry message
+    # whose field was not rewritten would leave a dangling type reference.
+    collapsed_entry_names: set[str] = set()
     new_fields: list[FieldElement] = []
     for field in message_element.fields:
-        entry_name = field.element_type.split(".")[-1]
-        entry = entry_messages.get(entry_name)
+        # Match on the full type path suffix, not just the last segment, to avoid
+        # false matches when two entry messages in different scopes share a simple name.
+        matched_name = next(
+            (name for name in entry_messages if field.element_type == name or field.element_type.endswith(f".{name}")),
+            None,
+        )
+        entry = entry_messages.get(matched_name) if matched_name else None
         if entry is not None and field.label == Field.Label.REPEATED:
             entry_fields = {f.name: f for f in entry.fields}
             key_field = entry_fields.get("key")
@@ -73,11 +82,14 @@ def _restore_map_shorthand(
                         options=field.options,
                     )
                 )
+                collapsed_entry_names.add(matched_name)
                 continue
         new_fields.append(field)
 
     new_nested_types: list[TypeElement] = [
-        nt for nt in message_element.nested_types if not (isinstance(nt, MessageElement) and nt.name in entry_messages)
+        nt
+        for nt in message_element.nested_types
+        if not (isinstance(nt, MessageElement) and nt.name in collapsed_entry_names)
     ]
     return new_fields, new_nested_types
 

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -46,9 +46,7 @@ def _restore_map_shorthand(
     synthetic entry message, matching Confluent SR's ?normalize=true behaviour.
     """
     entry_messages: dict[str, MessageElement] = {
-        nt.name: nt
-        for nt in message_element.nested_types
-        if isinstance(nt, MessageElement) and _is_map_entry(nt)
+        nt.name: nt for nt in message_element.nested_types if isinstance(nt, MessageElement) and _is_map_entry(nt)
     }
     if not entry_messages:
         return list(message_element.fields), list(message_element.nested_types)

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -37,6 +37,7 @@ def _is_map_entry(message: MessageElement) -> bool:
 
 def _restore_map_shorthand(
     message_element: MessageElement,
+    qualified_name: str,
 ) -> tuple[list[FieldElement], list[TypeElement]]:
     """Convert binary-deserialized map fields back to map<K,V> shorthand syntax during normalisation.
 
@@ -53,9 +54,19 @@ def _restore_map_shorthand(
 
     collapsed_entry_names: set[str] = set()
     new_fields: list[FieldElement] = []
+    # Pre-compute both the dotted and dot-free qualified prefix to match element_type
+    # values regardless of whether they carry a leading dot.
+    _qn_dot = qualified_name
+    _qn_no_dot = qualified_name.lstrip(".")
     for field in message_element.fields:
         matched_name = next(
-            (name for name in entry_messages if field.element_type == name or field.element_type.endswith(f".{name}")),
+            (
+                name
+                for name in entry_messages
+                if field.element_type == name
+                or field.element_type == f"{_qn_dot}.{name}"
+                or field.element_type == f"{_qn_no_dot}.{name}"
+            ),
             None,
         )
         entry = entry_messages.get(matched_name) if matched_name else None
@@ -235,14 +246,15 @@ def one_ofs_with_sorted_options(one_ofs: OneOfElement, package: str, type_tree: 
 
 
 def message_element_with_sorted_options(
-    message_element: MessageElement, package: str, type_tree: TypeTree
+    message_element: MessageElement, package: str, type_tree: TypeTree, qualified_name: str
 ) -> NormalizedMessageElement:
     sorted_options = None if message_element.options is None else list(sorted(message_element.options, key=sort_by_name))
 
-    shorthand_fields, shorthand_nested_types = _restore_map_shorthand(message_element)
+    shorthand_fields, shorthand_nested_types = _restore_map_shorthand(message_element, qualified_name)
 
     sorted_nested_types = [
-        type_element_with_sorted_options(nested_type, package, type_tree) for nested_type in shorthand_nested_types
+        type_element_with_sorted_options(nested_type, package, type_tree, f"{qualified_name}.{nested_type.name}")
+        for nested_type in shorthand_nested_types
     ]
     sorted_fields = [normalize_type_field_element(field, package, type_tree) for field in shorthand_fields]
     sorted_one_ofs = [one_ofs_with_sorted_options(one_of, package, type_tree) for one_of in message_element.one_ofs]
@@ -261,14 +273,19 @@ def message_element_with_sorted_options(
     )
 
 
-def type_element_with_sorted_options(type_element: TypeElement, package: str, type_tree: TypeTree) -> NormalizedTypeElement:
+def type_element_with_sorted_options(
+    type_element: TypeElement, package: str, type_tree: TypeTree, qualified_name: str
+) -> NormalizedTypeElement:
     sorted_nested_types: list[TypeElement] = []
 
     for nested_type in type_element.nested_types:
+        nested_qualified = f"{qualified_name}.{nested_type.name}"
         if isinstance(nested_type, EnumElement):
             sorted_nested_types.append(enum_element_with_sorted_options(nested_type))
         elif isinstance(nested_type, MessageElement):
-            sorted_nested_types.append(message_element_with_sorted_options(nested_type, package, type_tree))
+            sorted_nested_types.append(
+                message_element_with_sorted_options(nested_type, package, type_tree, nested_qualified)
+            )
         else:
             raise ValueError(f"Unknown type element {type(nested_type)}")  # tried with assert_never but it did not work
 
@@ -279,7 +296,7 @@ def type_element_with_sorted_options(type_element: TypeElement, package: str, ty
         return enum_element_with_sorted_options(type_element)
 
     if isinstance(type_element, MessageElement):
-        return message_element_with_sorted_options(type_element, package, type_tree)
+        return message_element_with_sorted_options(type_element, package, type_tree, qualified_name)
 
     raise ValueError(f"Unknown type element of type {type(type_element)}")  # tried with assert_never but it did not work
 
@@ -334,7 +351,13 @@ def normalize(protobuf_schema: ProtobufSchema) -> NormalizedProtobufSchema:
     type_tree = protobuf_schema.types_tree()
     package = proto_file_element.package_name or ""
     sorted_types: Sequence[NormalizedTypeElement] = [
-        type_element_with_sorted_options(type_element, package, type_tree) for type_element in proto_file_element.types
+        type_element_with_sorted_options(
+            type_element,
+            package,
+            type_tree,
+            f".{package}.{type_element.name}" if package else f".{type_element.name}",
+        )
+        for type_element in proto_file_element.types
     ]
     sorted_options = list(sorted(proto_file_element.options, key=sort_by_name))
     sorted_services: Sequence[NormalizedServiceElement] = [

--- a/src/karapace/core/protobuf/proto_normalizations.py
+++ b/src/karapace/core/protobuf/proto_normalizations.py
@@ -70,7 +70,7 @@ def _restore_map_shorthand(
             None,
         )
         entry = entry_messages.get(matched_name) if matched_name else None
-        if entry is not None and field.label == Field.Label.REPEATED:
+        if matched_name is not None and entry is not None and field.label == Field.Label.REPEATED:
             entry_fields = {f.name: f for f in entry.fields}
             key_field = entry_fields.get("key")
             value_field = entry_fields.get("value")

--- a/src/karapace/core/protobuf/serialization.py
+++ b/src/karapace/core/protobuf/serialization.py
@@ -74,6 +74,15 @@ def _deserialize_enum(enumtype: Any) -> EnumElement:
     return EnumElement(DEFAULT_LOCATION, enumtype.name, "", None, constants)
 
 
+def _deserialize_message_options(options: Any) -> list[OptionElement]:
+    result: list[OptionElement] = []
+    if options.HasField("map_entry") and options.map_entry:
+        result.append(OptionElement("map_entry", OptionElement.Kind.BOOLEAN, True))
+    if options.HasField("deprecated") and options.deprecated:
+        result.append(OptionElement("deprecated", OptionElement.Kind.BOOLEAN, True))
+    return result
+
+
 def _deserialize_msg(msgtype: Any) -> MessageElement:
     reserved_values: list[str | int | KotlinRange] = []
     reserveds: list[ReservedElement] = []
@@ -112,6 +121,7 @@ def _deserialize_msg(msgtype: Any) -> MessageElement:
             fields.append(sf)
 
     one_ofs_filtered: list[OneOfElement] = [oneof for oneof in one_ofs if oneof is not None]
+    message_options = _deserialize_message_options(msgtype.options)
     return MessageElement(
         DEFAULT_LOCATION,
         msgtype.name,
@@ -119,6 +129,7 @@ def _deserialize_msg(msgtype: Any) -> MessageElement:
         reserveds=reserveds,
         fields=fields,
         one_ofs=one_ofs_filtered,
+        options=message_options or None,
     )
 
 
@@ -280,6 +291,11 @@ def _serialize_msgtype(t: MessageElement) -> google.protobuf.descriptor_pb2.Desc
             sf = _serialize_field(field)
             sf.oneof_index = oneof_index
             d.field.append(sf)
+    for opt in t.options:
+        if opt.name == "map_entry":
+            d.options.map_entry = opt.value is True or opt.value == "true"
+        elif opt.name == "deprecated":
+            d.options.deprecated = opt.value is True or opt.value == "true"
     return d
 
 

--- a/tests/unit/protobuf/test_protobuf_normalization.py
+++ b/tests/unit/protobuf/test_protobuf_normalization.py
@@ -1064,3 +1064,126 @@ def test_full_path_and_simple_names_are_not_equal_if_simple_name_is_not_unique_w
     assert (
         normalized_schema.schema == schema.schema
     ), "Since the simple name is not unique identifying the type isn't replacing the source"
+
+
+# ---------------------------------------------------------------------------
+# map<K,V> shorthand restoration on normalisation
+# ---------------------------------------------------------------------------
+
+# The explicit expanded form — as written in source text or as returned by
+# Karapace (patched) after binary registration without ?normalize=true.
+_MAP_ENTRY_EXPLICIT_PROTO = """\
+syntax = "proto3";
+
+message MapMessage {
+  repeated .MapMessage.LabelsEntry labels = 1;
+
+  message LabelsEntry {
+    option map_entry = true;
+
+    string key = 1;
+    string value = 2;
+  }
+}
+"""
+
+# Pre-compiled binary FileDescriptorProto produced by protoc from the map<string,string>
+# source above.  The binary does NOT contain map<> shorthand — protoc always compiles map<K,V>
+# to the expanded entry-message form: a repeated field plus a synthetic LabelsEntry nested
+# message with options { map_entry: true } (wire bytes 3a 02 38 01 at offset 98).
+_MAP_ENTRY_BIN = (
+    "ImQKCk1hcE1lc3NhZ2USJwoGbGFiZWxzGAEgAygLMhcuTWFwTWVzc2FnZS5MYWJlbHNFbnRyeRot"
+    "CgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBYgZwcm90bzM="
+)
+
+_MAP_SHORTHAND_NORMALISED = """\
+syntax = "proto3";
+
+message MapMessage {
+  map<string, string> labels = 1;
+}
+"""
+
+
+def test_normalize_converts_explicit_map_entry_to_map_shorthand() -> None:
+    """option map_entry = true in text source is converted to map<> shorthand on normalisation."""
+    result = parse_protobuf_schema_definition(
+        schema_definition=_MAP_ENTRY_EXPLICIT_PROTO,
+        references=None,
+        dependencies=None,
+        validate_references=True,
+        normalize=True,
+    )
+    assert result.to_schema().strip() == _MAP_SHORTHAND_NORMALISED.strip()
+
+
+def test_normalize_converts_binary_map_field_to_map_shorthand() -> None:
+    """Binary-registered schema with map<string,string>: normalisation converts to map<> shorthand."""
+    from karapace.core.protobuf.serialization import deserialize
+    from karapace.core.protobuf.schema import ProtobufSchema
+    from karapace.core.protobuf.proto_normalizations import normalize
+
+    pfe = deserialize(_MAP_ENTRY_BIN)
+    schema = ProtobufSchema("", None, None, proto_file_element=pfe)
+    result = normalize(schema)
+    assert result.to_schema().strip() == _MAP_SHORTHAND_NORMALISED.strip()
+
+
+def test_normalize_map_is_idempotent() -> None:
+    """Normalising a schema that already uses map<> shorthand syntax leaves it unchanged."""
+    shorthand_proto = 'syntax = "proto3";\n\nmessage MapMessage {\n  map<string, string> labels = 1;\n}\n'
+    result = parse_protobuf_schema_definition(
+        schema_definition=shorthand_proto,
+        references=None,
+        dependencies=None,
+        validate_references=True,
+        normalize=True,
+    )
+    assert result.to_schema().strip() == shorthand_proto.strip()
+
+
+# Binary FileDescriptorProto produced by google.protobuf.descriptor_pb2 from:
+#   syntax = "proto3";
+#   message Mixed {
+#     string name = 1;
+#     map<string, string> labels = 2;
+#     int32 count = 3;
+#   }
+# The binary contains the expanded entry-message form with options { map_entry: true }
+# at byte offset 117.  Used to verify that shorthand restoration preserves field order.
+_MIXED_FIELDS_BIN = (
+    "IncKBU1peGVkEgwKBG5hbWUYASABKAkSIgoGbGFiZWxzGAIgAygLMhIuTWl4ZWQuTGFiZWxzRW50"
+    "cnkSDQoFY291bnQYAyABKAUaLQoLTGFiZWxzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIg"
+    "ASgJOgI4AWIGcHJvdG8z"
+)
+
+
+def test_normalize_map_field_order_when_map_is_in_the_middle() -> None:
+    """map<> field between two regular fields keeps its position after shorthand restoration.
+
+    Input (binary, expanded form):
+      message Mixed {
+        string name = 1;
+        repeated .Mixed.LabelsEntry labels = 2;
+        int32 count = 3;
+        message LabelsEntry { option map_entry = true; string key = 1; string value = 2; }
+      }
+    Expected after normalize:
+      message Mixed {
+        string name = 1;
+        map<string, string> labels = 2;
+        int32 count = 3;
+      }
+    """
+    from karapace.core.protobuf.serialization import deserialize
+    from karapace.core.protobuf.schema import ProtobufSchema
+    from karapace.core.protobuf.proto_normalizations import normalize
+
+    pfe = deserialize(_MIXED_FIELDS_BIN)
+    result = normalize(ProtobufSchema("", None, None, proto_file_element=pfe)).to_schema()
+
+    assert "map<string, string>" in result, "map field not converted to shorthand"
+    assert "LabelsEntry" not in result, "synthetic entry message not suppressed"
+    assert result.index("name") < result.index("labels") < result.index("count"), (
+        f"field order wrong:\n{result}"
+    )

--- a/tests/unit/protobuf/test_protobuf_normalization.py
+++ b/tests/unit/protobuf/test_protobuf_normalization.py
@@ -1280,3 +1280,89 @@ def test_normalize_only_well_formed_entry_messages_are_collapsed() -> None:
     assert "GoodEntry" not in result, "well-formed entry message should be suppressed"
     assert "BadEntry" in result, "malformed entry message must not be removed"
     assert "repeated" in result and "bad" in result, "malformed field should remain as repeated"
+
+
+def test_normalize_does_not_collapse_field_pointing_to_same_named_entry_in_sibling_message() -> None:
+    """A field pointing to a same-named entry message in a sibling nested message must not be
+    incorrectly collapsed.
+
+    Schema (binary):
+      message Outer {
+        repeated .Outer.Sibling.LabelsEntry other = 1;   <- points to Sibling.LabelsEntry, NOT the map entry
+        map<string, string> labels = 2;                  <- the real map field
+
+        message Sibling {
+          message LabelsEntry { string x = 1; }          <- NOT a map entry, different scope
+        }
+        message LabelsEntry {                            <- the real map entry (direct child of Outer)
+          option map_entry = true;
+          string key = 1;
+          string value = 2;
+        }
+      }
+
+    The 'other' field ends with '.LabelsEntry' but refers to Sibling.LabelsEntry, not the map
+    entry.  A suffix-only match incorrectly collapses it; the qualified-name match does not.
+    """
+    import base64
+    import google.protobuf.descriptor_pb2 as pb2
+    from karapace.core.protobuf.serialization import deserialize
+    from karapace.core.protobuf.schema import ProtobufSchema
+    from karapace.core.protobuf.proto_normalizations import normalize
+
+    fd = pb2.FileDescriptorProto()
+    fd.syntax = "proto3"
+    outer = fd.message_type.add()
+    outer.name = "Outer"
+
+    # Sibling message containing its own LabelsEntry (NOT a map entry)
+    sibling = outer.nested_type.add()
+    sibling.name = "Sibling"
+    sibling_entry = sibling.nested_type.add()
+    sibling_entry.name = "LabelsEntry"  # same simple name as the real map entry, different scope
+    sx = sibling_entry.field.add()
+    sx.name = "x"
+    sx.number = 1
+    sx.label = 1
+    sx.type = 9
+
+    # The real map entry as a direct child of Outer
+    map_entry = outer.nested_type.add()
+    map_entry.name = "LabelsEntry"
+    map_entry.options.map_entry = True
+    mk = map_entry.field.add()
+    mk.name = "key"
+    mk.number = 1
+    mk.label = 1
+    mk.type = 9
+    mv = map_entry.field.add()
+    mv.name = "value"
+    mv.number = 2
+    mv.label = 1
+    mv.type = 9
+
+    # Field pointing to Sibling.LabelsEntry (should NOT be collapsed)
+    f_other = outer.field.add()
+    f_other.name = "other"
+    f_other.number = 1
+    f_other.label = 3  # LABEL_REPEATED
+    f_other.type = 11
+    f_other.type_name = ".Outer.Sibling.LabelsEntry"
+
+    # Field pointing to the real map entry (SHOULD be collapsed)
+    f_labels = outer.field.add()
+    f_labels.name = "labels"
+    f_labels.number = 2
+    f_labels.label = 3  # LABEL_REPEATED
+    f_labels.type = 11
+    f_labels.type_name = ".Outer.LabelsEntry"
+
+    b64 = base64.b64encode(fd.SerializeToString()).decode()
+    pfe = deserialize(b64)
+    result = normalize(ProtobufSchema("", None, None, proto_file_element=pfe)).to_schema()
+
+    assert "map<string, string> labels" in result, "map field should be collapsed to map<>"
+    assert (
+        "repeated" in result and "other" in result
+    ), "'other' field must remain as repeated (points to sibling, not map entry)"
+    assert "Sibling" in result, "Sibling message must not be removed"

--- a/tests/unit/protobuf/test_protobuf_normalization.py
+++ b/tests/unit/protobuf/test_protobuf_normalization.py
@@ -1184,6 +1184,4 @@ def test_normalize_map_field_order_when_map_is_in_the_middle() -> None:
 
     assert "map<string, string>" in result, "map field not converted to shorthand"
     assert "LabelsEntry" not in result, "synthetic entry message not suppressed"
-    assert result.index("name") < result.index("labels") < result.index("count"), (
-        f"field order wrong:\n{result}"
-    )
+    assert result.index("name") < result.index("labels") < result.index("count"), f"field order wrong:\n{result}"

--- a/tests/unit/protobuf/test_protobuf_normalization.py
+++ b/tests/unit/protobuf/test_protobuf_normalization.py
@@ -1185,3 +1185,98 @@ def test_normalize_map_field_order_when_map_is_in_the_middle() -> None:
     assert "map<string, string>" in result, "map field not converted to shorthand"
     assert "LabelsEntry" not in result, "synthetic entry message not suppressed"
     assert result.index("name") < result.index("labels") < result.index("count"), f"field order wrong:\n{result}"
+
+
+def _make_binary(setup_fn) -> str:
+    """Build a base64 FileDescriptorProto by applying setup_fn to a blank message descriptor."""
+    import base64
+    import google.protobuf.descriptor_pb2 as pb2
+
+    fd = pb2.FileDescriptorProto()
+    fd.syntax = "proto3"
+    msg = fd.message_type.add()
+    setup_fn(msg)
+    return base64.b64encode(fd.SerializeToString()).decode()
+
+
+def test_normalize_malformed_entry_message_is_not_collapsed_and_not_removed() -> None:
+    """A map_entry message missing the value field must not be collapsed to map<>
+    and must not be removed from nested types (which would leave a dangling reference)."""
+    from karapace.core.protobuf.serialization import deserialize
+    from karapace.core.protobuf.schema import ProtobufSchema
+    from karapace.core.protobuf.proto_normalizations import normalize
+
+    def setup(msg) -> None:
+        msg.name = "Msg"
+        entry = msg.nested_type.add()
+        entry.name = "LabelsEntry"
+        entry.options.map_entry = True
+        k = entry.field.add()
+        k.name = "key"
+        k.number = 1
+        k.label = 1
+        k.type = 9  # no value field
+        f = msg.field.add()
+        f.name = "labels"
+        f.number = 1
+        f.label = 3
+        f.type = 11
+        f.type_name = ".Msg.LabelsEntry"
+
+    pfe = deserialize(_make_binary(setup))
+    result = normalize(ProtobufSchema("", None, None, proto_file_element=pfe)).to_schema()
+
+    assert "map<" not in result, "malformed entry should not be converted to map<>"
+    assert "LabelsEntry" in result, "malformed entry message must not be removed (would dangle)"
+
+
+def test_normalize_only_well_formed_entry_messages_are_collapsed() -> None:
+    """When a message has two map_entry nested messages and only one is well-formed,
+    only the well-formed entry is collapsed to map<> and removed; the other is kept."""
+    from karapace.core.protobuf.serialization import deserialize
+    from karapace.core.protobuf.schema import ProtobufSchema
+    from karapace.core.protobuf.proto_normalizations import normalize
+
+    def setup(msg) -> None:
+        msg.name = "Msg"
+        good = msg.nested_type.add()
+        good.name = "GoodEntry"
+        good.options.map_entry = True
+        k1 = good.field.add()
+        k1.name = "key"
+        k1.number = 1
+        k1.label = 1
+        k1.type = 9
+        v1 = good.field.add()
+        v1.name = "value"
+        v1.number = 2
+        v1.label = 1
+        v1.type = 9
+        bad = msg.nested_type.add()
+        bad.name = "BadEntry"
+        bad.options.map_entry = True
+        k2 = bad.field.add()
+        k2.name = "key"
+        k2.number = 1
+        k2.label = 1
+        k2.type = 9  # no value
+        f1 = msg.field.add()
+        f1.name = "good"
+        f1.number = 1
+        f1.label = 3
+        f1.type = 11
+        f1.type_name = ".Msg.GoodEntry"
+        f2 = msg.field.add()
+        f2.name = "bad"
+        f2.number = 2
+        f2.label = 3
+        f2.type = 11
+        f2.type_name = ".Msg.BadEntry"
+
+    pfe = deserialize(_make_binary(setup))
+    result = normalize(ProtobufSchema("", None, None, proto_file_element=pfe)).to_schema()
+
+    assert "map<string, string> good" in result, "well-formed entry should be collapsed to map<>"
+    assert "GoodEntry" not in result, "well-formed entry message should be suppressed"
+    assert "BadEntry" in result, "malformed entry message must not be removed"
+    assert "repeated" in result and "bad" in result, "malformed field should remain as repeated"

--- a/tests/unit/test_protobuf_binary_serialization.py
+++ b/tests/unit/test_protobuf_binary_serialization.py
@@ -139,12 +139,14 @@ def test_simple_schema_serialize(schema):
     assert schema.strip() == ProtobufSchema("", None, None, proto_file_element=deserialize(serialized)).to_schema().strip()
 
 
-# Binary descriptor for:
+# Binary FileDescriptorProto produced by google.protobuf.descriptor_pb2 from:
 #   syntax = "proto3";
 #   message MapMessage {
 #     map<string, string> labels = 1;
 #   }
-# Produced by google.protobuf.descriptor_pb2 — contains 3a 02 38 01 (options { map_entry: true })
+# The binary does NOT contain map<> shorthand — protoc always compiles map<K,V> to the
+# expanded entry-message form: a repeated field plus a synthetic LabelsEntry nested
+# message with options { map_entry: true } (wire bytes 3a 02 38 01 at offset 98).
 _MAP_ENTRY_BIN = "ImQKCk1hcE1lc3NhZ2USJwoGbGFiZWxzGAEgAygLMhcuTWFwTWVzc2FnZS5MYWJlbHNFbnRyeRotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBYgZwcm90bzM="
 
 

--- a/tests/unit/test_protobuf_binary_serialization.py
+++ b/tests/unit/test_protobuf_binary_serialization.py
@@ -7,6 +7,8 @@ import pytest
 
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.protobuf.serialization import deserialize, serialize
+import google.protobuf.descriptor_pb2 as _pb2
+import base64
 from tests.schemas.protobuf import (
     schema_protobuf_complex,
     schema_protobuf_complex_bin,
@@ -135,3 +137,43 @@ def test_protoc_serialized_schema_deserialize(schema_plain, schema_serialized):
 def test_simple_schema_serialize(schema):
     serialized = serialize(ProtobufSchema(schema).proto_file_element)
     assert schema.strip() == ProtobufSchema("", None, None, proto_file_element=deserialize(serialized)).to_schema().strip()
+
+
+# Binary descriptor for:
+#   syntax = "proto3";
+#   message MapMessage {
+#     map<string, string> labels = 1;
+#   }
+# Produced by google.protobuf.descriptor_pb2 — contains 3a 02 38 01 (options { map_entry: true })
+_MAP_ENTRY_BIN = "ImQKCk1hcE1lc3NhZ2USJwoGbGFiZWxzGAEgAygLMhcuTWFwTWVzc2FnZS5MYWJlbHNFbnRyeRotCgtMYWJlbHNFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgBYgZwcm90bzM="
+
+
+def test_map_entry_option_preserved_on_deserialize():
+    """Binary-registered schema with map<string,string>: map_entry=true must survive deserialize."""
+    pfe = deserialize(_MAP_ENTRY_BIN)
+    schema_text = ProtobufSchema("", None, None, proto_file_element=pfe).to_schema()
+    assert "map_entry = true" in schema_text, f"map_entry not found in:\n{schema_text}"
+
+
+def test_map_entry_option_preserved_on_serialize_roundtrip():
+    """map_entry=true must survive a full deserialize → serialize → deserialize round-trip."""
+    pfe = deserialize(_MAP_ENTRY_BIN)
+    re_serialized = serialize(pfe)
+    # Re-serialized binary must still contain 3a 02 38 01
+    raw = base64.b64decode(re_serialized)
+    assert bytes([0x3A, 0x02, 0x38, 0x01]) in raw, "3a 02 38 01 (map_entry=true) missing from re-serialized descriptor"
+    # And the text form must still declare it
+    pfe2 = deserialize(re_serialized)
+    schema_text = ProtobufSchema("", None, None, proto_file_element=pfe2).to_schema()
+    assert "map_entry = true" in schema_text
+
+
+def test_map_entry_option_only_on_entry_message():
+    """map_entry=true must appear only on LabelsEntry, not on the outer MapMessage."""
+    pfe = deserialize(_MAP_ENTRY_BIN)
+    from karapace.core.protobuf.message_element import MessageElement
+    messages = {t.name: t for t in pfe.types if isinstance(t, MessageElement)}
+    outer = messages["MapMessage"]
+    assert not any(o.name == "map_entry" for o in outer.options), "map_entry leaked onto outer message"
+    entry = next(t for t in outer.nested_types if isinstance(t, MessageElement) and t.name == "LabelsEntry")
+    assert any(o.name == "map_entry" and o.value is True for o in entry.options), "map_entry missing from LabelsEntry"

--- a/tests/unit/test_protobuf_binary_serialization.py
+++ b/tests/unit/test_protobuf_binary_serialization.py
@@ -7,7 +7,6 @@ import pytest
 
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.protobuf.serialization import deserialize, serialize
-import google.protobuf.descriptor_pb2 as _pb2
 import base64
 from tests.schemas.protobuf import (
     schema_protobuf_complex,
@@ -174,6 +173,7 @@ def test_map_entry_option_only_on_entry_message():
     """map_entry=true must appear only on LabelsEntry, not on the outer MapMessage."""
     pfe = deserialize(_MAP_ENTRY_BIN)
     from karapace.core.protobuf.message_element import MessageElement
+
     messages = {t.name: t for t in pfe.types if isinstance(t, MessageElement)}
     outer = messages["MapMessage"]
     assert not any(o.name == "map_entry" for o in outer.options), "map_entry leaked onto outer message"


### PR DESCRIPTION
Fixes #1319

## Summary

Two related bugs affect PROTOBUF schemas registered as a base64-encoded `FileDescriptorProto` binary (the format produced by Confluent Java, C#, and .NET SDK serialisers).

### Bug 1 — `map_entry` silently stripped on binary registration

`_deserialize_msg()` constructed `MessageElement` without reading `MessageOptions`, so `option map_entry = true` was silently dropped from any `map<K,V>` entry message. The same gap in `_serialize_msgtype()` meant binary round-trips also lost the option.

### Bug 2 — `?normalize=true` did not restore `map<K,V>` shorthand

Normalisation only sorted options; it had no logic to detect the expanded entry-message pattern and convert it back to `map<K,V>` syntax, diverging from Confluent Schema Registry's `?normalize=true` behaviour.

## Changes

**`src/karapace/core/protobuf/serialization.py`**
- Add `_deserialize_message_options()` which reads `map_entry` and `deprecated` from `MessageOptions` via `HasField()`
- Pass the result as `options=` to `MessageElement` in `_deserialize_msg()`
- Write `map_entry` and `deprecated` back onto `DescriptorProto.options` in `_serialize_msgtype()`

**`src/karapace/core/protobuf/proto_normalizations.py`**
- Add `_is_map_entry()` to detect synthetic entry messages by `option map_entry = true`
- Add `_restore_map_shorthand()` which replaces the `repeated .Foo.LabelsEntry` field with `map<K,V>` and suppresses the entry message from the nested types list
- Call `_restore_map_shorthand()` in `message_element_with_sorted_options()` before processing fields and nested types

**`README.rst`**
- Document map shorthand restoration as a normalisation behaviour alongside field ordering

## Tests

**`tests/unit/test_protobuf_binary_serialization.py`** — 3 new tests:
- `test_map_entry_option_preserved_on_deserialize`
- `test_map_entry_option_preserved_on_serialize_roundtrip`
- `test_map_entry_option_only_on_entry_message`

**`tests/unit/protobuf/test_protobuf_normalization.py`** — 4 new tests:
- `test_normalize_converts_explicit_map_entry_to_map_shorthand`
- `test_normalize_converts_binary_map_field_to_map_shorthand`
- `test_normalize_map_is_idempotent`
- `test_normalize_map_field_order_when_map_is_in_the_middle`

## Verification

After both fixes, `karapace-patched` output matches `confluent-sr` exactly across all 8 registration modes (text/binary × shorthand/explicit × with/without `?normalize=true`), confirmed locally.