### PR TITLE
OIDC enhancements - remove client-id, standardize roles

### DIFF
--- a/.claude/skills/oidc-auth/SKILL.md
+++ b/.claude/skills/oidc-auth/SKILL.md
@@ -62,6 +62,13 @@ After validation, only the configured subject claim (`claim_name`, default `"sub
 
 Missing it → `ValueError` at startup (fail-closed).
 
+### Canonical role names — `src/karapace/core/constants.py`
+Role strings are prefixed `karapace.` (e.g. `karapace.schema:read`) and defined as `OIDC_ROLE_*`
+constants. `DEFAULT_OIDC_METHOD_ROLES` maps HTTP methods to them and is the config default for
+`sasl_oauthbearer_method_roles`. These must match the roles the IdP mints into tokens — the
+reference Keycloak realm (`container/keycloak/realm-export.json`) defines the same set. Change
+role names in the constants module, keep the realm export and `container/compose.yml` in sync.
+
 ### Backwards-compat shim — `Config._enforce_authn_when_authz_enabled`
 If `sasl_oauthbearer_authorization_enabled=true` but `sasl_oauthbearer_authentication_enabled=false`, we auto-enable authn and log a deprecation warning. Authz without authn is meaningless; the prior single-flag config is preserved with a warning so operators migrate.
 
@@ -190,7 +197,7 @@ return http_authorizer if config.registry_authfile else no_auth_authorizer
 | `sasl_oauthbearer_expected_audience` | `None` | Comma-separated list; required when JWKS is set |
 | `sasl_oauthbearer_sub_claim_name` | `"sub"` | Claim to expose as `request.state.user` |
 | `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT; required for authz |
-| `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles |
+| `sasl_oauthbearer_method_roles` | `DEFAULT_OIDC_METHOD_ROLES` (the `karapace.*` roles) | Per-method allowed roles |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths |
 | `sasl_oauthbearer_leeway_seconds` | `0` | Clock-skew tolerance for `exp`/`nbf`/`iat` (must be >= 0) |
 | `sasl_oauthbearer_require_access_token_typ` | `False` | Require header `typ: at+jwt` (or `application/at+jwt`) |

--- a/.claude/skills/oidc-auth/SKILL.md
+++ b/.claude/skills/oidc-auth/SKILL.md
@@ -54,14 +54,13 @@ After validation, only the configured subject claim (`claim_name`, default `"sub
 ### Flow — `OIDCMiddleware.authorize_request`
 - Off when `sasl_oauthbearer_authorization_enabled=false` — returns `True` immediately.
 - Looks up allowed roles for the request method in `sasl_oauthbearer_method_roles`, e.g. `{"GET": ["reader","admin"], "POST": ["admin"], ...}`.
-- Extracts user roles via `sasl_oauthbearer_roles_claim_path` (dot-path, e.g. `realm_access.roles`). Supports `[client_id]` token in the path that gets replaced with `sasl_oauthbearer_client_id` (Keycloak `resource_access.<client>.roles` style).
+- Extracts user roles via `sasl_oauthbearer_roles_claim_path` (dot-path, e.g. `realm_access.roles`, or a literal Keycloak path `resource_access.<client>.roles`).
 - Mismatch (or any misconfig) → **403 with the same body** as a real role mismatch. This is intentional — an attacker with a valid token must not be able to distinguish "bad config" from "missing role" via response differences.
 
 ### Required config when authz is on (`OIDCMiddleware.__init__`)
-- `sasl_oauthbearer_client_id`
 - `sasl_oauthbearer_roles_claim_path`
 
-Missing either → `ValueError` at startup (fail-closed).
+Missing it → `ValueError` at startup (fail-closed).
 
 ### Backwards-compat shim — `Config._enforce_authn_when_authz_enabled`
 If `sasl_oauthbearer_authorization_enabled=true` but `sasl_oauthbearer_authentication_enabled=false`, we auto-enable authn and log a deprecation warning. Authz without authn is meaningless; the prior single-flag config is preserved with a warning so operators migrate.
@@ -190,13 +189,11 @@ return http_authorizer if config.registry_authfile else no_auth_authorizer
 | `sasl_oauthbearer_expected_issuer` | `None` | Required when JWKS is set |
 | `sasl_oauthbearer_expected_audience` | `None` | Comma-separated list; required when JWKS is set |
 | `sasl_oauthbearer_sub_claim_name` | `"sub"` | Claim to expose as `request.state.user` |
-| `sasl_oauthbearer_client_id` | `None` | Required for authz; substituted into `[client_id]` in roles path |
-| `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT |
+| `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT; required for authz |
 | `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths |
 | `sasl_oauthbearer_leeway_seconds` | `0` | Clock-skew tolerance for `exp`/`nbf`/`iat` (must be >= 0) |
 | `sasl_oauthbearer_require_access_token_typ` | `False` | Require header `typ: at+jwt` (or `application/at+jwt`) |
-| `sasl_oauthbearer_enforce_azp` | `False` | Require `azp == client_id`; needs `client_id` |
 | `schema_registry_client_cache_maxsize` | `100` | LRU cap on `(subject, version, fp)` |
 | `registry_authfile` | `None` | Selects basic-auth `HTTPAuthorizer` |
 

--- a/README.rst
+++ b/README.rst
@@ -133,17 +133,12 @@ Optional hardening flags::
 
    sasl_oauthbearer_leeway_seconds: int = 0           # clock-skew tolerance for exp/nbf/iat (must be >= 0)
    sasl_oauthbearer_require_access_token_typ: bool = False  # require typ "at+jwt" header
-   sasl_oauthbearer_enforce_azp: bool = False         # require azp claim == client_id
-
-``sasl_oauthbearer_enforce_azp=true`` requires ``sasl_oauthbearer_client_id`` to be set;
-startup fails otherwise.
 
 There is a detailed section about OAuth2 authentication for karapace below.
 
 To enable oidc authorization on karapace, configure the below params together with the above ::
 
    sasl_oauthbearer_authorization_enabled: bool = False
-   sasl_oauthbearer_client_id: str | None = None
    sasl_oauthbearer_roles_claim_path: str | None = None
    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
 
@@ -717,7 +712,6 @@ Below here is an example of karapace OpenId connect config ::
 
    sasl_oauthbearer_authentication_enabled: bool = True
    sasl_oauthbearer_authorization_enabled: bool = False
-   sasl_oauthbearer_client_id: str | None = None
    sasl_oauthbearer_roles_claim_path: str | None = None
    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
 
@@ -734,10 +728,15 @@ Below here is an example of karapace OpenId connect docker config ::
 
   KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: True
   KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: True
-  KARAPACE_SASL_OAUTHBEARER_CLIENT_ID: "karapace"
-  KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.[client_id].roles"
+  KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
   KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: dict[str, list[str]] = {"GET": ["schema:read", "subject:read"],
                                                            "POST": ["schema:write", "subject:write"], "PUT": [], "DELETE": []}
+
+.. note::
+   ``sasl_oauthbearer_client_id`` and ``sasl_oauthbearer_enforce_azp`` have been removed. The
+   ``azp`` claim is no longer validated. The ``[client_id]`` placeholder in
+   ``sasl_oauthbearer_roles_claim_path`` is no longer substituted — write the literal client id
+   into the path (e.g. ``resource_access.karapace-client.roles``).
 
 
 Production hardening notes

--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,8 @@ To enable oidc authorization on karapace, configure the below params together wi
 
    sasl_oauthbearer_authorization_enabled: bool = False
    sasl_oauthbearer_roles_claim_path: str | None = None
-   sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
+   # Defaults to the karapace.* roles shown in the example below; override per deployment.
+   sasl_oauthbearer_method_roles: dict[str, list[str]]
 
 Note: ``sasl_oauthbearer_authorization_enabled=true`` requires
 ``sasl_oauthbearer_authentication_enabled=true``. For backwards compatibility, enabling
@@ -713,7 +714,8 @@ Below here is an example of karapace OpenId connect config ::
    sasl_oauthbearer_authentication_enabled: bool = True
    sasl_oauthbearer_authorization_enabled: bool = False
    sasl_oauthbearer_roles_claim_path: str | None = None
-   sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
+   # Defaults to the karapace.* roles shown in the example below; override per deployment.
+   sasl_oauthbearer_method_roles: dict[str, list[str]]
 
 
 Below here is an example of karapace OpenId connect docker config ::
@@ -729,8 +731,8 @@ Below here is an example of karapace OpenId connect docker config ::
   KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: True
   KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: True
   KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
-  KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: dict[str, list[str]] = {"GET": ["schema:read", "subject:read"],
-                                                           "POST": ["schema:write", "subject:write"], "PUT": [], "DELETE": []}
+  KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: dict[str, list[str]] = {"GET": ["karapace.schema:read", "karapace.subject:read"],
+                                                           "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": [], "DELETE": []}
 
 .. note::
    ``sasl_oauthbearer_client_id`` and ``sasl_oauthbearer_enforce_azp`` have been removed. The

--- a/bin/smoke-test-schema-registry.sh
+++ b/bin/smoke-test-schema-registry.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 retries=5
-chmod +x /opt/karapace/bin/get_oidc_token.py
-token=$(/opt/karapace/bin/get_oidc_token.py)
 
 for ((i = 0; i <= retries; i++)); do
     response=$(
         curl --silent --verbose --fail --request POST \
             --cacert "$CAROOT/rootCA.pem" \
-            --header "Authorization: Bearer $token" \
             --header 'Content-Type: application/vnd.schemaregistry.v1+json' \
             --data '{"schema": "{\"type\": \"record\", \"name\": \"Obj\", \"fields\":[{\"name\": \"age\", \"type\": \"int\"}]}"}' \
             "https://karapace-schema-registry:8081/subjects/test-key/versions"

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -94,7 +94,6 @@ services:
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
-      KARAPACE_SASL_OAUTHBEARER_CLIENT_ID: "karapace-client"
       KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
       KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
@@ -155,7 +154,6 @@ services:
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
-      KARAPACE_SASL_OAUTHBEARER_CLIENT_ID: "karapace-client"
       KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
       KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -187,6 +187,59 @@ services:
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
+  # Full OIDC (authentication + role-based authorization). Target for the
+  # authn+authz e2e tests (registry_async_client_oidc* fixtures).
+  karapace-schema-registry-oidc:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-schema-registry-oidc
+    container_name: karapace-schema-registry-oidc
+    entrypoint:
+      - python3
+      - -m
+      - karapace
+    depends_on:
+      - kafka
+      - opentelemetry-collector
+    ports:
+      - 8091:8091
+    volumes:
+      - ./certs:/opt/karapace/certs
+    environment:
+      KARAPACE_KARAPACE_REGISTRY: true
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-schema-registry-oidc
+      KARAPACE_ADVERTISED_PROTOCOL: https
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_PORT: 8091
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_CLIENT_ID: karapace-schema-registry-oidc
+      KARAPACE_GROUP_ID: karapace-schema-registry-oidc
+      KARAPACE_MASTER_ELECTION_STRATEGY: highest
+      KARAPACE_MASTER_ELIGIBILITY: true
+      KARAPACE_TOPIC_NAME: _schemas_oidc
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_COMPATIBILITY: FULL
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_TAGS__APP: karapace-schema-registry-oidc
+      KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
+      KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
+      KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
+      KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: true
+      KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
+      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
+      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
+      KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
+      KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
+      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["karapace.schema:read", "karapace.subject:read"], "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": ["karapace.config_subject:update","karapace.config_global:update"], "DELETE": ["karapace.schema:delete", "karapace.subject:delete"]}'
+      KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
+
   # REST Proxy with the forwarding gate ON, against the authn-only SR.
   karapace-rest-proxy-oidc:
     profiles:

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -95,7 +95,7 @@ services:
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
-      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
+      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["karapace.schema:read", "karapace.subject:read"], "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": ["karapace.config_subject:update","karapace.config_global:update"], "DELETE": ["karapace.schema:delete", "karapace.subject:delete"]}'
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
   karapace-schema-registry-follower:
@@ -155,7 +155,7 @@ services:
       KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
       KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
-      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["schema:read", "subject:read"], "POST": ["schema:write", "subject:write"], "PUT": ["config_subject:update","config_global:update"], "DELETE": ["schema:delete", "subject:delete"]}'
+      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["karapace.schema:read", "karapace.subject:read"], "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": ["karapace.config_subject:update","karapace.config_global:update"], "DELETE": ["karapace.schema:delete", "karapace.subject:delete"]}'
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
   # OIDC authentication only (no role-based authorization).

--- a/container/compose.yml
+++ b/container/compose.yml
@@ -86,17 +86,6 @@ services:
       KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
       KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
       KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
-      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
-      KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: true
-      KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
-      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
-      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
-      KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
-      KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
-      KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
-      KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
-      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["karapace.schema:read", "karapace.subject:read"], "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": ["karapace.config_subject:update","karapace.config_global:update"], "DELETE": ["karapace.schema:delete", "karapace.subject:delete"]}'
-      KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
   karapace-schema-registry-follower:
     networks:
@@ -146,17 +135,6 @@ services:
       KARAPACE_SERVER_TLS_CAFILE: /opt/karapace/certs/ca/rootCA.pem
       KARAPACE_SERVER_TLS_CERTFILE: /opt/karapace/certs/cert.pem
       KARAPACE_SERVER_TLS_KEYFILE: /opt/karapace/certs/key.pem
-      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
-      KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: true
-      KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: http://keycloak:8080/realms/karapace/protocol/openid-connect/certs
-      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
-      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: true
-      KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: http://keycloak:8080/realms/karapace
-      KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: "karapace-audience"
-      KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
-      KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH: "resource_access.karapace-client.roles"
-      KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES: '{"GET": ["karapace.schema:read", "karapace.subject:read"], "POST": ["karapace.schema:write", "karapace.subject:write"], "PUT": ["karapace.config_subject:update","karapace.config_global:update"], "DELETE": ["karapace.schema:delete", "karapace.subject:delete"]}'
-      KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
   # OIDC authentication only (no role-based authorization).
   # Used to isolate the sasl_oauthbearer_authentication_enabled flag in tests.
@@ -504,6 +482,10 @@ services:
       - 14268:14268
 
   keycloak:
+    # Only needed by the OIDC services under the e2e profile; kept out of the
+    # default (smoke-test) startup so it isn't a startup-race dependency there.
+    profiles:
+      - e2e
     networks:
       - karapace
     image: quay.io/keycloak/keycloak:24.0

--- a/container/keycloak/realm-export.json
+++ b/container/keycloak/realm-export.json
@@ -66,14 +66,14 @@
       "serviceAccountClientId": "karapace-client",
       "clientRoles": {
         "karapace-client": [
-          "schema:read",
-          "schema:write",
-          "schema:delete",
-          "subject:read",
-          "subject:write",
-          "subject:delete",
-          "config_subject:update",
-          "config_global:update"
+          "karapace.schema:read",
+          "karapace.schema:write",
+          "karapace.schema:delete",
+          "karapace.subject:read",
+          "karapace.subject:write",
+          "karapace.subject:delete",
+          "karapace.config_subject:update",
+          "karapace.config_global:update"
         ]
       }
     }
@@ -91,7 +91,7 @@
     "client": {
       "karapace-client": [
         {
-          "name": "schema:read",
+          "name": "karapace.schema:read",
           "description": "Read access to schemas",
           "composite": false,
           "clientRole": true,
@@ -99,7 +99,7 @@
           "attributes": {}
         },
         {
-          "name": "schema:write",
+          "name": "karapace.schema:write",
           "description": "Write access to schemas",
           "composite": false,
           "clientRole": true,
@@ -107,7 +107,7 @@
           "attributes": {}
         },
         {
-          "name": "subject:read",
+          "name": "karapace.subject:read",
           "description": "Read access to subjects",
           "composite": false,
           "clientRole": true,
@@ -115,14 +115,14 @@
           "attributes": {}
         },
         {
-          "name": "subject:write",
+          "name": "karapace.subject:write",
           "description": "Write access to subjects",
           "composite": false,
           "clientRole": true,
           "containerId": "karapace-client",
           "attributes": {}
         },{
-          "name": "subject:delete",
+          "name": "karapace.subject:delete",
           "description": "Delete access to subjects",
           "composite": false,
           "clientRole": true,
@@ -130,7 +130,7 @@
           "attributes": {}
         },
         {
-          "name": "schema:delete",
+          "name": "karapace.schema:delete",
           "description": "Delete access to schemas",
           "composite": false,
           "clientRole": true,
@@ -138,7 +138,7 @@
           "attributes": {}
         },
         {
-          "name": "config_subject:update",
+          "name": "karapace.config_subject:update",
           "description": "Update configs to subjects, like compatibility",
           "composite": false,
           "clientRole": true,
@@ -146,7 +146,7 @@
           "attributes": {}
         },
         {
-          "name": "config_global:update",
+          "name": "karapace.config_global:update",
           "description": "Update configs to global, like compatibility",
           "composite": false,
           "clientRole": true,

--- a/src/karapace/api/AGENTS.md
+++ b/src/karapace/api/AGENTS.md
@@ -32,9 +32,9 @@ After validation, **only the configured subject claim** (`claim_name`, default `
 
 - Off when `sasl_oauthbearer_authorization_enabled=false` — returns `True` immediately.
 - Allowed roles per HTTP method come from `sasl_oauthbearer_method_roles`, e.g. `{"GET": ["reader","admin"], "POST": ["admin"], ...}`.
-- Roles are extracted via `sasl_oauthbearer_roles_claim_path` (dot-path, e.g. `realm_access.roles`). Supports a `[client_id]` token in the path that's substituted with `sasl_oauthbearer_client_id` (Keycloak `resource_access.<client>.roles` style).
+- Roles are extracted via `sasl_oauthbearer_roles_claim_path` (dot-path, e.g. `realm_access.roles`, or a literal Keycloak path `resource_access.<client>.roles`).
 - Mismatch **or any misconfig** ⇒ **403 with the same body** as a real role mismatch. This is intentional — an attacker with a valid token must not be able to distinguish "bad config" from "missing role" by the response.
-- Required config when authz is on: `sasl_oauthbearer_client_id` and `sasl_oauthbearer_roles_claim_path`. Missing either ⇒ `ValueError` at startup (fail-closed).
+- Required config when authz is on: `sasl_oauthbearer_roles_claim_path`. Missing it ⇒ `ValueError` at startup (fail-closed).
 
 ## Error response shape
 

--- a/src/karapace/api/oidc/middleware.py
+++ b/src/karapace/api/oidc/middleware.py
@@ -37,12 +37,10 @@ class OIDCMiddleware:
         self.claim_name = config.sasl_oauthbearer_sub_claim_name
         self.authentication_enabled = config.sasl_oauthbearer_authentication_enabled
         self.authorization_enabled = config.sasl_oauthbearer_authorization_enabled
-        self.client_id = config.sasl_oauthbearer_client_id
         self.sasl_oauthbearer_method_roles: dict[str, list[str]] = config.sasl_oauthbearer_method_roles
         self.sasl_oauthbearer_roles_claim_path = config.sasl_oauthbearer_roles_claim_path
         self.leeway_seconds = config.sasl_oauthbearer_leeway_seconds
         self.require_access_token_typ = config.sasl_oauthbearer_require_access_token_typ
-        self.enforce_azp = config.sasl_oauthbearer_enforce_azp
         self.allow_insecure_jwks = config.sasl_oauthbearer_allow_insecure_jwks
 
         # Hardcoded default algorithms
@@ -66,8 +64,6 @@ class OIDCMiddleware:
                 raise ValueError(
                     "OIDC config error: 'issuer' and 'audience' must be set if 'jwks_endpoint_url' is provided."
                 )
-            if self.enforce_azp and not self.client_id:
-                raise ValueError("OIDC config error: client_id is required when sasl_oauthbearer_enforce_azp is enabled.")
             log.info(
                 "OIDC middleware initialized — Bearer token validation enabled. jwks_url=%s issuer=%s audience=%s",
                 self.jwks_url,
@@ -89,10 +85,8 @@ class OIDCMiddleware:
 
             log.info("OIDC Authorization enabled: %s", self.authorization_enabled)
             if self.authorization_enabled:
-                if self.client_id is None or self.sasl_oauthbearer_roles_claim_path is None:
-                    raise ValueError(
-                        "OIDC config error: client_id and roles_claim_path are required when authorization is enabled."
-                    )
+                if self.sasl_oauthbearer_roles_claim_path is None:
+                    raise ValueError("OIDC config error: roles_claim_path is required when authorization is enabled.")
 
                 # Fail fast on incomplete ``method_roles`` rather than silently 403 at request time.
                 configured_methods = {m.upper() for m in self.sasl_oauthbearer_method_roles.keys()}
@@ -102,8 +96,7 @@ class OIDCMiddleware:
                         f"OIDC config error: method_roles is missing definitions for: {', '.join(sorted(missing_methods))}"
                     )
                 log.info(
-                    "OIDC Authorization configured. — client_id: %s, method_roles: %s, roles_claim_path: %s",
-                    self.client_id,
+                    "OIDC Authorization configured. — method_roles: %s, roles_claim_path: %s",
                     self.sasl_oauthbearer_method_roles,
                     self.sasl_oauthbearer_roles_claim_path,
                 )
@@ -125,7 +118,6 @@ class OIDCMiddleware:
         try:
             self._check_at_jwt_typ(token)
             payload = self._decode_and_verify(token)
-            self._check_azp(payload)
             return payload
         except ExpiredSignatureError:
             log.warning("JWT validation failed: token expired")
@@ -161,12 +153,6 @@ class OIDCMiddleware:
             options={"require": list(require)},
         )
 
