### PR TITLE
Add json draft 09 and 12 validation & storage support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -840,10 +840,9 @@ migrating between drafts.
 Supported drafts and ``$schema`` URIs
 -------------------------------------
 
-Karapace validates every JSON Schema as **Draft-7**, regardless of the ``$schema`` value declared in the document. This
-matches the behaviour of Confluent Schema Registry, which also standardizes on Draft-7. The ``$schema`` keyword is
-currently **not used to select a validator** — it is accepted and stored as part of the schema, but does not change how
-the schema is validated or compared.
+Karapace selects the JSON Schema draft from the ``$schema`` keyword and validates the schema against that draft's
+metaschema. When ``$schema`` is absent or its value is not recognized, the schema is validated as **Draft-7**, which
+preserves the previous behaviour and matches the default used by Confluent Schema Registry.
 
 .. list-table::
    :header-rows: 1
@@ -853,19 +852,21 @@ the schema is validated or compared.
      - Status
    * - draft-04
      - ``http://json-schema.org/draft-04/schema#``
-     - Accepted, but validated as Draft-7 (unknown keywords ignored)
+     - Validated with its own draft validator
    * - draft-06
      - ``http://json-schema.org/draft-06/schema#``
-     - Accepted, but validated as Draft-7 (unknown keywords ignored)
+     - Validated with its own draft validator
    * - draft-07
      - ``http://json-schema.org/draft-07/schema#``
-     - Supported (native)
+     - Validated with its own draft validator (also the default when ``$schema`` is absent or unrecognized)
    * - 2019-09
      - ``https://json-schema.org/draft/2019-09/schema``
-     - Not yet natively supported; validated as Draft-7 (roadmap)
+     - Validated with its own draft validator
    * - 2020-12
      - ``https://json-schema.org/draft/2020-12/schema``
-     - Not yet natively supported; validated as Draft-7 (roadmap)
+     - Validated with its own draft validator
+
+Compatibility checking, however, is still computed under Draft-7 semantics for all drafts — see `Limitations`_ below.
 
 Compatibility behavior
 ----------------------
@@ -903,12 +904,15 @@ Forward compatibility applies the mirror of these rules, and full compatibility 
 Limitations
 -----------
 
-Because all schemas are validated and compared as Draft-7, keywords introduced in later drafts are **not enforced with
-their intended semantics**. Such keywords are treated as unknown (and therefore ignored) or handled with Draft-7
-meaning. These include, among others: ``$defs`` (Draft-7 uses ``definitions``), keywords placed as siblings of
-``$ref``, ``prefixItems`` (2020-12 tuple validation), the ``dependentRequired`` / ``dependentSchemas`` split,
-``$recursiveRef`` / ``$dynamicRef``, and ``unevaluatedProperties`` / ``unevaluatedItems``. A schema using these will be
-accepted, but the newer-draft behaviour is not applied.
+Schema **validation** is draft-specific: a schema is validated against the draft declared in ``$schema`` (defaulting to
+Draft-7), so newer-draft keywords such as ``$defs``, ``prefixItems``, ``dependentRequired`` / ``dependentSchemas``,
+``$recursiveRef`` / ``$dynamicRef`` and ``unevaluatedProperties`` / ``unevaluatedItems`` are validated with their
+intended semantics.
+
+**Compatibility checking**, however, is still computed under Draft-7 semantics for every draft. When comparing versions,
+newer-draft keywords are treated as unknown (ignored) or interpreted with Draft-7 meaning — for example ``prefixItems``
+is not recognized as a tuple and ``$defs`` is not resolved as ``definitions`` is. A schema using these keywords is
+validated and stored correctly, but the newer-draft behaviour is not yet applied during compatibility checks.
 
 There is no strict/lenient mode for JSON Schema validation or compatibility. (The ``kafka_schema_reader_strict_mode``
 configuration is unrelated — it controls error handling when reading the internal ``_schemas`` topic, not JSON Schema
@@ -917,15 +921,15 @@ validation.)
 Migration guidance
 ------------------
 
