### PR TITLE
Upgrade protobuf and confluent-kafka and few others

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ source venv/bin/activate
 pip install -e ".[dev]"     # development install (includes test/lint deps)
 ```
 
-Requires Python 3.12+, Go, Rust, and protoc < 3.20.0.
+Requires Python 3.12+, Go, Rust, and protoc whose major is not ahead of the pinned `protobuf` runtime lib (currently 5.29.x); an older protoc is fine.
 
 ### Running services locally
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "jsonschema",
   "lz4",
   "networkx",
-  "protobuf==3.20.3",
+  "protobuf==5.29.6",
   "pydantic",
   "pydantic-settings",
   "pyjwt",
@@ -38,7 +38,7 @@ dependencies = [
   "opentelemetry-api",
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
-  "opentelemetry-proto<1.28.0",
+  "opentelemetry-proto",
   "dependency-injector",
 
   # Patched dependencies
@@ -105,7 +105,7 @@ typing = [
   "sentry-sdk",
   "types-cachetools",
   "types-jsonschema",
-  "types-protobuf < 4"
+  "types-protobuf < 6"
 ]
 
 [tool.setuptools]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,9 +6,9 @@
 #
 accept-types==0.4.1
     # via karapace (/karapace/pyproject.toml)
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via karapace (/karapace/pyproject.toml)
 aiokafka==0.12.0
     # via karapace (/karapace/pyproject.toml)
@@ -20,7 +20,7 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
@@ -36,47 +36,44 @@ attrs==26.1.0
     #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via karapace (/karapace/pyproject.toml)
-backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
 bidict==0.23.1
     # via python-socketio
 blinker==1.9.0
     # via flask
 brotli==1.2.0
     # via geventhttpclient
-cachetools==7.0.5
+cachetools==7.1.4
     # via karapace (/karapace/pyproject.toml)
-certifi==2026.2.25
+certifi==2026.6.17
     # via
     #   geventhttpclient
     #   httpcore
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.9
     # via requests
-click==8.3.1
+click==8.4.2
     # via
     #   flask
     #   rich-toolkit
-    #   typer
     #   uvicorn
 configargparse==1.7.5
     # via locust
-confluent-kafka==2.13.2
+confluent-kafka==2.15.0
     # via karapace (/karapace/pyproject.toml)
-coverage[toml]==7.13.5
+coverage[toml]==7.15.1
     # via pytest-cov
 cramjam==2.11.0
     # via python-snappy
-cryptography==46.0.6
+cryptography==49.0.0
     # via karapace (/karapace/pyproject.toml)
-dependency-injector==4.49.0
+dependency-injector==4.49.1
     # via karapace (/karapace/pyproject.toml)
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dnspython==2.8.0
     # via email-validator
 email-validator==2.3.0
@@ -87,22 +84,24 @@ execnet==2.1.2
     # via pytest-xdist
 fancycompleter==0.11.1
     # via pdbpp
-fastapi[standard]==0.135.2
+fastapi[standard]==0.139.0
     # via karapace (/karapace/pyproject.toml)
-fastapi-cli[standard]==0.0.24
+fastapi-cli[standard]==0.0.29
     # via fastapi
-fastapi-cloud-cli==0.15.1
+fastapi-cloud-cli==0.22.2
     # via fastapi-cli
-fastar==0.9.0
-    # via fastapi-cloud-cli
-filelock==3.25.2
+fastar==0.11.0
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
+filelock==3.29.7
     # via karapace (/karapace/pyproject.toml)
 flask==3.1.3
     # via
     #   flask-cors
     #   flask-login
     #   locust
-flask-cors==6.0.2
+flask-cors==6.0.5
     # via locust
 flask-login==0.6.3
     # via locust
@@ -116,13 +115,13 @@ gevent==25.9.1
     #   locust
 geventhttpclient==2.3.9
     # via locust
-googleapis-common-protos==1.73.0
+googleapis-common-protos==1.75.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.3.2
+greenlet==3.5.3
     # via gevent
-grpcio==1.78.0
+grpcio==1.82.1
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
@@ -131,23 +130,21 @@ h11==0.16.0
     #   wsproto
 httpcore==1.0.9
     # via httpx
-httptools==0.7.1
+httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
     # via
     #   fastapi
     #   fastapi-cloud-cli
-hypothesis==6.151.10
+hypothesis==6.156.6
     # via karapace (/karapace/pyproject.toml)
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 itsdangerous==2.2.0
@@ -160,11 +157,11 @@ jsonschema==4.26.0
     # via karapace (/karapace/pyproject.toml)
 jsonschema-specifications==2025.9.1
     # via jsonschema
-locust==2.43.3
+locust==2.45.0
     # via karapace (/karapace/pyproject.toml)
 lz4==4.4.5
     # via karapace (/karapace/pyproject.toml)
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via
@@ -173,7 +170,7 @@ markupsafe==3.0.3
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.1.2
+msgpack==1.2.1
     # via locust
 multidict==6.7.1
     # via
@@ -181,34 +178,39 @@ multidict==6.7.1
     #   yarl
 networkx==3.6.1
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-api==1.40.0
+opentelemetry-api==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.15.0
+opentelemetry-exporter-otlp==1.43.0
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-exporter-otlp-proto-grpc==1.15.0
+opentelemetry-exporter-otlp-proto-common==1.43.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.15.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-proto==1.15.0
+opentelemetry-proto==1.43.0
+    # via
+    #   karapace (/karapace/pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
-    # via
-    #   karapace (/karapace/pyproject.toml)
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.64b0
     # via opentelemetry-sdk
-orjson==3.11.7
+orjson==3.11.9
     # via karapace (/karapace/pyproject.toml)
-packaging==26.0
+packaging==26.2
     # via
     #   aiokafka
     #   pytest
@@ -218,17 +220,17 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.0.2
     # via karapace (/karapace/pyproject.toml)
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-protobuf==3.20.3
+protobuf==5.29.6
     # via
     #   googleapis-common-protos
     #   karapace (/karapace/pyproject.toml)
@@ -240,18 +242,18 @@ psutil==7.2.2
     #   pytest-xdist
 pycparser==3.0
     # via cffi
-pydantic[email]==2.12.5
+pydantic[email]==2.13.4
     # via
     #   fastapi
     #   fastapi-cloud-cli
     #   karapace (/karapace/pyproject.toml)
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via pydantic
 pydantic-extra-types==2.11.1
     # via fastapi
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via
     #   fastapi
     #   karapace (/karapace/pyproject.toml)
@@ -260,11 +262,11 @@ pygments==2.20.0
     #   pdbpp
     #   pytest
     #   rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via karapace (/karapace/pyproject.toml)
 pyrepl==0.11.4
     # via fancycompleter
-pytest==9.0.2
+pytest==9.1.1
     # via
     #   karapace (/karapace/pyproject.toml)
     #   locust
@@ -286,15 +288,15 @@ python-dotenv==1.2.2
     # via
     #   pydantic-settings
     #   uvicorn
-python-engineio==4.13.1
+python-engineio==4.13.3
     # via
     #   locust
     #   python-socketio
-python-multipart==0.0.22
+python-multipart==0.0.32
     # via fastapi
 python-snappy==0.7.3
     # via karapace (/karapace/pyproject.toml)
-python-socketio[client]==5.16.1
+python-socketio[client]==5.16.3
     # via locust
 pyyaml==6.0.3
     # via uvicorn
@@ -304,29 +306,29 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.0
+requests==2.34.2
     # via
     #   karapace (/karapace/pyproject.toml)
     #   locust
     #   opentelemetry-exporter-otlp-proto-http
     #   python-socketio
-rich==14.3.3
+rich==15.0.0
     # via
     #   rich-toolkit
     #   typer
-rich-toolkit==0.19.7
+rich-toolkit==0.20.3
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
 rignore==0.7.6
     # via fastapi-cloud-cli
-rpds-py==0.30.0
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.8
+ruff==0.15.21
     # via karapace (/karapace/pyproject.toml)
-sentry-sdk==2.56.0
+sentry-sdk==2.65.0
     # via
     #   fastapi-cloud-cli
     #   karapace (/karapace/pyproject.toml)
@@ -338,18 +340,19 @@ six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via hypothesis
-starlette==0.52.1
+starlette==1.3.1
     # via
     #   fastapi
     #   prometheus-fastapi-instrumentator
 tenacity==9.1.4
     # via karapace (/karapace/pyproject.toml)
-typer==0.24.1
+typer==0.26.8
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
+    #   aiohttp
     #   aiokafka
     #   aiosignal
     #   anyio
@@ -358,6 +361,8 @@ typing-extensions==4.15.0
     #   grpcio
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pydantic
@@ -372,29 +377,29 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-ujson==5.12.0
+ujson==5.13.0
     # via karapace (/karapace/pyproject.toml)
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   geventhttpclient
     #   requests
     #   sentry-sdk
-uvicorn[standard]==0.42.0
+uvicorn[standard]==0.51.0
     # via
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
 uvloop==0.22.1
     # via uvicorn
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   uvicorn
 websocket-client==1.9.0
     # via python-socketio
-websockets==16.0
+websockets==16.1
     # via uvicorn
-werkzeug==3.1.7
+werkzeug==3.1.8
     # via
     #   flask
     #   flask-cors
@@ -402,15 +407,13 @@ werkzeug==3.1.7
     #   locust
 wsproto==1.3.2
     # via simple-websocket
-yarl==1.23.0
+yarl==1.24.2
     # via
     #   aiohttp
     #   karapace (/karapace/pyproject.toml)
-zipp==3.23.0
-    # via importlib-metadata
-zope-event==6.1
+zope-event==6.2
     # via gevent
-zope-interface==8.2
+zope-interface==8.5
     # via gevent
 zstandard==0.25.0
     # via karapace (/karapace/pyproject.toml)

--- a/requirements/requirements-typing.txt
+++ b/requirements/requirements-typing.txt
@@ -6,9 +6,9 @@
 #
 accept-types==0.4.1
     # via karapace (/karapace/pyproject.toml)
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via karapace (/karapace/pyproject.toml)
 aiokafka==0.12.0
     # via karapace (/karapace/pyproject.toml)
@@ -20,11 +20,13 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
     #   watchfiles
+ast-serialize==0.6.0
+    # via mypy
 async-lru==2.3.0
     # via karapace (/karapace/pyproject.toml)
 async-timeout==5.0.1
@@ -36,58 +38,57 @@ attrs==26.1.0
     #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via karapace (/karapace/pyproject.toml)
-backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-cachetools==7.0.5
+cachetools==7.1.4
     # via karapace (/karapace/pyproject.toml)
-certifi==2026.2.25
+certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.9
     # via requests
-click==8.3.1
+click==8.4.2
     # via
     #   rich-toolkit
-    #   typer
     #   uvicorn
-confluent-kafka==2.13.2
+confluent-kafka==2.15.0
     # via karapace (/karapace/pyproject.toml)
 cramjam==2.11.0
     # via python-snappy
-cryptography==46.0.6
+cryptography==49.0.0
     # via karapace (/karapace/pyproject.toml)
-dependency-injector==4.49.0
+dependency-injector==4.49.1
     # via karapace (/karapace/pyproject.toml)
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dnspython==2.8.0
     # via email-validator
 email-validator==2.3.0
     # via
     #   fastapi
     #   pydantic
-fastapi[standard]==0.135.2
+fastapi[standard]==0.139.0
     # via karapace (/karapace/pyproject.toml)
-fastapi-cli[standard]==0.0.24
+fastapi-cli[standard]==0.0.29
     # via fastapi
-fastapi-cloud-cli==0.15.1
+fastapi-cloud-cli==0.22.2
     # via fastapi-cli
-fastar==0.9.0
-    # via fastapi-cloud-cli
+fastar==0.11.0
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
 frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.73.0
+googleapis-common-protos==1.75.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.78.0
+grpcio==1.82.1
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
@@ -95,32 +96,30 @@ h11==0.16.0
     #   uvicorn
 httpcore==1.0.9
     # via httpx
-httptools==0.7.1
+httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
     # via
     #   fastapi
     #   fastapi-cloud-cli
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via fastapi
 jsonschema==4.26.0
     # via karapace (/karapace/pyproject.toml)
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.8.1
+librt==0.13.0
     # via mypy
 lz4==4.4.5
     # via karapace (/karapace/pyproject.toml)
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
@@ -130,78 +129,83 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-mypy==1.19.1
+mypy==2.3.0
     # via karapace (/karapace/pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
 networkx==3.6.1
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-api==1.40.0
+opentelemetry-api==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.15.0
+opentelemetry-exporter-otlp==1.43.0
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-exporter-otlp-proto-grpc==1.15.0
+opentelemetry-exporter-otlp-proto-common==1.43.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.15.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-proto==1.15.0
+opentelemetry-proto==1.43.0
+    # via
+    #   karapace (/karapace/pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
-    # via
-    #   karapace (/karapace/pyproject.toml)
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.64b0
     # via opentelemetry-sdk
-orjson==3.11.7
+orjson==3.11.9
     # via karapace (/karapace/pyproject.toml)
-packaging==26.0
+packaging==26.2
     # via aiokafka
-pathspec==1.0.4
+pathspec==1.1.1
     # via mypy
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.0.2
     # via karapace (/karapace/pyproject.toml)
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-protobuf==3.20.3
+protobuf==5.29.6
     # via
     #   googleapis-common-protos
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-proto
 pycparser==3.0
     # via cffi
-pydantic[email]==2.12.5
+pydantic[email]==2.13.4
     # via
     #   fastapi
     #   fastapi-cloud-cli
     #   karapace (/karapace/pyproject.toml)
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via pydantic
 pydantic-extra-types==2.11.1
     # via fastapi
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via
     #   fastapi
     #   karapace (/karapace/pyproject.toml)
 pygments==2.20.0
     # via rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via karapace (/karapace/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via karapace (/karapace/pyproject.toml)
@@ -209,7 +213,7 @@ python-dotenv==1.2.2
     # via
     #   pydantic-settings
     #   uvicorn
-python-multipart==0.0.22
+python-multipart==0.0.32
     # via fastapi
 python-snappy==0.7.3
     # via karapace (/karapace/pyproject.toml)
@@ -220,23 +224,23 @@ referencing==0.37.0
     #   jsonschema
     #   jsonschema-specifications
     #   types-jsonschema
-requests==2.33.0
+requests==2.34.2
     # via opentelemetry-exporter-otlp-proto-http
-rich==14.3.3
+rich==15.0.0
     # via
     #   rich-toolkit
     #   typer
-rich-toolkit==0.19.7
+rich-toolkit==0.20.3
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
 rignore==0.7.6
     # via fastapi-cloud-cli
-rpds-py==0.30.0
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-sentry-sdk==2.56.0
+sentry-sdk==2.65.0
     # via
     #   fastapi-cloud-cli
     #   karapace (/karapace/pyproject.toml)
@@ -244,24 +248,25 @@ shellingham==1.5.4
     # via typer
 six==1.17.0
     # via python-dateutil
-starlette==0.52.1
+starlette==1.3.1
     # via
     #   fastapi
     #   prometheus-fastapi-instrumentator
 tenacity==9.1.4
     # via karapace (/karapace/pyproject.toml)
-typer==0.24.1
+typer==0.26.8
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
-types-cachetools==6.2.0.20260317
+types-cachetools==7.0.0.20260713
     # via karapace (/karapace/pyproject.toml)
-types-jsonschema==4.26.0.20260325
+types-jsonschema==4.26.0.20260518
     # via karapace (/karapace/pyproject.toml)
-types-protobuf==3.20.4.6
+types-protobuf==5.29.1.20250403
     # via karapace (/karapace/pyproject.toml)
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
+    #   aiohttp
     #   aiokafka
     #   aiosignal
     #   anyio
@@ -271,6 +276,8 @@ typing-extensions==4.15.0
     #   karapace (/karapace/pyproject.toml)
     #   mypy
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pydantic
@@ -285,30 +292,28 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-ujson==5.12.0
+ujson==5.13.0
     # via karapace (/karapace/pyproject.toml)
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   requests
     #   sentry-sdk
-uvicorn[standard]==0.42.0
+uvicorn[standard]==0.51.0
     # via
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
 uvloop==0.22.1
     # via uvicorn
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   uvicorn
-websockets==16.0
+websockets==16.1
     # via uvicorn
-yarl==1.23.0
+yarl==1.24.2
     # via
     #   aiohttp
     #   karapace (/karapace/pyproject.toml)
-zipp==3.23.0
-    # via importlib-metadata
 zstandard==0.25.0
     # via karapace (/karapace/pyproject.toml)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,9 +6,9 @@
 #
 accept-types==0.4.1
     # via karapace (/karapace/pyproject.toml)
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.7.1
     # via aiohttp
-aiohttp==3.13.4
+aiohttp==3.14.1
     # via karapace (/karapace/pyproject.toml)
 aiokafka==0.12.0
     # via karapace (/karapace/pyproject.toml)
@@ -20,7 +20,7 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anyio==4.13.0
+anyio==4.14.2
     # via
     #   httpx
     #   starlette
@@ -36,58 +36,57 @@ attrs==26.1.0
     #   referencing
 avro @ https://github.com/aiven/avro/archive/5a82d57f2a650fd87c819a30e433f1abb2c76ca2.tar.gz#subdirectory=lang/py
     # via karapace (/karapace/pyproject.toml)
-backoff==2.2.1
-    # via
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-cachetools==7.0.5
+cachetools==7.1.4
     # via karapace (/karapace/pyproject.toml)
-certifi==2026.2.25
+certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.1.0
     # via cryptography
-charset-normalizer==3.4.6
+charset-normalizer==3.4.9
     # via requests
-click==8.3.1
+click==8.4.2
     # via
     #   rich-toolkit
-    #   typer
     #   uvicorn
-confluent-kafka==2.13.2
+confluent-kafka==2.15.0
     # via karapace (/karapace/pyproject.toml)
 cramjam==2.11.0
     # via python-snappy
-cryptography==46.0.6
+cryptography==49.0.0
     # via karapace (/karapace/pyproject.toml)
-dependency-injector==4.49.0
+dependency-injector==4.49.1
     # via karapace (/karapace/pyproject.toml)
+detect-installer==0.1.0
+    # via fastapi-cloud-cli
 dnspython==2.8.0
     # via email-validator
 email-validator==2.3.0
     # via
     #   fastapi
     #   pydantic
-fastapi[standard]==0.135.2
+fastapi[standard]==0.139.0
     # via karapace (/karapace/pyproject.toml)
-fastapi-cli[standard]==0.0.24
+fastapi-cli[standard]==0.0.29
     # via fastapi
-fastapi-cloud-cli==0.15.1
+fastapi-cloud-cli==0.22.2
     # via fastapi-cli
-fastar==0.9.0
-    # via fastapi-cloud-cli
+fastar==0.11.0
+    # via
+    #   fastapi
+    #   fastapi-cloud-cli
 frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.73.0
+googleapis-common-protos==1.75.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.78.0
+grpcio==1.82.1
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
@@ -95,21 +94,19 @@ h11==0.16.0
     #   uvicorn
 httpcore==1.0.9
     # via httpx
-httptools==0.7.1
+httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
     # via
     #   fastapi
     #   fastapi-cloud-cli
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via fastapi
 jsonschema==4.26.0
@@ -118,7 +115,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 lz4==4.4.5
     # via karapace (/karapace/pyproject.toml)
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
@@ -130,70 +127,75 @@ multidict==6.7.1
     #   yarl
 networkx==3.6.1
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-api==1.40.0
+opentelemetry-api==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.15.0
+opentelemetry-exporter-otlp==1.43.0
     # via karapace (/karapace/pyproject.toml)
-opentelemetry-exporter-otlp-proto-grpc==1.15.0
+opentelemetry-exporter-otlp-proto-common==1.43.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.15.0
+opentelemetry-exporter-otlp-proto-http==1.43.0
     # via opentelemetry-exporter-otlp
-opentelemetry-proto==1.15.0
+opentelemetry-proto==1.43.0
+    # via
+    #   karapace (/karapace/pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.43.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
-    # via
-    #   karapace (/karapace/pyproject.toml)
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.64b0
     # via opentelemetry-sdk
-orjson==3.11.7
+orjson==3.11.9
     # via karapace (/karapace/pyproject.toml)
-packaging==26.0
+packaging==26.2
     # via aiokafka
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.0.2
     # via karapace (/karapace/pyproject.toml)
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-protobuf==3.20.3
+protobuf==5.29.6
     # via
     #   googleapis-common-protos
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-proto
 pycparser==3.0
     # via cffi
-pydantic[email]==2.12.5
+pydantic[email]==2.13.4
     # via
     #   fastapi
     #   fastapi-cloud-cli
     #   karapace (/karapace/pyproject.toml)
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via pydantic
 pydantic-extra-types==2.11.1
     # via fastapi
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via
     #   fastapi
     #   karapace (/karapace/pyproject.toml)
 pygments==2.20.0
     # via rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via karapace (/karapace/pyproject.toml)
 python-dateutil==2.9.0.post0
     # via karapace (/karapace/pyproject.toml)
@@ -201,7 +203,7 @@ python-dotenv==1.2.2
     # via
     #   pydantic-settings
     #   uvicorn
-python-multipart==0.0.22
+python-multipart==0.0.32
     # via fastapi
 python-snappy==0.7.3
     # via karapace (/karapace/pyproject.toml)
@@ -211,40 +213,41 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.0
+requests==2.34.2
     # via opentelemetry-exporter-otlp-proto-http
-rich==14.3.3
+rich==15.0.0
     # via
     #   rich-toolkit
     #   typer
-rich-toolkit==0.19.7
+rich-toolkit==0.20.3
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
 rignore==0.7.6
     # via fastapi-cloud-cli
-rpds-py==0.30.0
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-sentry-sdk==2.56.0
+sentry-sdk==2.65.0
     # via fastapi-cloud-cli
 shellingham==1.5.4
     # via typer
 six==1.17.0
     # via python-dateutil
-starlette==0.52.1
+starlette==1.3.1
     # via
     #   fastapi
     #   prometheus-fastapi-instrumentator
 tenacity==9.1.4
     # via karapace (/karapace/pyproject.toml)
-typer==0.24.1
+typer==0.26.8
     # via
     #   fastapi-cli
     #   fastapi-cloud-cli
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
+    #   aiohttp
     #   aiokafka
     #   aiosignal
     #   anyio
@@ -253,6 +256,8 @@ typing-extensions==4.15.0
     #   grpcio
     #   karapace (/karapace/pyproject.toml)
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pydantic
@@ -267,30 +272,28 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-ujson==5.12.0
+ujson==5.13.0
     # via karapace (/karapace/pyproject.toml)
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   requests
     #   sentry-sdk
-uvicorn[standard]==0.42.0
+uvicorn[standard]==0.51.0
     # via
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
 uvloop==0.22.1
     # via uvicorn
-watchfiles==1.1.1
+watchfiles==1.2.0
     # via
     #   karapace (/karapace/pyproject.toml)
     #   uvicorn
-websockets==16.0
+websockets==16.1
     # via uvicorn
-yarl==1.23.0
+yarl==1.24.2
     # via
     #   aiohttp
     #   karapace (/karapace/pyproject.toml)
-zipp==3.23.0
-    # via importlib-metadata
 zstandard==0.25.0
     # via karapace (/karapace/pyproject.toml)

--- a/src/karapace/core/avro_dataclasses/introspect.py
+++ b/src/karapace/core/avro_dataclasses/introspect.py
@@ -67,7 +67,7 @@ def _field_type(field: Field, type_: object) -> AvroType:
         type_ = field.metadata.get("type", "int")
         if type_ not in ("int", "long"):
             raise UnsupportedAnnotation(f"Invalid avro type for int: {type_!r}")
-        return type_  # type: ignore[return-value]
+        return type_
     if type_ is bytes:
         return "bytes"
     if type_ is type(None) or type_ is None:  # noqa: E721

--- a/src/karapace/core/protobuf/serialization.py
+++ b/src/karapace/core/protobuf/serialization.py
@@ -160,8 +160,6 @@ def _deserialize_options(options: Any) -> list[OptionElement]:
         result.append(OptionElement("php_class_prefix", OptionElement.Kind.STRING, options.php_class_prefix))
     if options.HasField("php_namespace"):
         result.append(OptionElement("php_namespace", OptionElement.Kind.STRING, options.php_namespace))
-    if options.HasField("php_generic_services"):
-        result.append(OptionElement("php_generic_services", OptionElement.Kind.BOOLEAN, options.php_generic_services))
     if options.HasField("php_metadata_namespace"):
         result.append(OptionElement("php_metadata_namespace", OptionElement.Kind.STRING, options.php_metadata_namespace))
     if options.HasField("ruby_package"):
@@ -321,8 +319,6 @@ def _serialize_options(options: Sequence[OptionElement], result: google.protobuf
             result.php_class_prefix = opt.value
         if opt.name == ("php_namespace"):
             result.php_namespace = opt.value
-        if opt.name == ("php_generic_services"):
-            result.php_generic_services = opt.value
         if opt.name == ("php_metadata_namespace"):
             result.php_metadata_namespace = opt.value
         if opt.name == ("ruby_package"):

--- a/tests/unit/protobuf/test_protobuf_to_dict.py
+++ b/tests/unit/protobuf/test_protobuf_to_dict.py
@@ -25,13 +25,15 @@ import pytest
 _POOL = descriptor_pool.DescriptorPool()
 
 
-_FACTORY = message_factory.MessageFactory(pool=_POOL)
-
-
 def _build_message_class(file_proto: descriptor_pb2.FileDescriptorProto, message_name: str):
-    _POOL.Add(file_proto)
-    msg_desc = _POOL.FindMessageTypeByName(f"{file_proto.package}.{message_name}")
-    return _FACTORY.GetPrototype(msg_desc)
+    full_name = f"{file_proto.package}.{message_name}"
+    try:
+        # protobuf>=5 raises on adding a duplicate file name; reuse if already registered.
+        msg_desc = _POOL.FindMessageTypeByName(full_name)
+    except KeyError:
+        _POOL.Add(file_proto)
+        msg_desc = _POOL.FindMessageTypeByName(full_name)
+    return message_factory.GetMessageClass(msg_desc)
 
 
 def _make_file_proto(name: str, package: str) -> descriptor_pb2.FileDescriptorProto:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- Upgrades protobuf to 5.29.6
- Upgrades confluent-kafka to 2.15.0
- aiohttp
- and a few other packages upgrade in requirements. 
- tests upgrade for protobuf


<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