-    def _check_azp(self, payload: dict) -> None:
-        if not self.enforce_azp:
-            return
-        if payload.get("azp") != self.client_id:
-            raise InvalidTokenError("azp claim does not match configured client_id")
-
     def authorize_request(self, payload: dict, request_method: str) -> bool:
         if not self.authorization_enabled:
             return True
@@ -175,13 +161,13 @@ class OIDCMiddleware:
         allowed_roles = self.sasl_oauthbearer_method_roles.get(request_method, [])
 
         # Dynamic role extraction based on configured path
-        if self.sasl_oauthbearer_roles_claim_path is not None and self.client_id is not None:
-            roles_claim_path = self.sasl_oauthbearer_roles_claim_path.replace("[client_id]", self.client_id)
+        if self.sasl_oauthbearer_roles_claim_path is not None:
+            roles_claim_path = self.sasl_oauthbearer_roles_claim_path
         else:
             # Same body as the role-mismatch branch below so an attacker cannot use the
             # response to distinguish a valid token with bad config from a token that
             # simply lacks the required role.
-            log.error("Authorization misconfigured: roles_claim_path or client_id is unset")
+            log.error("Authorization misconfigured: roles_claim_path is unset")
             raise HTTPException(status_code=403, detail="Forbidden")
 
         user_roles = self.get_roles_from_claim_path(payload, roles_claim_path)