-* **Recommended today:** author schemas as Draft-7, or omit ``$schema`` entirely, for predictable validation and
-  compatibility results.
-* **Sending 2019-09 or 2020-12 schemas today:** they are accepted, but validated and compared as Draft-7. Do not rely on
-  newer-draft-only keyword semantics until native support ships.
-* **Mixing drafts within a subject:** a subject may contain versions that declare different ``$schema`` values, but
-  compatibility is always computed under Draft-7 rules. Changing a version's declared draft does not change how
-  compatibility is evaluated. Review the limitations above before relying on newer-draft keywords across versions.
-* **Roadmap:** native validation and compatibility support for Draft 2019-09 and 2020-12 keywords is planned. This
-  section will be expanded when that support lands.
+* **Validation:** schemas declaring Draft 2019-09 or 2020-12 (or draft-04 / draft-06) via ``$schema`` are validated with
+  that draft's rules; omitting ``$schema`` defaults to Draft-7.
+* **Compatibility:** regardless of the declared draft, compatibility is still evaluated under Draft-7 semantics. Do not
+  rely on newer-draft-only keyword semantics *during compatibility checks* until that support ships.
+* **Mixing drafts within a subject:** a subject may contain versions that declare different ``$schema`` values;
+  compatibility across them is always computed under Draft-7 rules. Review the limitations above before relying on
+  newer-draft keywords across versions.
+* **Roadmap:** native *compatibility* support for Draft 2019-09 and 2020-12 keywords is planned. This section will be
+  expanded when that support lands.
 
 
 Uninstall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "confluent-kafka",
   "cryptography",
   "fastapi[standard]",
-  "jsonschema",
+  "jsonschema>=4.18,<5",
   "lz4",
   "networkx",
   "protobuf==5.29.6",

--- a/src/karapace/core/compatibility/jsonschema/checks.py
+++ b/src/karapace/core/compatibility/jsonschema/checks.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from avro.compatibility import merge, SchemaCompatibilityResult, SchemaCompatibilityType, SchemaIncompatibilityType
 from dataclasses import dataclass
 from itertools import product
