### PR TITLE
Refactoring - Rename OIDCMiddleware to OIDCTokenValidator and split auth gate

### DIFF
--- a/.claude/skills/oidc-auth/SKILL.md
+++ b/.claude/skills/oidc-auth/SKILL.md
@@ -18,10 +18,10 @@ This file is the load-bearing context for those flows. Anchors below are file pa
 ## 1. SR OIDC — Token Validation
 
 ### Files
-- `src/karapace/api/oidc/middleware.py` — `OIDCMiddleware` (validation + authz)
+- `src/karapace/api/oidc/validator.py` — `OIDCTokenValidator` (validation + authz)
 - `src/karapace/api/middlewares/__init__.py` — HTTP middleware that runs the gate (`_authenticate_and_authorize`, `setup_middlewares`)
 
-### Validation flow — `OIDCMiddleware.validate_jwt`
+### Validation flow — `OIDCTokenValidator.validate_jwt`
 1. `PyJWKClient.get_signing_key_from_jwt(token)` fetches the signing key (cached).
 2. `jwt.decode()` with:
    - `algorithms=["RS256","RS384","RS512"]` (hardcoded, RSA only)
@@ -30,14 +30,14 @@ This file is the load-bearing context for those flows. Anchors below are file pa
    - `options={"require": ["exp","iss","aud"]}` — PyJWT does **not** require these by default; we do, explicitly.
 3. `ExpiredSignatureError` → custom `TokenExpiredError` (subclass of `AuthenticationError`) so the 401 reason can say "Token expired" vs. "Invalid token/payload".
 
-### JWKS client cache — `OIDCMiddleware.__init__` (`self._jwks_client`)
+### JWKS client cache — `OIDCTokenValidator.__init__` (`self._jwks_client`)
 ```python
 PyJWKClient(self.jwks_url, cache_keys=True, lifespan=300, max_cached_keys=16)
 ```
 - `lifespan=300` caps how long a key stays cached after IdP key rotation/revocation.
 - `max_cached_keys=16` — IdPs typically expose 1-3; 16 is generous.
 
-### HTTPS enforcement — `OIDCMiddleware.__init__` (search for `allow_insecure_jwks`)
+### HTTPS enforcement — `OIDCTokenValidator.__init__` (search for `allow_insecure_jwks`)
 JWKS over plain HTTP is rejected unless `sasl_oauthbearer_allow_insecure_jwks=true` (dev-only override; logs a loud warning). Reason: an in-path attacker could swap signing keys and forge valid tokens.
 
 ### Subject exposure — `_authenticate_and_authorize` (search for `request.state.user`)