--- a/src/karapace/core/AGENTS.md
+++ b/src/karapace/core/AGENTS.md
@@ -71,7 +71,7 @@ All env vars are prefixed `KARAPACE_`. The OIDC fields live on `Config`:
 | `sasl_oauthbearer_expected_audience` | `None` | Comma-separated list; required when JWKS is set. |
 | `sasl_oauthbearer_sub_claim_name` | `"sub"` | Claim exposed as `request.state.user`. |
 | `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT; required for authz. |
-| `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles. |
+| `sasl_oauthbearer_method_roles` | `DEFAULT_OIDC_METHOD_ROLES` (the `karapace.*` roles) | Per-method allowed roles. |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths. |
 | `schema_registry_client_cache_maxsize` | `100` | LRU cap on `(subject, version, fp)`. |
 | `registry_authfile` | `None` | Selects basic-auth `HTTPAuthorizer`. |

--- a/src/karapace/core/AGENTS.md
+++ b/src/karapace/core/AGENTS.md
@@ -70,8 +70,7 @@ All env vars are prefixed `KARAPACE_`. The OIDC fields live on `Config`:
 | `sasl_oauthbearer_expected_issuer` | `None` | Required when JWKS is set. |
 | `sasl_oauthbearer_expected_audience` | `None` | Comma-separated list; required when JWKS is set. |
 | `sasl_oauthbearer_sub_claim_name` | `"sub"` | Claim exposed as `request.state.user`. |