-from jsonschema import Draft7Validator
 from karapace.core.compatibility.jsonschema.types import (
     AssertionCheck,
     BooleanSchema,
@@ -35,6 +34,7 @@ from karapace.core.compatibility.jsonschema.utils import (
     normalize_schema,
     schema_from_partially_open_content_model,
 )
+from karapace.core.typing import JsonSchemaValidator
 from typing import Any
 
 import networkx as nx
@@ -218,7 +218,7 @@ def is_compatible(result: SchemaCompatibilityResult) -> bool:
     return result.compatibility is SchemaCompatibilityType.compatible
 
 
-def compatibility(reader: Draft7Validator, writer: Draft7Validator) -> SchemaCompatibilityResult:
+def compatibility(reader: JsonSchemaValidator, writer: JsonSchemaValidator) -> SchemaCompatibilityResult:
     """Checks that `reader` can read values produced by `writer`."""
     assert reader is not None
     assert writer is not None

--- a/src/karapace/core/compatibility/jsonschema/utils.py
+++ b/src/karapace/core/compatibility/jsonschema/utils.py
@@ -4,8 +4,8 @@ See LICENSE for details
 """
 
 from copy import copy
-from jsonschema import Draft7Validator
 from karapace.core.compatibility.jsonschema.types import BooleanSchema, Instance, Keyword, Subschema
+from karapace.core.typing import JsonSchemaValidator
 from typing import Any, TypeVar, Union
 
 import re
@@ -14,12 +14,12 @@ T = TypeVar("T")
 JSONSCHEMA_TYPES = Union[Instance, Subschema, Keyword, type[BooleanSchema]]
 
 
-def normalize_schema(validator: Draft7Validator) -> Any:
+def normalize_schema(validator: JsonSchemaValidator) -> Any:
     original_schema = validator.schema
     return normalize_schema_rec(validator, original_schema)
 
 
-def normalize_schema_rec(validator: Draft7Validator, original_schema: Any) -> Any:
+def normalize_schema_rec(validator: JsonSchemaValidator, original_schema: Any) -> Any:
     if isinstance(original_schema, (bool, str, float, int)) or original_schema is None:
         return original_schema
 

--- a/src/karapace/core/compatibility/schema_compatibility.py
+++ b/src/karapace/core/compatibility/schema_compatibility.py
@@ -11,13 +11,13 @@ from avro.compatibility import (
     SchemaIncompatibilityType,
 )
 from avro.schema import Schema as AvroSchema
-from jsonschema import Draft7Validator
 from karapace.core.compatibility import CompatibilityModes
 from karapace.core.compatibility.jsonschema.checks import compatibility as jsonschema_compatibility, incompatible_schema
 from karapace.core.compatibility.protobuf.checks import check_protobuf_schema_compatibility
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.schema_models import ParsedTypedSchema, ValidatedTypedSchema
 from karapace.core.schema_type import SchemaType
+from karapace.core.typing import JsonSchemaValidator
 from karapace.core.utils import assert_never
 
 import logging
@@ -71,8 +71,12 @@ class SchemaCompatibility:
                     ),
                 )
         elif old_schema.schema_type is SchemaType.JSONSCHEMA:
-            assert isinstance(old_schema.schema, Draft7Validator)
-            assert isinstance(new_schema.schema, Draft7Validator)
+            # The parsed schema may be any JSON Schema draft validator (Draft-7 default,
+            # or 2019-09 / 2020-12 when selected via $schema). The compatibility engine
+            # is still Draft-7-shaped; cross-draft compatibility semantics are pending, see
+            # docs/json-schema-draft-compatibility-strategy.md.
+            assert isinstance(old_schema.schema, JsonSchemaValidator)
+            assert isinstance(new_schema.schema, JsonSchemaValidator)
             if compatibility_mode in {CompatibilityModes.BACKWARD, CompatibilityModes.BACKWARD_TRANSITIVE}:
                 result = SchemaCompatibility.check_jsonschema_compatibility(
                     reader=new_schema.schema,
@@ -131,7 +135,9 @@ class SchemaCompatibility:
         return AvroChecker().get_compatibility(reader=reader_schema, writer=writer_schema)
 
     @staticmethod
-    def check_jsonschema_compatibility(reader: Draft7Validator, writer: Draft7Validator) -> SchemaCompatibilityResult:
+    def check_jsonschema_compatibility(
+        reader: JsonSchemaValidator, writer: JsonSchemaValidator
+    ) -> SchemaCompatibilityResult:
         return jsonschema_compatibility(reader, writer)
 
     @staticmethod

--- a/src/karapace/core/schema_models.py
+++ b/src/karapace/core/schema_models.py
@@ -10,8 +10,8 @@ from avro.name import Names as AvroNames
 from avro.schema import make_avsc_object, parse as avro_parse, Schema as AvroSchema
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from jsonschema import Draft7Validator
 from jsonschema.exceptions import SchemaError
+from jsonschema.validators import Draft7Validator, validator_for
 from karapace.core.dependency import Dependency
 from karapace.core.errors import InvalidSchema, InvalidVersion, VersionNotFoundException
 from karapace.core.protobuf import protopace
@@ -27,7 +27,7 @@ from karapace.core.protobuf.proto_normalizations import NormalizedProtobufSchema
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.schema_references import Reference
 from karapace.core.schema_type import SchemaType
-from karapace.core.typing import JsonObject, SchemaId, Subject, Version, VersionTag
+from karapace.core.typing import JsonObject, JsonSchemaValidator, SchemaId, Subject, Version, VersionTag
 from karapace.core.utils import assert_never, json_decode, json_encode, JSONDecodeError
 from typing import Any, cast, Final, final
 
@@ -49,17 +49,21 @@ def parse_avro_schema_definition(s: str, validate_enum_symbols: bool = True, val
     return avro_parse(json_encode(json_data), validate_enum_symbols=validate_enum_symbols, validate_names=validate_names)
 
 
-def parse_jsonschema_definition(schema_definition: str) -> Draft7Validator:
-    """Parses and validates `schema_definition`.
+def parse_jsonschema_definition(schema_definition: str) -> JsonSchemaValidator:
+    """Parses and validates `schema_definition`, selecting the draft from `$schema`.
+
+    Defaults to Draft-7 when `$schema` is absent or unrecognized, preserving prior behavior.
 
     Raises:
-        SchemaError: If `schema_definition` is not a valid Draft7 schema.
+        SchemaError: If `schema_definition` is not valid for its declared draft.
     """
     schema = json_decode(schema_definition)
     # TODO: Annotations dictate Mapping[str, Any] here, but we have unit tests that
     #  use bool values and fail if we assert isinstance(_, dict).
-    Draft7Validator.check_schema(schema)  # type: ignore[arg-type]
-    return Draft7Validator(schema)  # type: ignore[arg-type]
+    validator_cls = validator_for(schema, default=Draft7Validator)  # type: ignore[arg-type]
+    validator_cls.check_schema(schema)  # type: ignore[arg-type]
+    validator = validator_cls(schema)  # type: ignore[arg-type]
+    return cast(JsonSchemaValidator, validator)
 
 
 def _format_protobuf(schema: str, dependencies: Collection[Dependency], name: str = "schema.proto") -> str:
@@ -107,7 +111,7 @@ class TypedSchema:
         *,
         schema_type: SchemaType,
         schema_str: str,
-        schema: Draft7Validator | AvroSchema | ProtobufSchema | None = None,
+        schema: JsonSchemaValidator | AvroSchema | ProtobufSchema | None = None,
         references: Sequence[Reference] | None = None,
         dependencies: Mapping[str, Dependency] | None = None,
     ) -> None:
@@ -116,7 +120,7 @@ class TypedSchema:
         Args:
             schema_type (SchemaType): The type of the schema
             schema_str (str): The original schema string
-            schema (Optional[Union[Draft7Validator, AvroSchema, ProtobufSchema]]): The parsed and validated schema
+            schema (Optional[Union[JsonSchemaValidator, AvroSchema, ProtobufSchema]]): The parsed and validated schema
             references (Optional[List[Dependency]]): The references of schema
         """
         self.schema_type: Final = schema_type
@@ -147,7 +151,7 @@ class TypedSchema:
     def normalize_schema_str(
         schema_str: str,
         schema_type: SchemaType,
-        schema: Draft7Validator | AvroSchema | ProtobufSchema | None = None,
+        schema: JsonSchemaValidator | AvroSchema | ProtobufSchema | None = None,
     ) -> str:
         if schema_type is SchemaType.AVRO or schema_type is SchemaType.JSONSCHEMA:
             try:
@@ -184,7 +188,7 @@ class TypedSchema:
         )
 
     @property
-    def schema(self) -> Draft7Validator | AvroSchema | ProtobufSchema:
+    def schema(self) -> JsonSchemaValidator | AvroSchema | ProtobufSchema:
         parsed_typed_schema = parse(
             schema_type=self.schema_type,
             schema_str=self.schema_str,
@@ -235,7 +239,7 @@ def parse(
     if schema_type not in [SchemaType.AVRO, SchemaType.JSONSCHEMA, SchemaType.PROTOBUF]:
         raise InvalidSchema(f"Unknown parser {schema_type} for {schema_str}")
 
-    parsed_schema: Draft7Validator | AvroSchema | ProtobufSchema
+    parsed_schema: JsonSchemaValidator | AvroSchema | ProtobufSchema
     if schema_type is SchemaType.AVRO:
         try:
             if dependencies:
@@ -329,11 +333,11 @@ class ParsedTypedSchema(TypedSchema):
         self,
         schema_type: SchemaType,
         schema_str: str,
-        schema: Draft7Validator | AvroSchema | ProtobufSchema,
+        schema: JsonSchemaValidator | AvroSchema | ProtobufSchema,
         references: Sequence[Reference] | None = None,
         dependencies: Mapping[str, Dependency] | None = None,
     ) -> None:
-        self._schema_cached: Draft7Validator | AvroSchema | ProtobufSchema | None = schema
+        self._schema_cached: JsonSchemaValidator | AvroSchema | ProtobufSchema | None = schema
 
         super().__init__(
             schema_type=schema_type,
@@ -384,7 +388,7 @@ class ParsedTypedSchema(TypedSchema):
         return self.schema_type is other.schema_type and self.schema == other.schema and self.references == other.references
 
     @property
-    def schema(self) -> Draft7Validator | AvroSchema | ProtobufSchema:
+    def schema(self) -> JsonSchemaValidator | AvroSchema | ProtobufSchema:
         if self._schema_cached is not None:
             return self._schema_cached
         self._schema_cached = super().schema
@@ -417,7 +421,7 @@ class ValidatedTypedSchema(ParsedTypedSchema):
         self,
         schema_type: SchemaType,
         schema_str: str,
-        schema: Draft7Validator | AvroSchema | ProtobufSchema,
+        schema: JsonSchemaValidator | AvroSchema | ProtobufSchema,
         references: list[Reference] | None = None,
         dependencies: dict[str, Dependency] | None = None,
     ) -> None:

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -26,7 +26,6 @@ from collections.abc import Mapping, Sequence
 from confluent_kafka import Message, TopicCollection, TopicPartition
 from contextlib import closing, ExitStack
 from enum import Enum
-from jsonschema.validators import Draft7Validator
 from karapace.core.instrumentation.tracer import Tracer
 from karapace.core import constants
 from karapace.core.config import Config
@@ -47,7 +46,7 @@ from karapace.core.schema_models import parse_protobuf_schema_definition, Schema
 from karapace.core.schema_references import LatestVersionReference, Reference, reference_from_mapping, Referents
 
 from karapace.core.stats import StatsClient
-from karapace.core.typing import JsonObject, SchemaReaderStoppper, Subject, Version
+from karapace.core.typing import JsonObject, JsonSchemaValidator, SchemaReaderStoppper, Subject, Version
 from karapace.core.utils import json_decode, JSONDecodeError, shutdown
 from threading import Event, Lock, Thread
 from typing import Final, cast
@@ -665,7 +664,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         # for the REST API to return data that is formatted differently from
         # what is available in the topic.
 
-        parsed_schema: Draft7Validator | AvroSchema | ProtobufSchema | None = None
+        parsed_schema: JsonSchemaValidator | AvroSchema | ProtobufSchema | None = None
         resolved_dependencies: dict[str, Dependency] | None = None
         if schema_type_parsed == SchemaType.JSONSCHEMA:
             try:

--- a/src/karapace/core/typing.py
+++ b/src/karapace/core/typing.py
@@ -13,7 +13,7 @@ from karapace.core.errors import InvalidVersion
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, ValidationInfo
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
-from typing import Any, ClassVar, NewType, TypeAlias, Union
+from typing import Any, ClassVar, NewType, Protocol, runtime_checkable, TypeAlias, Union
 
 import functools
 
@@ -21,6 +21,29 @@ JsonArray: TypeAlias = list["JsonData"]
 JsonObject: TypeAlias = dict[str, "JsonData"]
 JsonScalar: TypeAlias = Union[str, int, float, None]
 JsonData: TypeAlias = Union[JsonScalar, JsonObject, JsonArray]
+
+
+@runtime_checkable
+class JsonSchemaValidator(Protocol):
+    """Structural type for a parsed JSON Schema validator across drafts.
+
+    `jsonschema.protocols.Validator` is neither runtime-checkable nor declares the
+    `resolver`/`ID_OF` members the compatibility engine relies on, so we declare the
+    subset Karapace uses here. Satisfied by Draft7/Draft201909/Draft202012 validators.
+    """
+
+    schema: Any
+
+    @staticmethod
+    def ID_OF(contents: Any) -> str | None: ...
+
+    @property
+    def resolver(self) -> Any: ...
+
+    def iter_errors(self, instance: Any) -> Any: ...
+
+    def is_valid(self, instance: Any) -> bool: ...
+
 
 # JSON types suitable as arguments, i.e. using abstract types that don't allow mutation.
 ArgJsonArray: TypeAlias = Sequence["ArgJsonData"]

--- a/tests/integration/test_jsonschema.py
+++ b/tests/integration/test_jsonschema.py
@@ -1225,3 +1225,49 @@ async def test_same_jsonschema_must_have_same_id(
         )
         assert second_res.status_code == 200
         assert first_id == second_res.json()["id"]
+
+
+@pytest.mark.parametrize(
+    "schema_uri, draft_schema",
+    [
+        (
+            "https://json-schema.org/draft/2019-09/schema",
+            {"type": "object", "properties": {"a": {"type": "string"}}, "dependentRequired": {"a": ["b"]}},
+        ),
+        (
+            "https://json-schema.org/draft/2020-12/schema",
+            {"type": "object", "properties": {"items": {"type": "array", "prefixItems": [{"type": "integer"}]}}},
+        ),
+    ],
+)
+async def test_schemaregistry_register_retrieve_list_newer_drafts(
+    registry_async_client: Client,
+    schema_uri: str,
+    draft_schema: dict,
+) -> None:
+    """A newer-draft schema (declared via $schema, using a draft-specific keyword) can be
+    registered, retrieved, and appears in the subject's version listing."""
+    subject = new_random_name("subject")
+    schema_str = json.dumps({"$schema": schema_uri, **draft_schema})
+
+    register_res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schema": schema_str, "schemaType": SchemaType.JSONSCHEMA.value},
+    )
+    assert register_res.status_code == 200
+    schema_id = register_res.json()["id"]
+    assert schema_id
+
+    # retrieve by version
+    version_res = await registry_async_client.get(f"subjects/{subject}/versions/latest")
+    assert version_res.status_code == 200
+    assert json.loads(version_res.json()["schema"])["$schema"] == schema_uri
+
+    # retrieve by id
+    id_res = await registry_async_client.get(f"schemas/ids/{schema_id}")
+    assert id_res.status_code == 200
+
+    # version listing
+    versions_res = await registry_async_client.get(f"subjects/{subject}/versions")
+    assert versions_res.status_code == 200
+    assert versions_res.json() == [1]

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -5,20 +5,36 @@ Copyright (c) 2024 Aiven Ltd
 See LICENSE for details
 """
 
+import json
 import operator
+import socket
 from collections.abc import Callable
 from typing import Any
 
 import pytest
 from avro.schema import Schema as AvroSchema
 
-from karapace.core.errors import InvalidVersion, VersionNotFoundException
-from karapace.core.schema_models import SchemaVersion, TypedSchema, Versioner, parse_avro_schema_definition
+from karapace.core.compatibility import CompatibilityModes
+from karapace.core.compatibility.schema_compatibility import SchemaCompatibility
+from karapace.core.errors import InvalidSchema, InvalidVersion, VersionNotFoundException
+from karapace.core.schema_models import (
+    ParsedTypedSchema,
+    SchemaVersion,
+    TypedSchema,
+    ValidatedTypedSchema,
+    Versioner,
+    parse_avro_schema_definition,
+    parse_jsonschema_definition,
+)
 from karapace.core.schema_type import SchemaType
 from karapace.core.typing import Version, VersionTag
 
 # Schema versions factory fixture type
 SVFCallable = Callable[[None], Callable[[int, dict[str, Any]], dict[int, SchemaVersion]]]
+
+DRAFT7_URI = "http://json-schema.org/draft-07/schema#"
+DRAFT201909_URI = "https://json-schema.org/draft/2019-09/schema"
+DRAFT202012_URI = "https://json-schema.org/draft/2020-12/schema"
 
 
 class TestVersion:
@@ -173,3 +189,143 @@ class TestVersioner:
         """
         with pytest.raises(InvalidVersion):
             Versioner.validate_tag(tag=tag)