@@ -51,13 +51,13 @@ After validation, only the configured subject claim (`claim_name`, default `"sub
 
 ## 2. SR OIDC — Authorization (RBAC)
 
-### Flow — `OIDCMiddleware.authorize_request`
+### Flow — `OIDCTokenValidator.authorize_request`
 - Off when `sasl_oauthbearer_authorization_enabled=false` — returns `True` immediately.
 - Looks up allowed roles for the request method in `sasl_oauthbearer_method_roles`, e.g. `{"GET": ["reader","admin"], "POST": ["admin"], ...}`.
 - Extracts user roles via `sasl_oauthbearer_roles_claim_path` (dot-path, e.g. `realm_access.roles`, or a literal Keycloak path `resource_access.<client>.roles`).
 - Mismatch (or any misconfig) → **403 with the same body** as a real role mismatch. This is intentional — an attacker with a valid token must not be able to distinguish "bad config" from "missing role" via response differences.
 
-### Required config when authz is on (`OIDCMiddleware.__init__`)
+### Required config when authz is on (`OIDCTokenValidator.__init__`)
 - `sasl_oauthbearer_roles_claim_path`
 
 Missing it → `ValueError` at startup (fail-closed).
@@ -212,7 +212,7 @@ All env vars are prefixed `KARAPACE_` (Pydantic `BaseSettings`). The flag double
 
 | Path | What it covers |
 |---|---|
-| `tests/unit/test_oidc.py` | `OIDCMiddleware` unit tests: config validation, `validate_jwt`, role extraction, `authorize_request`. Two flavors of JWT test — **mocked** `jwt.decode` (argument wiring) and **real RS256** (in-test RSA keypair + stubbed JWKS client, so PyJWT genuinely validates `aud`/`iss`/`exp`/`nbf`/`sub`/alg/`typ`, incl. HS256 & `alg:none` rejection). Also: Authorization-header parsing branches (non-Bearer scheme, lowercase, empty/whitespace token) and RBAC through the real HTTP middleware (empty/missing/wrong roles → 403, anti-oracle body parity). |
+| `tests/unit/test_oidc.py` | `OIDCTokenValidator` unit tests: config validation, `validate_jwt`, role extraction, `authorize_request`. Two flavors of JWT test — **mocked** `jwt.decode` (argument wiring) and **real RS256** (in-test RSA keypair + stubbed JWKS client, so PyJWT genuinely validates `aud`/`iss`/`exp`/`nbf`/`sub`/alg/`typ`, incl. HS256 & `alg:none` rejection). Also: Authorization-header parsing branches (non-Bearer scheme, lowercase, empty/whitespace token) and RBAC through the real HTTP middleware (empty/missing/wrong roles → 403, anti-oracle body parity). |
 | `tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py` | RP gate: enabled/disabled, with/without header, concurrent isolation across coroutines |
 | `tests/e2e/schema_registry/test_oidc.py` | SR e2e: valid/invalid/expired tokens, missing headers, skip paths; **RBAC 403 denial** (PUT/DELETE with the reduced-role token) and **GET success**; unauthenticated existence non-leakage (existing vs missing subject → identical 401) |
 | `tests/e2e/kafka_rest_apis/test_oidc_forwarding.py` | RP→SR e2e: AVRO/JSON publish + consumer fetch with bearer, invalid bearer, no-auth fallthrough |
@@ -249,5 +249,5 @@ When you add a feature that crosses the auth boundary, walk through these checks
 2. **New RP endpoint that calls `SchemaRegistryClient`?** Set `sr_authorization_ctx` from the inbound `Authorization` header, gated on `config.sasl_oauthbearer_authentication_enabled`. Update the comment on the contextvar listing the entry points.
 3. **New `SchemaRegistryClient` outbound call?** Pass `headers=_authorization_headers()` (or merge it if you already have headers — see the `post_new_schema` content-type pitfall).
 4. **New cacheable schema lookup?** Include `_token_fingerprint()` in the cache key. Don't store the raw token anywhere.
-5. **New authz rule?** Prefer extending `sasl_oauthbearer_method_roles` over inventing a parallel system. If you must inspect the JWT payload, do it inside `OIDCMiddleware` — don't leak the payload to handlers.
-6. **Error responses on auth failure?** Match the existing pattern: 401 with `{"error": "Unauthorized", "reason": "..."}` for authn, 403 with `{"error": "Authorization error", "reason": "Forbidden"}` for authz. Keep the 403 body identical to the misconfig branch — see `OIDCMiddleware.authorize_request` for the rationale (do not let the response distinguish bad config from a missing role).
+5. **New authz rule?** Prefer extending `sasl_oauthbearer_method_roles` over inventing a parallel system. If you must inspect the JWT payload, do it inside `OIDCTokenValidator` — don't leak the payload to handlers.
+6. **Error responses on auth failure?** Match the existing pattern: 401 with `{"error": "Unauthorized", "reason": "..."}` for authn, 403 with `{"error": "Authorization error", "reason": "Forbidden"}` for authz. Keep the 403 body identical to the misconfig branch — see `OIDCTokenValidator.authorize_request` for the rationale (do not let the response distinguish bad config from a missing role).

--- a/src/karapace/api/AGENTS.md
+++ b/src/karapace/api/AGENTS.md
@@ -4,11 +4,11 @@ This directory hosts the FastAPI-based Schema Registry. The notes below cover be
 
 The REST Proxy lives in `../kafka_rest_apis/`; shared logic (basic auth, the schema-client + token-forwarding contextvar) is in `../core/`. See `../core/AGENTS.md`.
 
-## OIDC validation gate — `api/oidc/middleware.py` + `api/middlewares/__init__.py`
+## OIDC validation gate — `api/oidc/validator.py` + `api/middlewares/__init__.py`
 
 OIDC runs as a **Starlette HTTP middleware**, before any FastAPI route handler. Setup is in `setup_middlewares()`.
 
-### `OIDCMiddleware.validate_jwt`
+### `OIDCTokenValidator.validate_jwt`
 
 1. `PyJWKClient.get_signing_key_from_jwt(token)` — JWKS is cached: `PyJWKClient(self.jwks_url, cache_keys=True, lifespan=300, max_cached_keys=16)`. `lifespan=300` caps how long a key stays cached after IdP rotation/revocation.
 2. `jwt.decode()` with:
@@ -18,7 +18,7 @@ OIDC runs as a **Starlette HTTP middleware**, before any FastAPI route handler. 
    - `options={"require": ["exp","iss","aud"]}` — PyJWT does **not** require these by default; we do, explicitly.
 3. `ExpiredSignatureError` → custom `TokenExpiredError` (subclass of `AuthenticationError`) so the 401 reason can distinguish "Token expired" from "Invalid token/payload".
 
-### HTTPS enforcement — `OIDCMiddleware.__init__`
+### HTTPS enforcement — `OIDCTokenValidator.__init__`
 JWKS over plain HTTP is rejected unless `sasl_oauthbearer_allow_insecure_jwks=true`. Reason: an in-path attacker could swap signing keys and forge valid tokens. The override is dev-only and logs a loud warning.
 
 ### Subject exposure — `_authenticate_and_authorize`
@@ -28,7 +28,7 @@ After validation, **only the configured subject claim** (`claim_name`, default `
 - Always skipped: `/docs`, `/docs/oauth2-redirect`, `/redoc`, `/openapi.json`.
 - Configurable: `sasl_oauthbearer_skip_auth_paths` (default `["/_health", "/metrics"]`).
 
-## Authorization (RBAC) — `OIDCMiddleware.authorize_request`
+## Authorization (RBAC) — `OIDCTokenValidator.authorize_request`
 
 - Off when `sasl_oauthbearer_authorization_enabled=false` — returns `True` immediately.
 - Allowed roles per HTTP method come from `sasl_oauthbearer_method_roles`, e.g. `{"GET": ["reader","admin"], "POST": ["admin"], ...}`.
@@ -54,12 +54,12 @@ Keep the 403 body identical to the misconfig branch (see `authorize_request`) �
 
 ## Tests
 
-- `tests/unit/test_oidc.py` — `OIDCMiddleware` unit tests (config validation, `validate_jwt`, role extraction, `authorize_request`).
+- `tests/unit/test_oidc.py` — `OIDCTokenValidator` unit tests (config validation, `validate_jwt`, role extraction, `authorize_request`).
 - `tests/e2e/schema_registry/test_oidc.py` — SR e2e (valid/invalid/expired tokens, missing headers, skip paths).
 - `tests/e2e/kafka_rest_apis/test_oidc_forwarding.py` — RP→SR e2e (AVRO/JSON publish + consumer fetch with bearer, invalid bearer, no-auth fallthrough).
 
 ## Checklist when extending
 
 - **New SR route?** It's automatically gated by `setup_middlewares`. If it should be public, add it to `sasl_oauthbearer_skip_auth_paths`. **Do not read claims other than the configured subject** off `request.state` — only `request.state.user` is exposed deliberately.
-- **New authz rule?** Prefer extending `sasl_oauthbearer_method_roles` over inventing a parallel system. If you must inspect the JWT payload, do it inside `OIDCMiddleware` — don't leak the payload to handlers.
+- **New authz rule?** Prefer extending `sasl_oauthbearer_method_roles` over inventing a parallel system. If you must inspect the JWT payload, do it inside `OIDCTokenValidator` — don't leak the payload to handlers.
 - **Touching the forwarding contextvar?** That logic lives in `../core/serialization.py`; see `../core/AGENTS.md`.

--- a/src/karapace/api/middlewares/__init__.py
+++ b/src/karapace/api/middlewares/__init__.py
@@ -12,7 +12,7 @@ from prometheus_client import Counter
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import Info, request_size, requests, response_size
 
-from karapace.api.oidc.middleware import OIDCMiddleware, TokenExpiredError
+from karapace.api.oidc.validator import OIDCTokenValidator, TokenExpiredError
 from karapace.core.auth import AuthenticationError
 from karapace.core.config import Config
 import logging
@@ -20,7 +20,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def _authenticate_and_authorize(request: Request, config: Config, oidc_middleware: OIDCMiddleware) -> JSONResponse | None:
+def _authenticate_and_authorize(request: Request, config: Config, oidc_validator: OIDCTokenValidator) -> JSONResponse | None:
     """Run the OIDC auth gate. Return a JSONResponse on failure, or None to continue."""
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
@@ -37,7 +37,7 @@ def _authenticate_and_authorize(request: Request, config: Config, oidc_middlewar
         )
 
     try:
-        payload = oidc_middleware.validate_jwt(token)
+        payload = oidc_validator.validate_jwt(token)
     except TokenExpiredError:
         return JSONResponse(
             status_code=401,
@@ -52,12 +52,12 @@ def _authenticate_and_authorize(request: Request, config: Config, oidc_middlewar
     # Expose only the configured subject claim to handlers, never the full payload.
     # Prevents downstream code from picking up attacker-controlled claims (e.g. "roles")
     # and using them for authz decisions.
-    request.state.user = payload.get(oidc_middleware.claim_name) if oidc_middleware.claim_name else None
+    request.state.user = payload.get(oidc_validator.claim_name) if oidc_validator.claim_name else None
     log.debug("Authenticated")
 
     if config.sasl_oauthbearer_authorization_enabled:
         try:
-            oidc_middleware.authorize_request(payload, request.method)
+            oidc_validator.authorize_request(payload, request.method)
         except HTTPException as e:
             return JSONResponse(
                 {"error": "Authorization error", "reason": e.detail},
@@ -66,24 +66,17 @@ def _authenticate_and_authorize(request: Request, config: Config, oidc_middlewar
     return None
 
 
-def setup_middlewares(app: FastAPI, config: Config) -> None:
-    oidc_middleware = OIDCMiddleware(app=app, config=config)
+# Paths that bypass the OIDC auth gate: API docs endpoints are always public.
+_DOCS_PATHS = frozenset({"/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json"})
 
+
+def setup_middlewares(app: FastAPI, config: Config) -> None:
+    oidc_validator = OIDCTokenValidator(app=app, config=config)
+
+    # Registered first, so it is the innermost middleware: it sees the response after the
+    # auth gate has passed the request through to the handler.
     @app.middleware("http")
     async def set_content_types(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
-        # Skip schema-registry header checks and Content-Type override for docs (Swagger UI, ReDoc, OpenAPI JSON).
-        if request.url.path in {"/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json"}:
-            return await call_next(request)
-
-        # Check for skip paths like /_health and /metrics and bypass
-        if request.url.path in config.sasl_oauthbearer_skip_auth_paths:
-            return await call_next(request)
-
-        if config.sasl_oauthbearer_authentication_enabled:
-            failure = _authenticate_and_authorize(request, config, oidc_middleware)
-            if failure is not None:
-                return failure
-
         response = await call_next(request)
 
         content_type = getattr(request.state, "schema_response_content_type", None)
@@ -91,6 +84,25 @@ def setup_middlewares(app: FastAPI, config: Config) -> None:
             response.headers["Content-Type"] = content_type
 
         return response
+
+    # Registered last, so it is the outermost middleware: unauthenticated requests are
+    # rejected before reaching the handler or any inner middleware.
+    @app.middleware("http")
+    async def oidc_auth_gate(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        # Docs (Swagger UI, ReDoc, OpenAPI JSON) are always public.
+        if request.url.path in _DOCS_PATHS:
+            return await call_next(request)
+
+        # Configurable bypass paths like /_health and /metrics.
+        if request.url.path in config.sasl_oauthbearer_skip_auth_paths:
+            return await call_next(request)
+
+        if config.sasl_oauthbearer_authentication_enabled:
+            failure = _authenticate_and_authorize(request, config, oidc_validator)
+            if failure is not None:
+                return failure
+
+        return await call_next(request)
 
     setup_telemetry_middleware(app=app)
 

--- a/src/karapace/api/oidc/validator.py
+++ b/src/karapace/api/oidc/validator.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 REQUIRED_HTTP_METHODS: frozenset[str] = frozenset({"GET", "POST", "PUT", "DELETE"})
 
 
-class OIDCMiddleware:
+class OIDCTokenValidator:
     def __init__(self, app: FastAPI, config: Config) -> None:
         self.app = app
         self.config = config
@@ -193,7 +193,7 @@ class OIDCMiddleware:
                     return []  # path broken
                 value = value.get(part)
 
-            return OIDCMiddleware._normalize_role_values(value)
+            return OIDCTokenValidator._normalize_role_values(value)
         except Exception:
             pass
         return []

--- a/src/karapace/core/AGENTS.md
+++ b/src/karapace/core/AGENTS.md
@@ -88,7 +88,7 @@ All env vars are prefixed `KARAPACE_`. The OIDC fields live on `Config`:
 
 ## Tests touching this directory
 
-- `tests/unit/test_oidc.py` — `OIDCMiddleware` (lives in `api/`, but config validation is exercised here).
+- `tests/unit/test_oidc.py` — `OIDCTokenValidator` (lives in `api/`, but config validation is exercised here).
 - `tests/unit/kafka_rest_apis/test_sr_authorization_forwarding.py` — RP gate behavior (enabled/disabled, with/without header, concurrent isolation across coroutines).
 - `tests/conftest.py` — fixtures `registry_async_client_oidc`, `registry_async_client_basic`, `reset_sr_authorization_ctx`. **The `reset_sr_authorization_ctx` fixture is required for any test that touches `sr_authorization_ctx`** — contextvars persist across tests in the same event-loop scope and will leak state otherwise.
 

--- a/src/karapace/core/config.py
+++ b/src/karapace/core/config.py
@@ -138,7 +138,7 @@ class Config(BaseSettings):
     ssl_crlfile: str | None = None
     ssl_password: str | None = None
     sasl_mechanism: str | None = None
-    # OIDC for Schema Registry (OIDCMiddleware). authZ requires authN.
+    # OIDC for Schema Registry (OIDCTokenValidator). authZ requires authN.
     sasl_oauthbearer_authentication_enabled: bool = False
     sasl_oauthbearer_authorization_enabled: bool = False
     sasl_oauthbearer_jwks_endpoint_url: str | None = None

--- a/tests/unit/api/test_middlewares.py
+++ b/tests/unit/api/test_middlewares.py
@@ -123,8 +123,8 @@ def test_valid_bearer_token_passes_and_sets_content_type() -> None:
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with (
-        patch("karapace.api.middlewares.OIDCMiddleware.validate_jwt", return_value={"sub": "u1"}),
-        patch("karapace.api.middlewares.OIDCMiddleware.authorize_request", return_value=True),
+        patch("karapace.api.middlewares.OIDCTokenValidator.validate_jwt", return_value={"sub": "u1"}),
+        patch("karapace.api.middlewares.OIDCTokenValidator.authorize_request", return_value=True),
     ):
         response = _client(config).get("/subjects", headers={"Authorization": "Bearer good-token"})
 
@@ -136,7 +136,7 @@ def test_invalid_jwt_returns_401() -> None:
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with patch(
-        "karapace.api.middlewares.OIDCMiddleware.validate_jwt",
+        "karapace.api.middlewares.OIDCTokenValidator.validate_jwt",
         side_effect=AuthenticationError("bad token"),
     ):
         response = _client(config).get("/subjects", headers={"Authorization": "Bearer bad-token"})
@@ -149,9 +149,9 @@ def test_authorization_failure_returns_role_error() -> None:
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_authorization_enabled=True)
 
     with (
-        patch("karapace.api.middlewares.OIDCMiddleware.validate_jwt", return_value={"sub": "u1"}),
+        patch("karapace.api.middlewares.OIDCTokenValidator.validate_jwt", return_value={"sub": "u1"}),
         patch(
-            "karapace.api.middlewares.OIDCMiddleware.authorize_request",
+            "karapace.api.middlewares.OIDCTokenValidator.authorize_request",
             side_effect=HTTPException(status_code=403, detail="Insufficient roles"),
         ),
     ):

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -20,7 +20,7 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import HTTPException
 from jwt import ExpiredSignatureError, InvalidTokenError
-from karapace.api.oidc.middleware import OIDCMiddleware, TokenExpiredError
+from karapace.api.oidc.validator import OIDCTokenValidator, TokenExpiredError
 from karapace.core.auth import AuthenticationError
 from karapace.core.config import Config
 from karapace.rapu import JSON_CONTENT_TYPE, HTTPResponse
@@ -126,8 +126,8 @@ def dummy_config(request):
         ),
     ),
 )
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_token_valid_configs(
     mock_jwt_decode, mock_pyjwks_client, auth_header, mock_payload, expected_expiration, dummy_config
 ):
@@ -135,7 +135,7 @@ def test_validate_token_valid_configs(
     mock_pyjwks_client.return_value = mock_client_instance
     mock_client_instance.get_signing_key_from_jwt.return_value.key = "fake-public-key"
 
-    oidc_middleware = OIDCMiddleware(app=MagicMock(), config=dummy_config)
+    oidc_middleware = OIDCTokenValidator(app=MagicMock(), config=dummy_config)
     mock_jwt_decode.return_value = mock_payload
 
     token = auth_header.split(" ", 1)[1]
@@ -164,7 +164,7 @@ def test_oidc_middleware_raises_on_incomplete_config(dummy_config):
     with pytest.raises(
         ValueError, match="OIDC config error: 'issuer' and 'audience' must be set if 'jwks_endpoint_url' is provided."
     ):
-        OIDCMiddleware(app=MagicMock(), config=config)
+        OIDCTokenValidator(app=MagicMock(), config=config)
 
 
 def test_oidc_middleware_rejects_http_jwks_url_by_default():
@@ -174,10 +174,10 @@ def test_oidc_middleware_rejects_http_jwks_url_by_default():
         sasl_oauthbearer_expected_audience="aud",
     )
     with pytest.raises(ValueError, match="https://"):
-        OIDCMiddleware(app=MagicMock(), config=config)
+        OIDCTokenValidator(app=MagicMock(), config=config)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_oidc_middleware_allows_http_jwks_when_override_set(mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     config = Config(
@@ -186,12 +186,12 @@ def test_oidc_middleware_allows_http_jwks_when_override_set(mock_pyjwks_client):
         sasl_oauthbearer_expected_audience="aud",
         sasl_oauthbearer_allow_insecure_jwks=True,
     )
-    OIDCMiddleware(app=MagicMock(), config=config)
+    OIDCTokenValidator(app=MagicMock(), config=config)
 
 
 @pytest.mark.parametrize("dummy_config", valid_configs, ids=["valid_full", "no_oidc"], indirect=True)
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_token_invalid_token(mock_jwt_decode, mock_pyjwks_client, dummy_config):
     # Setup mock PyJWKClient instance if JWKS URL is present, else None
     if dummy_config.sasl_oauthbearer_jwks_endpoint_url:
@@ -205,7 +205,7 @@ def test_validate_token_invalid_token(mock_jwt_decode, mock_pyjwks_client, dummy
     # Setup jwt.decode to raise InvalidTokenError
     mock_jwt_decode.side_effect = InvalidTokenError("Invalid token")
 
-    oidc_middleware = OIDCMiddleware(app=MagicMock(), config=dummy_config)
+    oidc_middleware = OIDCTokenValidator(app=MagicMock(), config=dummy_config)
 
     invalid_token = "invalid.jwt.token"
 
@@ -232,7 +232,7 @@ def test_validate_token_invalid_token(mock_jwt_decode, mock_pyjwks_client, dummy
     ],
 )
 def test_get_roles_from_claim_path(payload, path, expected_roles):
-    roles = OIDCMiddleware.get_roles_from_claim_path(payload, path)
+    roles = OIDCTokenValidator.get_roles_from_claim_path(payload, path)
     assert roles == expected_roles
 
 
@@ -264,7 +264,7 @@ def test_authorize_request_roles(monkeypatch, roles, method, method_roles, expec
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
         sasl_oauthbearer_method_roles=method_roles,
     )
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
 
     payload = {"realm_access": {"roles": roles}}
 
@@ -351,7 +351,7 @@ def _clean_prometheus_registry():
 def _build_app_with_middleware(
     monkeypatch, config: Config, *, validate_jwt_payload: dict | None = None, validate_jwt_raises: Exception | None = None
 ):
-    """Build a minimal FastAPI app wired to setup_middlewares, with OIDCMiddleware patched."""
+    """Build a minimal FastAPI app wired to setup_middlewares, with OIDCTokenValidator patched."""
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from karapace.api import middlewares as middlewares_mod
@@ -375,13 +375,13 @@ def _build_app_with_middleware(
         # Re-use real role logic to verify the gate, but make it raise if enabled+roles missing.
         return True
 
-    # Patch heavy bits of OIDCMiddleware: skip real JWKS client construction.
+    # Patch heavy bits of OIDCTokenValidator: skip real JWKS client construction.
     monkeypatch.setattr(
-        "karapace.api.oidc.middleware.PyJWKClient",
+        "karapace.api.oidc.validator.PyJWKClient",
         lambda *a, **kw: MagicMock(),
     )
-    monkeypatch.setattr(OIDCMiddleware, "validate_jwt", _fake_validate_jwt)
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _fake_authorize)
+    monkeypatch.setattr(OIDCTokenValidator, "validate_jwt", _fake_validate_jwt)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _fake_authorize)
 
     middlewares_mod.setup_middlewares(app=app, config=config)
     return TestClient(app, raise_server_exceptions=False)
@@ -426,10 +426,10 @@ def test_middleware_authn_only_skips_authorize_request(monkeypatch):
         return True
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _spy_authorize)
     client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
     # Re-patch authorize_request after _build_app_with_middleware (which also patches it).
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _spy_authorize)
 
     r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
     assert r.status_code == 200
@@ -449,9 +449,9 @@ def test_middleware_authn_and_authz_calls_authorize(monkeypatch):
         sasl_oauthbearer_authorization_enabled=True,
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
     )
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _spy_authorize)
     client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _spy_authorize)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _spy_authorize)
 
     r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
     assert r.status_code == 200