-| `sasl_oauthbearer_client_id` | `None` | Required for authz. Substituted into `[client_id]` in roles path. |
-| `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT. |
+| `sasl_oauthbearer_roles_claim_path` | `None` | Dot-path to roles list in JWT; required for authz. |
 | `sasl_oauthbearer_method_roles` | `{GET/POST/PUT/DELETE: []}` | Per-method allowed roles. |
 | `sasl_oauthbearer_skip_auth_paths` | `["/_health","/metrics"]` | Bypass paths. |
 | `schema_registry_client_cache_maxsize` | `100` | LRU cap on `(subject, version, fp)`. |

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -143,7 +143,6 @@ class Config(BaseSettings):
     sasl_oauthbearer_expected_issuer: str | None = None
     sasl_oauthbearer_expected_audience: str | None = None
     sasl_oauthbearer_sub_claim_name: str | None = "sub"
-    sasl_oauthbearer_client_id: str | None = None
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics", "/master_available"]
@@ -151,8 +150,6 @@ class Config(BaseSettings):
     sasl_oauthbearer_leeway_seconds: int = Field(default=0, ge=0)
     # Require header `typ: at+jwt` on access tokens.
     sasl_oauthbearer_require_access_token_typ: bool = False
-    # Enforce `azp == client_id`. Requires client_id.
-    sasl_oauthbearer_enforce_azp: bool = False
     # LRU cap on (subject, version, token_fingerprint) in the SR client. Raise for multi-tenant.
     schema_registry_client_cache_maxsize: int = 100
     # Kafka SASL client credentials (used by both services; selected by sasl_mechanism).
@@ -230,17 +227,6 @@ class Config(BaseSettings):
                 "Auto-enabling authentication for backwards compatibility."
             )
             self.sasl_oauthbearer_authentication_enabled = True
-        return self
-
-    @model_validator(mode="after")
-    def _enforce_azp_requires_client_id(self) -> Config:
-        # Catch misconfig at config-parse time, not just middleware construction.
-        # OIDCMiddleware also enforces this defensively for the case where Config is built
-        # directly (e.g. tests) bypassing this validator's failure path.
-        if self.sasl_oauthbearer_enforce_azp and not self.sasl_oauthbearer_client_id:
-            raise ValueError(
-                "OIDC config error: sasl_oauthbearer_client_id is required when " "sasl_oauthbearer_enforce_azp is enabled."
-            )
         return self
 
     def get_rest_base_uri(self) -> str:

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -11,7 +11,12 @@ from collections.abc import Mapping
 from copy import deepcopy
 from typing import Literal
 
-from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRODUCER_MAX_REQUEST, DEFAULT_SCHEMA_TOPIC
+from karapace.core.constants import (
+    DEFAULT_AIOHTTP_CLIENT_MAX_SIZE,
+    DEFAULT_OIDC_METHOD_ROLES,
+    DEFAULT_PRODUCER_MAX_REQUEST,
+    DEFAULT_SCHEMA_TOPIC,
+)
 from karapace.core.typing import ElectionStrategy, NameStrategy
 from karapace.core.utils import json_encode
 from pathlib import Path
@@ -144,7 +149,9 @@ class Config(BaseSettings):
     sasl_oauthbearer_expected_audience: str | None = None
     sasl_oauthbearer_sub_claim_name: str | None = "sub"
     sasl_oauthbearer_roles_claim_path: str | None = None
-    sasl_oauthbearer_method_roles: dict[str, list[str]] = {"GET": [], "POST": [], "PUT": [], "DELETE": []}
+    sasl_oauthbearer_method_roles: dict[str, list[str]] = Field(
+        default_factory=lambda: {method: list(roles) for method, roles in DEFAULT_OIDC_METHOD_ROLES.items()}
+    )
     sasl_oauthbearer_skip_auth_paths: list[str] = ["/_health", "/metrics", "/master_available"]
     # Clock-skew tolerance for exp/nbf/iat (seconds). 0 preserves prior strict behavior.
     sasl_oauthbearer_leeway_seconds: int = Field(default=0, ge=0)

--- a/src/karapace/core/constants.py
+++ b/src/karapace/core/constants.py
@@ -15,3 +15,22 @@ DEFAULT_AIOHTTP_CLIENT_MAX_SIZE: Final = 1048576
 
 SECOND: Final = 1000
 MINUTE: Final = 60 * SECOND
+
+# OIDC authorization role names. Must match the roles the IdP mints into tokens.
+OIDC_ROLE_PREFIX: Final = "karapace."
+OIDC_ROLE_SCHEMA_READ: Final = f"{OIDC_ROLE_PREFIX}schema:read"
+OIDC_ROLE_SCHEMA_WRITE: Final = f"{OIDC_ROLE_PREFIX}schema:write"
+OIDC_ROLE_SCHEMA_DELETE: Final = f"{OIDC_ROLE_PREFIX}schema:delete"
+OIDC_ROLE_SUBJECT_READ: Final = f"{OIDC_ROLE_PREFIX}subject:read"
+OIDC_ROLE_SUBJECT_WRITE: Final = f"{OIDC_ROLE_PREFIX}subject:write"
+OIDC_ROLE_SUBJECT_DELETE: Final = f"{OIDC_ROLE_PREFIX}subject:delete"
+OIDC_ROLE_CONFIG_SUBJECT_UPDATE: Final = f"{OIDC_ROLE_PREFIX}config_subject:update"
+OIDC_ROLE_CONFIG_GLOBAL_UPDATE: Final = f"{OIDC_ROLE_PREFIX}config_global:update"
+
+# Default OIDC method → allowed roles mapping. Mirrors the reference Keycloak realm.
+DEFAULT_OIDC_METHOD_ROLES: Final[dict[str, list[str]]] = {
+    "GET": [OIDC_ROLE_SCHEMA_READ, OIDC_ROLE_SUBJECT_READ],
+    "POST": [OIDC_ROLE_SCHEMA_WRITE, OIDC_ROLE_SUBJECT_WRITE],
+    "PUT": [OIDC_ROLE_CONFIG_SUBJECT_UPDATE, OIDC_ROLE_CONFIG_GLOBAL_UPDATE],
+    "DELETE": [OIDC_ROLE_SCHEMA_DELETE, OIDC_ROLE_SUBJECT_DELETE],
+}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -158,10 +158,21 @@ def oidc_token():
     return response.json()["access_token"]
 
 
+# Full OIDC (authn + authz) SR — karapace-schema-registry-oidc, profile: e2e.
+
+
+@pytest.fixture(scope="function", name="registry_oidc_cluster")
+async def fixture_registry_oidc_cluster(
+    loop: asyncio.AbstractEventLoop,
+) -> RegistryDescription:
+    endpoint = RegistryEndpoint("https", "karapace-schema-registry-oidc", 8091)
+    return RegistryDescription(endpoint, "_schemas_oidc")
+
+
 @pytest.fixture(scope="function", name="registry_async_client_oidc")
 async def fixture_registry_async_client_oidc(
     request: SubRequest,
-    registry_cluster: RegistryDescription,
+    registry_oidc_cluster: RegistryDescription,
     loop: asyncio.AbstractEventLoop,
     oidc_token,
 ) -> AsyncGenerator[Client, None]:
@@ -169,7 +180,7 @@ async def fixture_registry_async_client_oidc(
         return ClientSession(headers={"Authorization": f"Bearer {oidc_token}"})
 
     client = Client(
-        server_uri=registry_cluster.endpoint.to_url(),
+        server_uri=registry_oidc_cluster.endpoint.to_url(),
         server_ca=request.config.getoption("server_ca"),
         client_factory=factory,
         session_auth=None,
@@ -183,7 +194,7 @@ async def fixture_registry_async_client_oidc(
 @pytest.fixture(scope="function", name="registry_async_client_oidc_invalid")
 async def fixture_registry_async_client_oidc_invalid(
     request: SubRequest,
-    registry_cluster: RegistryDescription,
+    registry_oidc_cluster: RegistryDescription,
     loop: asyncio.AbstractEventLoop,
     oidc_token,
 ) -> AsyncGenerator[Client, None]:
@@ -191,7 +202,7 @@ async def fixture_registry_async_client_oidc_invalid(
         return ClientSession(headers={"Authorization": "Bearer invalid_token"})
 
     client = Client(
-        server_uri=registry_cluster.endpoint.to_url(),
+        server_uri=registry_oidc_cluster.endpoint.to_url(),
         server_ca=request.config.getoption("server_ca"),
         client_factory=factory,
         session_auth=None,
@@ -205,13 +216,13 @@ async def fixture_registry_async_client_oidc_invalid(
 @pytest.fixture(scope="function", name="registry_async_client_oidc_no_auth_header")
 async def registry_async_client_oidc_no_auth_header(
     request: SubRequest,
-    registry_cluster: RegistryDescription,
+    registry_oidc_cluster: RegistryDescription,
 ) -> AsyncGenerator[Client, None]:
     async def factory(auth):
         return ClientSession(headers={})
 
     client = Client(
-        server_uri=registry_cluster.endpoint.to_url(),
+        server_uri=registry_oidc_cluster.endpoint.to_url(),
         server_ca=request.config.getoption("server_ca"),
         client_factory=factory,
         session_auth=None,

--- a/tests/unit/api/test_middlewares.py
+++ b/tests/unit/api/test_middlewares.py
@@ -32,7 +32,6 @@ def _oidc_config(**overrides) -> Config:
         "sasl_oauthbearer_expected_issuer": "https://oidc.test/realms/r",
         "sasl_oauthbearer_expected_audience": "audience",
         "sasl_oauthbearer_sub_claim_name": "sub",
-        "sasl_oauthbearer_client_id": "client-id",
         "sasl_oauthbearer_roles_claim_path": "realm_access.roles",
     }
     base.update(overrides)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,11 @@ See LICENSE for details
 """
 
 from karapace.core.config import Config
-from karapace.core.constants import DEFAULT_AIOHTTP_CLIENT_MAX_SIZE, DEFAULT_PRODUCER_MAX_REQUEST
+from karapace.core.constants import (
+    DEFAULT_AIOHTTP_CLIENT_MAX_SIZE,
+    DEFAULT_OIDC_METHOD_ROLES,
+    DEFAULT_PRODUCER_MAX_REQUEST,
+)
 
 
 def test_http_request_max_size() -> None:
@@ -39,3 +43,20 @@ def test_http_request_max_size() -> None:
     config.http_request_max_size = 1024
     config.producer_max_request_size = DEFAULT_PRODUCER_MAX_REQUEST + 1024
     assert config.get_max_request_size() == 1024
+
+
+def test_method_roles_default_uses_prefixed_roles() -> None:
+    config = Config()
+    assert config.sasl_oauthbearer_method_roles == DEFAULT_OIDC_METHOD_ROLES
+    # All default role names carry the karapace. prefix.
+    all_roles = [role for roles in config.sasl_oauthbearer_method_roles.values() for role in roles]
+    assert all_roles and all(role.startswith("karapace.") for role in all_roles)
+
+
+def test_method_roles_default_is_isolated_per_instance() -> None:
+    # default_factory must deep-copy so mutating one Config never leaks into another.
+    a = Config()
+    b = Config()
+    a.sasl_oauthbearer_method_roles["GET"].append("karapace.extra:role")
+    assert "karapace.extra:role" not in b.sasl_oauthbearer_method_roles["GET"]
+    assert "karapace.extra:role" not in DEFAULT_OIDC_METHOD_ROLES["GET"]

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -38,14 +38,12 @@ class DummyConfig:
     sasl_oauthbearer_sub_claim_name: str | None
     sasl_oauthbearer_authorization_enabled: bool
     sasl_oauthbearer_authentication_enabled: bool = False
-    sasl_oauthbearer_client_id: str | None = None
     sasl_oauthbearer_roles_claim_path: str | None = None
     sasl_oauthbearer_method_roles: dict[str, list[str]] = field(
         default_factory=lambda: {"GET": [], "POST": [], "PUT": [], "DELETE": []}
     )
     sasl_oauthbearer_leeway_seconds: int = 30
     sasl_oauthbearer_require_access_token_typ: bool = False
-    sasl_oauthbearer_enforce_azp: bool = False
     sasl_oauthbearer_allow_insecure_jwks = False
 
 
@@ -56,7 +54,6 @@ valid_configs = [
         sasl_oauthbearer_expected_audience="accounts-audience",
         sasl_oauthbearer_sub_claim_name="sub",
         sasl_oauthbearer_authorization_enabled=False,
-        sasl_oauthbearer_client_id=None,
         sasl_oauthbearer_roles_claim_path=None,
         sasl_oauthbearer_method_roles={"GET": [], "POST": [], "PUT": [], "DELETE": []},
     ),
@@ -66,7 +63,6 @@ valid_configs = [
         sasl_oauthbearer_expected_audience=None,
         sasl_oauthbearer_sub_claim_name=None,
         sasl_oauthbearer_authorization_enabled=False,
-        sasl_oauthbearer_client_id=None,
         sasl_oauthbearer_roles_claim_path=None,
         sasl_oauthbearer_method_roles={"GET": [], "POST": [], "PUT": [], "DELETE": []},
     ),
@@ -79,7 +75,6 @@ invalid_configs = [
         sasl_oauthbearer_expected_audience="accounts-audience",
         sasl_oauthbearer_sub_claim_name="sub",
         sasl_oauthbearer_authorization_enabled=False,
-        sasl_oauthbearer_client_id=None,
         sasl_oauthbearer_roles_claim_path=None,
         sasl_oauthbearer_method_roles={"GET": [], "POST": [], "PUT": [], "DELETE": []},
     ),
@@ -89,7 +84,6 @@ invalid_configs = [
         sasl_oauthbearer_expected_audience=None,
         sasl_oauthbearer_sub_claim_name="sub",
         sasl_oauthbearer_authorization_enabled=False,
-        sasl_oauthbearer_client_id=None,
         sasl_oauthbearer_roles_claim_path=None,
         sasl_oauthbearer_method_roles={"GET": [], "POST": [], "PUT": [], "DELETE": []},
     ),
@@ -266,7 +260,6 @@ def test_authorize_request_roles(monkeypatch, roles, method, method_roles, expec
         sasl_oauthbearer_authorization_enabled=True,
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
         sasl_oauthbearer_method_roles=method_roles,
-        sasl_oauthbearer_client_id="client-id",
     )
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
 
@@ -451,7 +444,6 @@ def test_middleware_authn_and_authz_calls_authorize(monkeypatch):
     config = _oidc_config(
         sasl_oauthbearer_authentication_enabled=True,
         sasl_oauthbearer_authorization_enabled=True,
-        sasl_oauthbearer_client_id="client-id",
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
     )
     monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
@@ -470,7 +462,6 @@ def test_middleware_authn_and_authz_returns_403_on_role_failure(monkeypatch):
     config = _oidc_config(
         sasl_oauthbearer_authentication_enabled=True,
         sasl_oauthbearer_authorization_enabled=True,
-        sasl_oauthbearer_client_id="client-id",
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
     )
     monkeypatch.setattr(OIDCMiddleware, "authorize_request", _deny)
@@ -541,7 +532,7 @@ def test_middleware_invalid_token_still_returns_invalid_reason(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Hardening: leeway, require sub, log reason, audience guard, typ:at+jwt, azp.
+# Hardening: leeway, require sub, log reason, audience guard, typ:at+jwt.
 # ---------------------------------------------------------------------------
 
 
@@ -651,67 +642,18 @@ def test_validate_jwt_typ_check_skipped_when_flag_off(mock_jwt_decode, mock_unve
 
 
 @patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
-def test_validate_jwt_azp_enforced_accepts(mock_jwt_decode, mock_pyjwks_client):
+def test_authorization_enabled_without_client_id_is_accepted(mock_pyjwks_client):
+    """Authz needs only a static roles_claim_path — client_id is no longer required."""
     mock_pyjwks_client.return_value = MagicMock()
-    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
-    mock_jwt_decode.return_value = {"sub": "u", "azp": "client-id"}
-
     config = _oidc_config(
         sasl_oauthbearer_authentication_enabled=True,
-        sasl_oauthbearer_enforce_azp=True,
-        sasl_oauthbearer_client_id="client-id",
+        sasl_oauthbearer_authorization_enabled=True,
+        sasl_oauthbearer_roles_claim_path="realm_access.roles",
+        sasl_oauthbearer_method_roles={"GET": ["reader"], "POST": ["admin"], "PUT": ["admin"], "DELETE": ["admin"]},
     )
     middleware = OIDCMiddleware(app=MagicMock(), config=config)
-    assert middleware.validate_jwt("good.jwt.token")["azp"] == "client-id"
-
-
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
-def test_validate_jwt_azp_enforced_rejects_mismatch(mock_jwt_decode, mock_pyjwks_client):
-    mock_pyjwks_client.return_value = MagicMock()
-    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
-    mock_jwt_decode.return_value = {"sub": "u", "azp": "other-client"}
-
-    config = _oidc_config(
-        sasl_oauthbearer_authentication_enabled=True,
-        sasl_oauthbearer_enforce_azp=True,
-        sasl_oauthbearer_client_id="client-id",
-    )
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
-    with pytest.raises(AuthenticationError, match="Invalid OIDC token"):
-        middleware.validate_jwt("good.jwt.token")
-
-
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
-def test_validate_jwt_azp_check_skipped_when_flag_off(mock_jwt_decode, mock_pyjwks_client):
-    mock_pyjwks_client.return_value = MagicMock()
-    mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
-    mock_jwt_decode.return_value = {"sub": "u", "azp": "anything-goes"}
-
-    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_client_id="client-id")
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
-    assert middleware.validate_jwt("good.jwt.token")["azp"] == "anything-goes"
-
-
-def test_config_rejects_enforce_azp_without_client_id():
-    """Config-level validator catches the misconfig at parse time (before middleware construction)."""
-    with pytest.raises(ValueError, match="client_id is required"):
-        _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_enforce_azp=True)
-
-
-def test_oidc_middleware_requires_client_id_when_azp_enforced():
-    """Middleware-level guard: catches the misconfig when Config is constructed bypassing the
-    Pydantic validator (e.g. by mutating fields directly, as tests can do)."""
-    config = _oidc_config(
-        sasl_oauthbearer_authentication_enabled=True,
-        sasl_oauthbearer_enforce_azp=True,
-        sasl_oauthbearer_client_id="client-id",
-    )
-    config.sasl_oauthbearer_client_id = None  # bypass Pydantic validator
-    with pytest.raises(ValueError, match="client_id is required"):
-        OIDCMiddleware(app=MagicMock(), config=config)
+    payload = {"realm_access": {"roles": ["reader"]}}
+    assert middleware.authorize_request(payload, "GET") is True
 
 
 @patch("karapace.api.oidc.middleware.PyJWKClient")
@@ -763,8 +705,7 @@ def _authz_config(method_roles: dict[str, list[str]]) -> Config:
     return _oidc_config(
         sasl_oauthbearer_authentication_enabled=True,
         sasl_oauthbearer_authorization_enabled=True,
-        sasl_oauthbearer_client_id="karapace-client",
-        sasl_oauthbearer_roles_claim_path="resource_access.[client_id].roles",
+        sasl_oauthbearer_roles_claim_path="resource_access.karapace-client.roles",
         sasl_oauthbearer_method_roles=method_roles,
     )
 

--- a/tests/unit/test_oidc_startup.py
+++ b/tests/unit/test_oidc_startup.py
@@ -30,7 +30,6 @@ def test_karapace_startup_fails_when_method_roles_incomplete() -> None:
             "KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL": "https://idp.example.invalid/realms/r/protocol/openid-connect/certs",
             "KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER": "https://idp.example.invalid/realms/r",
             "KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE": "test-audience",
-            "KARAPACE_SASL_OAUTHBEARER_CLIENT_ID": "karapace-client",
             "KARAPACE_SASL_OAUTHBEARER_ROLES_CLAIM_PATH": "resource_access.karapace-client.roles",
             # Missing DELETE — should be rejected at startup.
             "KARAPACE_SASL_OAUTHBEARER_METHOD_ROLES": '{"GET": ["r"], "POST": ["w"], "PUT": ["w"]}',


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- karapace JWKS config should be agnostic of which client token is being handled. sasl_oauthbearer_client_id should be removed.
      sasl_oauthbearer_client_id cannot be be removed as there are two dependencies. azp (Authorized Party) and keycloak role path. These are not needed. Hence, will be removed.

- sasl_oauthbearer_method_roles has roles like schema:read schema:write, which can be standardized (constants)
- Remove oidc from smoke tests. oidc tests are in e2e anyways.
- Adding e2e tests for authz

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