+
+
+class TestJsonSchemaDraftRouting:
+    @pytest.mark.parametrize(
+        "schema_uri, expected_validator",
+        [
+            (None, "Draft7Validator"),
+            ("http://json-schema.org/draft-04/schema#", "Draft4Validator"),
+            ("http://json-schema.org/draft-06/schema#", "Draft6Validator"),
+            (DRAFT7_URI, "Draft7Validator"),
+            (DRAFT201909_URI, "Draft201909Validator"),
+            (DRAFT202012_URI, "Draft202012Validator"),
+        ],
+    )
+    def test_draft_selected_from_schema_keyword(self, schema_uri: str | None, expected_validator: str):
+        schema: dict[str, Any] = {"type": "object", "properties": {"a": {"type": "string"}}}
+        if schema_uri is not None:
+            schema["$schema"] = schema_uri
+        parsed = parse_jsonschema_definition(json.dumps(schema))
+        assert type(parsed).__name__ == expected_validator
+
+    def test_no_schema_keyword_defaults_to_draft7(self):
+        """No `$schema` must parse as Draft-7, preserving prior behavior (no regression)."""
+        parsed = parse_jsonschema_definition('{"type":"object"}')
+        assert type(parsed).__name__ == "Draft7Validator"
+
+    def test_unknown_schema_uri_defaults_to_draft7(self):
+        """An unrecognized `$schema` URI falls back to Draft-7 rather than raising."""
+        parsed = parse_jsonschema_definition('{"$schema":"http://example.com/unknown","type":"object"}')
+        assert type(parsed).__name__ == "Draft7Validator"
+
+    def test_2020_12_prefix_items_is_accepted(self):
+        parsed = parse_jsonschema_definition(
+            json.dumps({"$schema": DRAFT202012_URI, "type": "array", "prefixItems": [{"type": "integer"}]})
+        )
+        assert type(parsed).__name__ == "Draft202012Validator"
+
+    def test_2020_12_defs_ref_is_accepted(self):
+        parsed = parse_jsonschema_definition(
+            json.dumps({"$schema": DRAFT202012_URI, "$defs": {"a": {"type": "string"}}, "$ref": "#/$defs/a"})
+        )
+        assert type(parsed).__name__ == "Draft202012Validator"
+
+    def test_2019_09_dependent_required_is_accepted(self):
+        parsed = parse_jsonschema_definition(
+            json.dumps({"$schema": DRAFT201909_URI, "type": "object", "dependentRequired": {"a": ["b"]}})
+        )
+        assert type(parsed).__name__ == "Draft201909Validator"
+
+    def test_invalid_schema_for_declared_draft_raises(self):
+        """A schema that is invalid for its declared draft must be rejected, not silently accepted."""
+        # `type` must be a string or array of strings; an integer is invalid in every draft.
+        with pytest.raises(InvalidSchema):
+            ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, json.dumps({"$schema": DRAFT202012_URI, "type": 123}))
+
+    def test_no_network_fetch_on_parse(self, monkeypatch: pytest.MonkeyPatch):
+        """Parsing/validating any built-in draft must not trigger network I/O."""
+
+        def _no_connect(*args: Any, **kwargs: Any):
+            raise AssertionError("network access attempted during schema parse")
+
+        monkeypatch.setattr(socket.socket, "connect", _no_connect)
+        for uri in (DRAFT7_URI, DRAFT201909_URI, DRAFT202012_URI):
+            validator = parse_jsonschema_definition(
+                json.dumps({"$schema": uri, "type": "object", "properties": {"a": {"type": "string"}}})
+            )
+            # iter_errors exercises the validator against an instance without any remote fetch.
+            assert list(validator.iter_errors({"a": "x"})) == []
+
+    def test_stored_newer_draft_schema_loads_and_is_compatible_checkable(self):
+        """A previously stored 2020-12 schema must load and flow through compat without raising."""
+        schema_str = json.dumps(
+            {
+                "$schema": DRAFT202012_URI,
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "additionalProperties": True,
+            }
+        )
+        parsed = ParsedTypedSchema.parse(SchemaType.JSONSCHEMA, schema_str)
+        assert type(parsed.schema).__name__ == "Draft202012Validator"
+
+        result = SchemaCompatibility.check_compatibility(parsed, parsed, CompatibilityModes.BACKWARD)
+        assert result is not None
+
+    # Cross-draft smoke tests: the compatibility engine is still Draft-7-shaped (cross-draft
+    # *semantics* are a later ticket, see docs/json-schema-draft-compatibility-strategy.md).
+    # These pin only that mixing drafts across versions does NOT crash the engine — they assert a
+    # result is returned, never a specific compatible/incompatible verdict.
+    @pytest.mark.parametrize(
+        "old_uri, new_uri",
+        [
+            (DRAFT7_URI, DRAFT202012_URI),
+            (DRAFT202012_URI, DRAFT7_URI),
+            (DRAFT7_URI, DRAFT201909_URI),
+            (DRAFT201909_URI, DRAFT202012_URI),
+            (None, DRAFT202012_URI),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "compatibility_mode",
+        [CompatibilityModes.BACKWARD, CompatibilityModes.FORWARD, CompatibilityModes.FULL],
+    )
+    def test_cross_draft_compatibility_check_does_not_crash(
+        self,
+        old_uri: str | None,
+        new_uri: str | None,
+        compatibility_mode: CompatibilityModes,
+    ):
+        def _schema(uri: str | None, extra_property: bool) -> str:
+            schema: dict[str, Any] = {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "additionalProperties": True,
+            }
+            if extra_property:
+                schema["properties"]["b"] = {"type": "integer"}
+            if uri is not None:
+                schema["$schema"] = uri
+            return json.dumps(schema)
+
+        old = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, _schema(old_uri, extra_property=False))
+        new = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, _schema(new_uri, extra_property=True))
+
+        result = SchemaCompatibility.check_compatibility(old, new, compatibility_mode)
+        assert result is not None
+
+    def test_cross_draft_array_model_check_does_not_crash(self):
+        """Draft-7 list-`items` tuple vs 2020-12 `prefixItems` tuple must not crash the engine.
+
+        This is the §9 "array-model ambiguity" case; we only assert it returns a result, since the
+        canonicalization that makes the verdict correct is a later ticket.
+        """
+        draft7_tuple = json.dumps({"$schema": DRAFT7_URI, "type": "array", "items": [{"type": "integer"}]})
+        draft2020_tuple = json.dumps({"$schema": DRAFT202012_URI, "type": "array", "prefixItems": [{"type": "integer"}]})
+        old = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, draft7_tuple)
+        new = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, draft2020_tuple)
+
+        result = SchemaCompatibility.check_compatibility(old, new, CompatibilityModes.BACKWARD)
+        assert result is not None


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Karapace hardcoded Draft7Validator for all JSON Schema parsing, so schemas declaring a newer $schema were silently validated against the Draft-7 metaschema.

This PR detects the draft from $schema and routes to the matching validator (Draft7 / Draft201909 / Draft202012), while keeping Draft-7 as the default for schemas with no $schema (or an unrecognized one) — preserving all existing behavior.

- 2019-09 & 2020-12 schemas register
- draft-specific keywords validate
- no $schema → Draft-7 (no regression)
- existing Draft-7 schemas unchanged

Scope: validation + storage only

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