@@ -464,7 +464,7 @@ def test_middleware_authn_and_authz_calls_authorize(monkeypatch):
 # function-level authorize_request tests above.
 # ---------------------------------------------------------------------------
 
-_REAL_AUTHORIZE = OIDCMiddleware.authorize_request
+_REAL_AUTHORIZE = OIDCTokenValidator.authorize_request
 
 
 def _authz_middleware_client(monkeypatch, payload: dict):
@@ -478,7 +478,7 @@ def _authz_middleware_client(monkeypatch, payload: dict):
     )
     client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload=payload)
     # _build_app_with_middleware stubs authorize_request; restore the genuine impl.
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _REAL_AUTHORIZE)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _REAL_AUTHORIZE)
     return client
 
 
@@ -513,10 +513,10 @@ def test_middleware_real_authorize_denial_body_matches_misconfig(monkeypatch):
         authorization_enabled=True,
         sasl_oauthbearer_method_roles={"GET": ["reader"], "POST": ["w"], "PUT": ["w"], "DELETE": ["w"]},
         sasl_oauthbearer_roles_claim_path=None,
-        get_roles_from_claim_path=OIDCMiddleware.get_roles_from_claim_path,
+        get_roles_from_claim_path=OIDCTokenValidator.get_roles_from_claim_path,
     )
     with pytest.raises(HTTPException) as exc_info:
-        OIDCMiddleware.authorize_request(ns, {"realm_access": {"roles": ["reader"]}}, request_method="GET")
+        OIDCTokenValidator.authorize_request(ns, {"realm_access": {"roles": ["reader"]}}, request_method="GET")
     assert exc_info.value.status_code == 403
     # The middleware serializes HTTPException.detail into reason; both must render identically.
     assert mismatch.json() == {"error": "Authorization error", "reason": exc_info.value.detail}
@@ -531,9 +531,9 @@ def test_middleware_authn_and_authz_returns_403_on_role_failure(monkeypatch):
         sasl_oauthbearer_authorization_enabled=True,
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
     )
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _deny)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _deny)
     client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
-    monkeypatch.setattr(OIDCMiddleware, "authorize_request", _deny)
+    monkeypatch.setattr(OIDCTokenValidator, "authorize_request", _deny)
 
     r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
     assert r.status_code == 403
@@ -592,15 +592,15 @@ def test_middleware_accepts_bearer_with_valid_token(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_expired_token_raises_token_expired(mock_jwt_decode, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.side_effect = ExpiredSignatureError("Signature has expired")
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
 
     with pytest.raises(TokenExpiredError) as exc_info:
         middleware.validate_jwt("expired.jwt.token")
@@ -641,15 +641,15 @@ def test_middleware_invalid_token_still_returns_invalid_reason(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_passes_leeway_and_require_sub_to_decode(mock_jwt_decode, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_leeway_seconds=42)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     middleware.validate_jwt("good.jwt.token")
 
     kwargs = mock_jwt_decode.call_args.kwargs
@@ -657,54 +657,54 @@ def test_validate_jwt_passes_leeway_and_require_sub_to_decode(mock_jwt_decode, m
     assert "sub" in kwargs["options"]["require"]
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_require_uses_configured_sub_claim(mock_jwt_decode, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.return_value = {"user_id": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_sub_claim_name="user_id")
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     middleware.validate_jwt("good.jwt.token")
 
     require = mock_jwt_decode.call_args.kwargs["options"]["require"]
     assert "user_id" in require
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_logs_reason_on_invalid_token(mock_jwt_decode, mock_pyjwks_client, caplog):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.side_effect = InvalidTokenError("missing required claim sub")
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
 
-    with caplog.at_level(logging.WARNING, logger="karapace.api.oidc.middleware"):
+    with caplog.at_level(logging.WARNING, logger="karapace.api.oidc.validator"):
         with pytest.raises(AuthenticationError):
             middleware.validate_jwt("bad.jwt.token")
 
     assert any("missing required claim sub" in rec.message for rec in caplog.records)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_validate_jwt_audience_missing_raises(mock_pyjwks_client):
     """Defense-in-depth: if audience is somehow None at decode time, fail closed."""
     mock_pyjwks_client.return_value = MagicMock()
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     middleware.audience = None  # bypass __init__ guard
 
     with pytest.raises(AuthenticationError, match="audience missing"):
         middleware.validate_jwt("any.jwt.token")
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.get_unverified_header")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_at_jwt_typ_enforced_accepts(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
@@ -712,13 +712,13 @@ def test_validate_jwt_at_jwt_typ_enforced_accepts(mock_jwt_decode, mock_unverifi
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.get_unverified_header")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_at_jwt_typ_enforced_rejects_id_token(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
@@ -726,27 +726,27 @@ def test_validate_jwt_at_jwt_typ_enforced_rejects_id_token(mock_jwt_decode, mock
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     with pytest.raises(AuthenticationError, match="Invalid OIDC token"):
         middleware.validate_jwt("idtoken.jwt.token")
     mock_jwt_decode.assert_not_called()
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.get_unverified_header")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_typ_check_skipped_when_flag_off(mock_jwt_decode, mock_unverified_header, mock_pyjwks_client):
     mock_pyjwks_client.return_value = MagicMock()
     mock_pyjwks_client.return_value.get_signing_key_from_jwt.return_value.key = "fake-public-key"
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     middleware.validate_jwt("good.jwt.token")
     mock_unverified_header.assert_not_called()
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_authorization_enabled_without_client_id_is_accepted(mock_pyjwks_client):
     """Authz needs only a static roles_claim_path — client_id is no longer required."""
     mock_pyjwks_client.return_value = MagicMock()
@@ -756,13 +756,13 @@ def test_authorization_enabled_without_client_id_is_accepted(mock_pyjwks_client)
         sasl_oauthbearer_roles_claim_path="realm_access.roles",
         sasl_oauthbearer_method_roles={"GET": ["reader"], "POST": ["admin"], "PUT": ["admin"], "DELETE": ["admin"]},
     )
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     payload = {"realm_access": {"roles": ["reader"]}}
     assert middleware.authorize_request(payload, "GET") is True
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_default_leeway_is_zero(mock_jwt_decode, mock_pyjwks_client):
     """Default leeway is 0 — preserves prior strict behavior. Operators opt into skew tolerance."""
     mock_pyjwks_client.return_value = MagicMock()
@@ -770,7 +770,7 @@ def test_validate_jwt_default_leeway_is_zero(mock_jwt_decode, mock_pyjwks_client
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     middleware.validate_jwt("good.jwt.token")
 
     assert mock_jwt_decode.call_args.kwargs["leeway"] == 0
@@ -785,9 +785,9 @@ def test_config_rejects_negative_leeway():
 
 
 @pytest.mark.parametrize("typ_value", ["AT+JWT", "at+jwt", "application/at+jwt", "Application/AT+JWT"])
-@patch("karapace.api.oidc.middleware.PyJWKClient")
-@patch("karapace.api.oidc.middleware.jwt.get_unverified_header")
-@patch("karapace.api.oidc.middleware.jwt.decode")
+@patch("karapace.api.oidc.validator.PyJWKClient")
+@patch("karapace.api.oidc.validator.jwt.get_unverified_header")
+@patch("karapace.api.oidc.validator.jwt.decode")
 def test_validate_jwt_at_jwt_typ_accepts_case_insensitive_and_long_form(
     mock_jwt_decode, mock_unverified_header, mock_pyjwks_client, typ_value
 ):
@@ -797,7 +797,7 @@ def test_validate_jwt_at_jwt_typ_accepts_case_insensitive_and_long_form(
     mock_jwt_decode.return_value = {"sub": "u"}
 
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, sasl_oauthbearer_require_access_token_typ=True)
-    middleware = OIDCMiddleware(app=MagicMock(), config=config)
+    middleware = OIDCTokenValidator(app=MagicMock(), config=config)
     assert middleware.validate_jwt("good.jwt.token") == {"sub": "u"}
 
 
@@ -815,12 +815,12 @@ def _authz_config(method_roles: dict[str, list[str]]) -> Config:
     )
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_method_roles_complete_set_is_accepted(mock_pyjwks_client):
     """All four required methods present -> constructor succeeds."""
     mock_pyjwks_client.return_value = MagicMock()
     config = _authz_config({"GET": ["r"], "POST": ["w"], "PUT": ["w"], "DELETE": ["w"]})
-    OIDCMiddleware(app=MagicMock(), config=config)
+    OIDCTokenValidator(app=MagicMock(), config=config)
 
 
 @pytest.mark.parametrize(
@@ -836,31 +836,31 @@ def test_method_roles_complete_set_is_accepted(mock_pyjwks_client):
         ({}, "DELETE, GET, POST, PUT"),
     ],
 )
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_method_roles_missing_required_method_raises(mock_pyjwks_client, method_roles, expected_missing):
     mock_pyjwks_client.return_value = MagicMock()
     config = _authz_config(method_roles)
     with pytest.raises(ValueError, match=f"method_roles is missing definitions for: {expected_missing}"):
-        OIDCMiddleware(app=MagicMock(), config=config)
+        OIDCTokenValidator(app=MagicMock(), config=config)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_method_roles_extra_unknown_method_is_allowed(mock_pyjwks_client):
     """Extra methods beyond the required set are tolerated — only missing ones fail."""
     mock_pyjwks_client.return_value = MagicMock()
     config = _authz_config({"GET": ["r"], "POST": ["w"], "PUT": ["w"], "DELETE": ["w"], "PATCH": ["w"]})
-    OIDCMiddleware(app=MagicMock(), config=config)
+    OIDCTokenValidator(app=MagicMock(), config=config)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_method_roles_validation_is_case_insensitive(mock_pyjwks_client):
     """Lowercase method keys are normalised before the completeness check."""
     mock_pyjwks_client.return_value = MagicMock()
     config = _authz_config({"get": ["r"], "post": ["w"], "put": ["w"], "delete": ["w"]})
-    OIDCMiddleware(app=MagicMock(), config=config)
+    OIDCTokenValidator(app=MagicMock(), config=config)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_method_roles_not_validated_when_authorization_disabled(mock_pyjwks_client):
     """``method_roles`` is irrelevant when authz is off — even an empty dict is fine."""
     mock_pyjwks_client.return_value = MagicMock()
@@ -869,16 +869,16 @@ def test_method_roles_not_validated_when_authorization_disabled(mock_pyjwks_clie
         sasl_oauthbearer_authorization_enabled=False,
         sasl_oauthbearer_method_roles={},
     )
-    OIDCMiddleware(app=MagicMock(), config=config)
+    OIDCTokenValidator(app=MagicMock(), config=config)
 
 
-@patch("karapace.api.oidc.middleware.PyJWKClient")
+@patch("karapace.api.oidc.validator.PyJWKClient")
 def test_constructor_refuses_misconfigured_method_roles(mock_pyjwks_client):
     """The check refuses a config missing ``POST`` upfront at startup."""
     mock_pyjwks_client.return_value = MagicMock()
     bad_config = _authz_config({"GET": ["r"], "PUT": ["w"], "DELETE": ["w"]})
     with pytest.raises(ValueError, match="method_roles is missing definitions for: POST"):
-        OIDCMiddleware(app=MagicMock(), config=bad_config)
+        OIDCTokenValidator(app=MagicMock(), config=bad_config)
 
 
 def test_authorize_request_silently_denies_when_method_unmapped():
@@ -891,12 +891,12 @@ def test_authorize_request_silently_denies_when_method_unmapped():
         sasl_oauthbearer_method_roles={"GET": ["r"], "PUT": ["w"], "DELETE": ["w"]},
         sasl_oauthbearer_roles_claim_path="resource_access.karapace-client.roles",
         client_id="karapace-client",
-        get_roles_from_claim_path=OIDCMiddleware.get_roles_from_claim_path,
+        get_roles_from_claim_path=OIDCTokenValidator.get_roles_from_claim_path,
     )
     payload = {"resource_access": {"karapace-client": {"roles": ["w"]}}}
 
     with pytest.raises(HTTPException) as exc_info:
-        OIDCMiddleware.authorize_request(ns, payload, request_method="POST")
+        OIDCTokenValidator.authorize_request(ns, payload, request_method="POST")
     assert exc_info.value.status_code == 403
 
 
@@ -947,16 +947,16 @@ class _StubSigningKey:
 
 @pytest.fixture
 def build_real_middleware(rsa_keypair):
-    """Build an OIDCMiddleware backed by the REAL ``PyJWKClient``, stubbing only its
+    """Build an OIDCTokenValidator backed by the REAL ``PyJWKClient``, stubbing only its
     single network-touching method (``get_signing_key_from_jwt``) to return the in-test
     public key. ``PyJWKClient.__init__`` performs no I/O — the JWKS endpoint is only hit
     on key lookup — so the client is constructed for real; validate_jwt then runs the
     genuine PyJWT decode against real signatures. We patch the seam, not the whole class."""
     _, public_key = rsa_keypair
 
-    def _build(**config_overrides) -> OIDCMiddleware:
+    def _build(**config_overrides) -> OIDCTokenValidator:
         config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, **config_overrides)
-        middleware = OIDCMiddleware(app=MagicMock(), config=config)
+        middleware = OIDCTokenValidator(app=MagicMock(), config=config)
         # Stub the network boundary on the real client instance, leaving decode intact.
         middleware._jwks_client.get_signing_key_from_jwt = lambda _token: _StubSigningKey(public_key)
         return middleware


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

- Rename src/karapace/api/oidc/middleware.py -> validator.py
- Split setup_middlewares into two single-purpose middlewares:
    - oidc_auth_gate (registered last -> outermost, rejects unauthenticated requests before routing) and 
    - set_content_types (Content-Type only).

Pure refactoring.

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
