### PR TITLE
fix(serializer): offload Avro produce writes off the event loop

### DIFF
--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -359,6 +359,10 @@ class SchemaRegistrySerializer:
         self._avro_readers_by_thread: weakref.WeakKeyDictionary[threading.Thread, TTLCache[SchemaId, DatumReader]] = (
             weakref.WeakKeyDictionary()
         )
+        self._avro_writers_lock = threading.Lock()
+        self._avro_writers_by_thread: weakref.WeakKeyDictionary[threading.Thread, TTLCache[SchemaId, DatumWriter]] = (
+            weakref.WeakKeyDictionary()
+        )
 
     async def close(self) -> None:
         if self.registry_client:
@@ -412,15 +416,17 @@ class SchemaRegistrySerializer:
 
     async def serialize(self, schema: TypedSchema, value: dict) -> bytes:
         schema_id = self.schemas_to_ids[str(schema)]
-        with io.BytesIO() as bio:
-            bio.write(struct.pack(HEADER_FORMAT, START_BYTE, schema_id))
-            try:
+        try:
+            if schema.schema_type is SchemaType.AVRO:
+                return await asyncio.to_thread(self._write_avro_value, SchemaId(schema_id), schema, value)
+            with io.BytesIO() as bio:
+                bio.write(struct.pack(HEADER_FORMAT, START_BYTE, schema_id))
                 write_value(self.config, schema, bio, value)
                 return bio.getvalue()
-            except ProtobufTypeException as e:
-                raise InvalidMessageSchema("Object does not fit to stored schema") from e
-            except avro.errors.AvroTypeException as e:
-                raise InvalidMessageSchema("Object does not fit to stored schema") from e
+        except ProtobufTypeException as e:
+            raise InvalidMessageSchema("Object does not fit to stored schema") from e
+        except avro.errors.AvroTypeException as e:
+            raise InvalidMessageSchema("Object does not fit to stored schema") from e
 
     async def deserialize(self, bytes_: bytes) -> dict:
         with io.BytesIO(bytes_) as bio:
@@ -459,6 +465,26 @@ class SchemaRegistrySerializer:
 
     def _read_avro_value(self, schema_id: SchemaId, schema: TypedSchema, bio: io.BytesIO) -> Any:
         return read_value(self.config, schema, bio, avro_reader=self._get_avro_reader(schema_id, schema))
+
+    def _get_avro_writer(self, schema_id: SchemaId, schema: TypedSchema) -> DatumWriter:
+        current_thread = threading.current_thread()
+        with self._avro_writers_lock:
+            writer_cache = self._avro_writers_by_thread.get(current_thread)
+            if writer_cache is None:
+                writer_cache = TTLCache(maxsize=10000, ttl=600)
+                self._avro_writers_by_thread[current_thread] = writer_cache
+
+        writer = writer_cache.get(schema_id)
+        if writer is None:
+            writer = DatumWriter(writers_schema=schema.schema)
+            writer_cache[schema_id] = writer
+        return writer
+
+    def _write_avro_value(self, schema_id: SchemaId, schema: TypedSchema, value: dict) -> bytes:
+        with io.BytesIO() as bio:
+            bio.write(struct.pack(HEADER_FORMAT, START_BYTE, schema_id))
+            write_value(self.config, schema, bio, value, avro_writer=self._get_avro_writer(schema_id, schema))
+            return bio.getvalue()
 
 
 def _jsonify_avro_payload(value: Any) -> Any:
@@ -561,7 +587,9 @@ def read_value(config: Config, schema: TypedSchema, bio: io.BytesIO, avro_reader
     raise ValueError("Unknown schema type")
 
 
-def write_value(config: Config, schema: TypedSchema, bio: io.BytesIO, value: dict) -> None:
+def write_value(
+    config: Config, schema: TypedSchema, bio: io.BytesIO, value: dict, avro_writer: DatumWriter | None = None
+) -> None:
     if schema.schema_type is SchemaType.AVRO:
         # Backwards compatibility: Support JSON encoded data without the tags for unions.
         if avro.io.validate(schema.schema, value):
@@ -569,7 +597,7 @@ def write_value(config: Config, schema: TypedSchema, bio: io.BytesIO, value: dic
         else:
             data = flatten_unions(schema.schema, value)
 
-        writer = DatumWriter(writers_schema=schema.schema)
+        writer = avro_writer if avro_writer is not None else DatumWriter(writers_schema=schema.schema)
         writer.write(data, BinaryEncoder(bio))
     elif schema.schema_type is SchemaType.JSONSCHEMA:
         try:

--- a/src/karapace/core/serialization.py
+++ b/src/karapace/core/serialization.py
@@ -359,10 +359,6 @@ class SchemaRegistrySerializer:
         self._avro_readers_by_thread: weakref.WeakKeyDictionary[threading.Thread, TTLCache[SchemaId, DatumReader]] = (
             weakref.WeakKeyDictionary()
         )
-        self._avro_writers_lock = threading.Lock()
-        self._avro_writers_by_thread: weakref.WeakKeyDictionary[threading.Thread, TTLCache[SchemaId, DatumWriter]] = (
-            weakref.WeakKeyDictionary()
-        )
 
     async def close(self) -> None:
         if self.registry_client:
@@ -466,24 +462,10 @@ class SchemaRegistrySerializer:
     def _read_avro_value(self, schema_id: SchemaId, schema: TypedSchema, bio: io.BytesIO) -> Any:
         return read_value(self.config, schema, bio, avro_reader=self._get_avro_reader(schema_id, schema))
 
-    def _get_avro_writer(self, schema_id: SchemaId, schema: TypedSchema) -> DatumWriter:
-        current_thread = threading.current_thread()
-        with self._avro_writers_lock:
-            writer_cache = self._avro_writers_by_thread.get(current_thread)
-            if writer_cache is None:
-                writer_cache = TTLCache(maxsize=10000, ttl=600)
-                self._avro_writers_by_thread[current_thread] = writer_cache
-
-        writer = writer_cache.get(schema_id)
-        if writer is None:
-            writer = DatumWriter(writers_schema=schema.schema)
-            writer_cache[schema_id] = writer
-        return writer
-
     def _write_avro_value(self, schema_id: SchemaId, schema: TypedSchema, value: dict) -> bytes:
         with io.BytesIO() as bio:
             bio.write(struct.pack(HEADER_FORMAT, START_BYTE, schema_id))
-            write_value(self.config, schema, bio, value, avro_writer=self._get_avro_writer(schema_id, schema))
+            write_value(self.config, schema, bio, value)
             return bio.getvalue()
 
 
@@ -587,9 +569,7 @@ def read_value(config: Config, schema: TypedSchema, bio: io.BytesIO, avro_reader
     raise ValueError("Unknown schema type")
 
 
-def write_value(
-    config: Config, schema: TypedSchema, bio: io.BytesIO, value: dict, avro_writer: DatumWriter | None = None
-) -> None:
+def write_value(config: Config, schema: TypedSchema, bio: io.BytesIO, value: dict) -> None:
     if schema.schema_type is SchemaType.AVRO:
         # Backwards compatibility: Support JSON encoded data without the tags for unions.
         if avro.io.validate(schema.schema, value):
@@ -597,7 +577,7 @@ def write_value(
         else:
             data = flatten_unions(schema.schema, value)
 
-        writer = avro_writer if avro_writer is not None else DatumWriter(writers_schema=schema.schema)
+        writer = DatumWriter(writers_schema=schema.schema)
         writer.write(data, BinaryEncoder(bio))
     elif schema.schema_type is SchemaType.JSONSCHEMA:
         try:

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -593,34 +593,6 @@ async def test_serialize_offloads_avro_write_to_thread(karapace_container: Karap
     assert await serializer.deserialize(payload) == record
 
 
-async def test_serialize_reuses_datum_writer_for_map_union_schema(karapace_container: KarapaceContainer) -> None:
-    mock_registry_client = Mock()
-    get_latest_schema_future = asyncio.Future()
-    get_latest_schema_future.set_result((1, MAP_UNION_AVRO_SCHEMA, Versioner.V(1)))
-    mock_registry_client.get_schema.return_value = get_latest_schema_future
-
-    serializer = await make_ser_deser(karapace_container, mock_registry_client)
-    schema = await serializer.get_schema_for_subject(Subject("top"))
-    record = {"id": "one", "props": {"present": "yes", "missing": None}}
-    original_datum_writer = avro.io.DatumWriter
-    datum_writer_init_count = 0
-
-    class CountingDatumWriter:
-        def __init__(self, writers_schema):
-            nonlocal datum_writer_init_count
-            datum_writer_init_count += 1
-            self._delegate = original_datum_writer(writers_schema=writers_schema)
-
-        def write(self, datum, encoder):
-            return self._delegate.write(datum, encoder)
-
-    with patch("karapace.core.serialization.DatumWriter", CountingDatumWriter):
-        await serializer.serialize(schema, record)
-        await serializer.serialize(schema, record)
-
-    assert datum_writer_init_count == 1
-
-
 async def test_deserialize_converts_avro_bytes_to_base64_strings(karapace_container: KarapaceContainer) -> None:
     mock_registry_client = Mock()
     get_latest_schema_future = asyncio.Future()

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -567,6 +567,60 @@ async def test_deserialize_reuses_datum_reader_for_complex_avro_schema(karapace_
     assert datum_reader_init_count == 1
 
 
+async def test_serialize_offloads_avro_write_to_thread(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, MAP_UNION_AVRO_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+    schema_for_id_one_future = asyncio.Future()
+    schema_for_id_one_future.set_result((MAP_UNION_AVRO_SCHEMA, [Subject("stub")]))
+    mock_registry_client.get_schema_for_id.return_value = schema_for_id_one_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {"id": "one", "props": {"present": "yes", "missing": None}}
+
+    to_thread_calls: list[str] = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    with patch("karapace.core.serialization.asyncio.to_thread", side_effect=fake_to_thread):
+        payload = await serializer.serialize(schema, record)
+
+    assert to_thread_calls == ["_write_avro_value"]
+    assert await serializer.deserialize(payload) == record
+
+
+async def test_serialize_reuses_datum_writer_for_map_union_schema(karapace_container: KarapaceContainer) -> None:
+    mock_registry_client = Mock()
+    get_latest_schema_future = asyncio.Future()
+    get_latest_schema_future.set_result((1, MAP_UNION_AVRO_SCHEMA, Versioner.V(1)))
+    mock_registry_client.get_schema.return_value = get_latest_schema_future
+
+    serializer = await make_ser_deser(karapace_container, mock_registry_client)
+    schema = await serializer.get_schema_for_subject(Subject("top"))
+    record = {"id": "one", "props": {"present": "yes", "missing": None}}
+    original_datum_writer = avro.io.DatumWriter
+    datum_writer_init_count = 0
+
+    class CountingDatumWriter:
+        def __init__(self, writers_schema):
+            nonlocal datum_writer_init_count
+            datum_writer_init_count += 1
+            self._delegate = original_datum_writer(writers_schema=writers_schema)
+
+        def write(self, datum, encoder):
+            return self._delegate.write(datum, encoder)
+
+    with patch("karapace.core.serialization.DatumWriter", CountingDatumWriter):
+        await serializer.serialize(schema, record)
+        await serializer.serialize(schema, record)
+
+    assert datum_writer_init_count == 1
+
+
 async def test_deserialize_converts_avro_bytes_to_base64_strings(karapace_container: KarapaceContainer) -> None:
     mock_registry_client = Mock()
     get_latest_schema_future = asyncio.Future()


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

The read/fetch path was fixed in #1282 (thread offload + reader cache) but the produce/write path was left synchronous. 

For large batches with map/array-of-union schemas, the inline Avro encode in serialize() blocks the event loop long enough to time out health checks (504). 

Mirror the read-path treatment: offload writes via asyncio.to_thread and cache DatumWriter per thread. Closed PR #1281 attempted a writer cache but kept the write inline, so it would not have fixed the loop stall.

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
