### PR TITLE
Implement JSON Schema Draft 2019-09 / 2020-12 compatibility checking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -866,7 +866,8 @@ preserves the previous behaviour and matches the default used by Confluent Schem
      - ``https://json-schema.org/draft/2020-12/schema``
      - Validated with its own draft validator
 
-Compatibility checking, however, is still computed under Draft-7 semantics for all drafts — see `Limitations`_ below.
+Compatibility checking canonicalizes the renamed newer-draft keywords and rejects the ones it cannot yet evaluate — see
+`Compatibility behavior`_ and `Limitations`_ below.
 
 Compatibility behavior
 ----------------------
@@ -876,16 +877,23 @@ global default). The supported modes are ``NONE``, ``BACKWARD``, ``BACKWARD_TRAN
 ``FORWARD_TRANSITIVE``, ``FULL`` and ``FULL_TRANSITIVE``. Transitive modes check the new schema against *all* previous
 versions; non-transitive modes only check against the latest one.
 
-For JSON Schema, compatibility is computed under Draft-7 semantics. The following keywords are taken into account when
-comparing versions: ``type``, ``properties``, ``required``, ``additionalProperties``, ``enum``, ``$ref``, the numeric
-bounds (``minimum``, ``maximum``, ``exclusiveMinimum``, ``exclusiveMaximum``, ``multipleOf``), the string constraints
-(``minLength``, ``maxLength``, ``pattern``), the array constraints (``items``, ``additionalItems``, ``minItems``,
-``maxItems``, ``uniqueItems``), the object-size constraints (``minProperties``, ``maxProperties``, ``propertyNames``,
-``patternProperties``) and the dependency keywords (``dependencies``, ``dependentSchemas``).
+The following keywords are taken into account when comparing versions: ``type``, ``properties``, ``required``,
+``additionalProperties``, ``enum``, ``$ref``, the numeric bounds (``minimum``, ``maximum``, ``exclusiveMinimum``,
+``exclusiveMaximum``, ``multipleOf``), the string constraints (``minLength``, ``maxLength``, ``pattern``), the array
+constraints (``items``, ``additionalItems``, ``minItems``, ``maxItems``, ``uniqueItems``), the object-size constraints
+(``minProperties``, ``maxProperties``, ``propertyNames``, ``patternProperties``) and the dependency keywords
+(``dependencies``, ``dependentSchemas``).
+
+Draft 2019-09 / 2020-12 keywords that are renames or relocations of Draft-7 keywords are **canonicalized** before
+comparison, so they are evaluated correctly and are interchangeable across drafts within a subject:
+
+* ``$defs`` is treated as ``definitions``
+* ``prefixItems`` is treated as the array (tuple) form of ``items``; a sibling ``items`` schema is treated as
+  ``additionalItems``
+* ``dependentRequired`` is treated as the string-array form of ``dependencies``
 
 Examples of backward-compatible evolutions (a new schema can read data written with the old one):
 
-* Adding an optional property to an open content model (``additionalProperties: true``)
 * Widening a numeric range (lowering ``minimum`` or raising ``maximum``)
 * Relaxing string constraints (lowering ``minLength``, raising ``maxLength``, removing ``pattern``)
 * Adding options to an ``enum``
@@ -898,21 +906,28 @@ Examples of backward-**incompatible** evolutions:
 * Removing a property from a closed content model (``additionalProperties: false``)
 * Tightening ``additionalProperties`` (from ``true`` to ``false``)
 * Adding a ``required`` property to a content model that is not open
+* Adding a positional ``prefixItems`` entry the previous version did not require
 
-Forward compatibility applies the mirror of these rules, and full compatibility requires both directions.
+Forward compatibility applies the mirror of these rules, and full compatibility requires both directions. Because the
+renamed keywords share a single canonical form, a subject can evolve across drafts (e.g. a Draft-7 version followed by a
+2020-12 version) and compatibility is evaluated on that canonical form.
 
 Limitations
 -----------
 
 Schema **validation** is draft-specific: a schema is validated against the draft declared in ``$schema`` (defaulting to
-Draft-7), so newer-draft keywords such as ``$defs``, ``prefixItems``, ``dependentRequired`` / ``dependentSchemas``,
-``$recursiveRef`` / ``$dynamicRef`` and ``unevaluatedProperties`` / ``unevaluatedItems`` are validated with their
-intended semantics.
+Draft-7), so newer-draft keywords are validated with their intended semantics.
 
-**Compatibility checking**, however, is still computed under Draft-7 semantics for every draft. When comparing versions,
-newer-draft keywords are treated as unknown (ignored) or interpreted with Draft-7 meaning — for example ``prefixItems``
-is not recognized as a tuple and ``$defs`` is not resolved as ``definitions`` is. A schema using these keywords is
-validated and stored correctly, but the newer-draft behaviour is not yet applied during compatibility checks.
+Some newer-draft keywords cannot yet be evaluated correctly during **compatibility checking**. To avoid returning a
+result that looks safe but is not, Karapace **rejects the compatibility check** (fails closed) when either the previous
+or the new version uses any of: ``unevaluatedProperties``, ``unevaluatedItems``, ``$dynamicRef``, ``$dynamicAnchor``,
+``$recursiveRef``, ``$recursiveAnchor`` or ``$vocabulary``. The registration is rejected with an error naming the
+keyword, rather than accepted and later surprising a producer or consumer at runtime.
+
+Such schemas can still be registered under a subject whose compatibility is set to ``NONE`` (no compatibility check is
+performed). Evaluating these keywords correctly requires resolving dynamic references and reasoning across subschemas,
+which the compatibility checker does not do yet; until it does, they remain fail-closed rather than being compared
+under an approximation that could report a breaking change as safe.
 
 There is no strict/lenient mode for JSON Schema validation or compatibility. (The ``kafka_schema_reader_strict_mode``
 configuration is unrelated — it controls error handling when reading the internal ``_schemas`` topic, not JSON Schema
@@ -923,13 +938,12 @@ Migration guidance
 
 * **Validation:** schemas declaring Draft 2019-09 or 2020-12 (or draft-04 / draft-06) via ``$schema`` are validated with
   that draft's rules; omitting ``$schema`` defaults to Draft-7.
-* **Compatibility:** regardless of the declared draft, compatibility is still evaluated under Draft-7 semantics. Do not
-  rely on newer-draft-only keyword semantics *during compatibility checks* until that support ships.
-* **Mixing drafts within a subject:** a subject may contain versions that declare different ``$schema`` values;
-  compatibility across them is always computed under Draft-7 rules. Review the limitations above before relying on
-  newer-draft keywords across versions.
-* **Roadmap:** native *compatibility* support for Draft 2019-09 and 2020-12 keywords is planned. This section will be
-  expanded when that support lands.
+* **Compatibility:** the renamed/relocated keywords (``$defs``, ``prefixItems``, ``dependentRequired``) are evaluated
+  correctly and are interchangeable with their Draft-7 spelling, so you can migrate a subject from Draft-7 to
+  2019-09 / 2020-12 without a compatibility break as long as the schema shape is otherwise unchanged.
+* **Unsupported keywords fail closed:** if a version uses ``unevaluatedProperties`` / ``unevaluatedItems``,
+  ``$dynamicRef`` / ``$dynamicAnchor``, ``$recursiveRef`` / ``$recursiveAnchor`` or ``$vocabulary``, the compatibility
+  check is rejected. Use compatibility ``NONE`` for that subject if you need to register such schemas.
 
 
 Uninstall

--- a/src/karapace/core/compatibility/jsonschema/utils.py
+++ b/src/karapace/core/compatibility/jsonschema/utils.py
@@ -9,14 +9,70 @@ from karapace.core.typing import JsonSchemaValidator
 from typing import Any, TypeVar, Union
 
 import re
+import warnings
 
 T = TypeVar("T")
 JSONSCHEMA_TYPES = Union[Instance, Subschema, Keyword, type[BooleanSchema]]
+
+# Newer-draft (2019-09 / 2020-12) keyword names that are not part of the Draft-7 `Keyword` enum.
+PREFIX_ITEMS = "prefixItems"
+DEFS = "$defs"
+DEFINITIONS = "definitions"
+DEPENDENT_REQUIRED = "dependentRequired"
+
+# Keywords the compatibility engine cannot yet evaluate. Their presence makes a Draft-7-shaped
+# comparison unreliable, so compatibility checking fails closed rather than returning a possibly
+# wrong verdict.
+UNSUPPORTED_COMPAT_KEYWORDS = frozenset(
+    {
+        "$dynamicRef",
+        "$dynamicAnchor",
+        "$recursiveRef",
+        "$recursiveAnchor",
+        "unevaluatedProperties",
+        "unevaluatedItems",
+        "$vocabulary",
+    }
+)
+
+# Keywords whose *values are maps keyed by names chosen by the schema author* (property names,
+# definition names, patterns). Those keys are not schema keywords, so the scanner must recurse into
+# the values only — never treat the keys as keywords.
+_NAME_KEYED_MAP_KEYWORDS = frozenset(
+    {
+        "properties",
+        "patternProperties",
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "dependentRequired",
+    }
+)
+
+# Keywords whose values are arbitrary instance data, not subschemas. The scanner must not descend
+# into them, otherwise a user value that happens to be an object with a keyword-like key would be
+# misread as a schema keyword.
+_DATA_VALUE_KEYWORDS = frozenset({"enum", "const", "default", "examples"})
 
 
 def normalize_schema(validator: JsonSchemaValidator) -> Any:
     original_schema = validator.schema
     return normalize_schema_rec(validator, original_schema)
+
+
+def _resolver_of(validator: JsonSchemaValidator) -> Any:
+    """Return the validator's ref resolver.
+
+    ``Validator.resolver`` is deprecated as of jsonschema 4.18 in favour of the ``referencing``
+    library, but ``normalize_schema`` still relies on its ``push_scope``/``pop_scope``/``resolve``
+    API. The pin ``jsonschema>=4.18,<5`` guarantees the attribute stays available (deprecations are
+    not removed within a major series), so we access it in one place and silence the warning here.
+
+    TODO: migrate reference resolution to the ``referencing`` library and drop this shim.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return validator.resolver
 
 
 def normalize_schema_rec(validator: JsonSchemaValidator, original_schema: Any) -> Any:
@@ -26,7 +82,7 @@ def normalize_schema_rec(validator: JsonSchemaValidator, original_schema: Any) -
     normalized: Any
     if isinstance(original_schema, dict):
         scope = validator.ID_OF(original_schema)
-        resolver = validator.resolver
+        resolver = _resolver_of(validator)
         ref = original_schema.get(Keyword.REF.value)
 
         if scope:
@@ -46,12 +102,80 @@ def normalize_schema_rec(validator: JsonSchemaValidator, original_schema: Any) -
         if scope:
             resolver.pop_scope()
 
+        normalized = canonicalize_draft_keywords(normalized)
+
     elif isinstance(original_schema, list):
         normalized = [normalize_schema_rec(validator, item) for item in original_schema]
     else:
         raise ValueError(f"Cannot handle object of type {type(original_schema)}")
 
     return normalized
+
+
+def canonicalize_draft_keywords(schema: dict) -> dict:
+    """Rewrite Draft 2019-09 / 2020-12 keywords into their Draft-7 equivalents.
+
+    The compatibility engine is expressed in terms of Draft-7 keyword shapes. Rewriting the
+    renamed/relocated keywords here means every downstream check works unchanged, and comparisons
+    between schemas written in different drafts become well-defined (a single canonical form).
+    Keywords that cannot be canonicalized safely are handled by a fail-closed guard before
+    compatibility checking, not here.
+    """
+    # 2020-12 array model: `prefixItems` holds the positional (tuple) schemas that Draft-7 spells as
+    # the list form of `items`; when `prefixItems` is present, `items` holds the "additional items"
+    # schema that Draft-7 spells as `additionalItems`.
+    if PREFIX_ITEMS in schema:
+        prefix_items = schema.pop(PREFIX_ITEMS)
+        additional_items = schema.pop(Keyword.ITEMS.value, None)
+        schema[Keyword.ITEMS.value] = prefix_items
+        if additional_items is not None and Keyword.ADDITIONAL_ITEMS.value not in schema:
+            schema[Keyword.ADDITIONAL_ITEMS.value] = additional_items
+
+    # 2019-09 rename: `$defs` is the new name for `definitions`. References are already resolved by
+    # normalize_schema_rec, so this only keeps the canonical key name for any surviving subschema.
+    if DEFS in schema and DEFINITIONS not in schema:
+        schema[DEFINITIONS] = schema.pop(DEFS)
+
+    # 2019-09 split: `dependentRequired` is the string-array form of Draft-7 `dependencies`.
+    if DEPENDENT_REQUIRED in schema:
+        dependent_required = schema.pop(DEPENDENT_REQUIRED)
+        existing = schema.get(Keyword.DEPENDENCIES.value, {})
+        if isinstance(existing, dict) and isinstance(dependent_required, dict):
+            # Existing `dependencies` entries win on key conflict.
+            schema[Keyword.DEPENDENCIES.value] = {**dependent_required, **existing}
+
+    return schema
+
+
+def find_unsupported_compat_keywords(schema: Any) -> set[str]:
+    """Recursively collect keywords (in keyword position) the compatibility engine cannot evaluate.
+
+    Returns the subset of ``UNSUPPORTED_COMPAT_KEYWORDS`` used as *schema keywords* anywhere in the
+    schema. Used by the fail-closed guard before normalization, so it runs on the original schema.
+
+    The walk is position-aware to avoid false positives: a keyword-like string is only a match when
+    it is a schema keyword, not when it is an author-chosen name (e.g. a property named
+    ``unevaluatedItems``) or a value inside instance-data keywords (``enum``, ``const``, ``default``).
+    """
+    found: set[str] = set()
+    if isinstance(schema, dict):
+        for key, value in schema.items():
+            if key in UNSUPPORTED_COMPAT_KEYWORDS:
+                found.add(key)
+
+            if key in _DATA_VALUE_KEYWORDS:
+                # Value is arbitrary instance data, never a subschema — do not descend.
+                continue
+            if key in _NAME_KEYED_MAP_KEYWORDS and isinstance(value, dict):
+                # Keys here are author-chosen names; only the values are subschemas.
+                for subschema in value.values():
+                    found |= find_unsupported_compat_keywords(subschema)
+            else:
+                found |= find_unsupported_compat_keywords(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            found |= find_unsupported_compat_keywords(item)
+    return found
 
 
 def maybe_get_subschemas_and_type(schema: Any) -> tuple[list[Any], Subschema] | None:

--- a/src/karapace/core/compatibility/schema_compatibility.py
+++ b/src/karapace/core/compatibility/schema_compatibility.py
@@ -13,6 +13,7 @@ from avro.compatibility import (
 from avro.schema import Schema as AvroSchema
 from karapace.core.compatibility import CompatibilityModes
 from karapace.core.compatibility.jsonschema.checks import compatibility as jsonschema_compatibility, incompatible_schema
+from karapace.core.compatibility.jsonschema.utils import find_unsupported_compat_keywords
 from karapace.core.compatibility.protobuf.checks import check_protobuf_schema_compatibility
 from karapace.core.protobuf.schema import ProtobufSchema
 from karapace.core.schema_models import ParsedTypedSchema, ValidatedTypedSchema
@@ -72,11 +73,30 @@ class SchemaCompatibility:
                 )
         elif old_schema.schema_type is SchemaType.JSONSCHEMA:
             # The parsed schema may be any JSON Schema draft validator (Draft-7 default,
-            # or 2019-09 / 2020-12 when selected via $schema). The compatibility engine
-            # is still Draft-7-shaped; cross-draft compatibility semantics are pending, see
-            # docs/json-schema-draft-compatibility-strategy.md.
+            # or 2019-09 / 2020-12 when selected via $schema). Renamed/relocated keywords are
+            # canonicalized to Draft-7 shapes during normalization so the engine compares them
+            # correctly across drafts. Keywords the engine cannot yet evaluate are rejected below
+            # rather than mis-judged.
             assert isinstance(old_schema.schema, JsonSchemaValidator)
             assert isinstance(new_schema.schema, JsonSchemaValidator)
+
+            # Fail closed: reject rather than return a possibly-wrong verdict for keywords whose
+            # compatibility semantics are not implemented. NONE mode already returned above, so this
+            # only affects compatibility-checked modes.
+            unsupported = find_unsupported_compat_keywords(old_schema.schema.schema) | find_unsupported_compat_keywords(
+                new_schema.schema.schema
+            )
+            if unsupported:
+                keywords = ", ".join(sorted(unsupported))
+                return incompatible_schema(
+                    incompat_type=SchemaIncompatibilityType.type_mismatch,
+                    message=(
+                        f"Compatibility checking is not supported for JSON Schema keyword(s): {keywords}. "
+                        "Register the schema under a subject with compatibility NONE, or remove these keywords."
+                    ),
+                    location=[],
+                )
+
             if compatibility_mode in {CompatibilityModes.BACKWARD, CompatibilityModes.BACKWARD_TRANSITIVE}:
                 result = SchemaCompatibility.check_jsonschema_compatibility(
                     reader=new_schema.schema,

--- a/src/karapace/core/schema_models.py
+++ b/src/karapace/core/schema_models.py
@@ -58,6 +58,11 @@ def parse_jsonschema_definition(schema_definition: str) -> JsonSchemaValidator:
         SchemaError: If `schema_definition` is not valid for its declared draft.
     """
     schema = json_decode(schema_definition)
+    # `$schema` selects the draft. It must be a string URI; a non-string value makes
+    # `validator_for` raise a bare AttributeError/TypeError (it feeds the value to urlsplit),
+    # which is not part of the parse() error contract. Reject it as a schema error instead.
+    if isinstance(schema, dict) and "$schema" in schema and not isinstance(schema["$schema"], str):
+        raise SchemaError(f"$schema must be a string URI, got {type(schema['$schema']).__name__}")
     # TODO: Annotations dictate Mapping[str, Any] here, but we have unit tests that
     #  use bool values and fail if we assert isinstance(_, dict).
     validator_cls = validator_for(schema, default=Draft7Validator)  # type: ignore[arg-type]

--- a/tests/integration/test_jsonschema.py
+++ b/tests/integration/test_jsonschema.py
@@ -1271,3 +1271,99 @@ async def test_schemaregistry_register_retrieve_list_newer_drafts(
     versions_res = await registry_async_client.get(f"subjects/{subject}/versions")
     assert versions_res.status_code == 200
     assert versions_res.json() == [1]
+
+
+async def _register(client: Client, subject: str, schema: dict) -> int:
+    res = await client.post(
+        f"subjects/{subject}/versions",
+        json={"schema": json.dumps(schema), "schemaType": SchemaType.JSONSCHEMA.value},
+    )
+    assert res.status_code == 200, res.json()
+    return res.json()["id"]
+
+
+async def test_schemaregistry_cross_draft_compatible_evolution(registry_async_client: Client) -> None:
+    """A subject may evolve from Draft-7 to Draft 2020-12; a structurally-equal newer-draft version
+    is accepted under BACKWARD compatibility."""
+    subject = new_random_name("subject")
+    draft7 = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "additionalProperties": True,
+    }
+    draft2020 = {**draft7, "$schema": "https://json-schema.org/draft/2020-12/schema"}
+
+    await _register(registry_async_client, subject, draft7)
+
+    config_res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD"})
+    assert config_res.status_code == 200
+
+    # The renamed-keyword canonicalization makes the two drafts comparable; identical shape -> compatible.
+    second_id = await _register(registry_async_client, subject, draft2020)
+    assert second_id
+
+
+async def test_schemaregistry_cross_draft_breaking_evolution_is_rejected(registry_async_client: Client) -> None:
+    """A structurally-breaking change is rejected even across drafts (narrowing number -> integer)."""
+    subject = new_random_name("subject")
+    draft7 = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+    }
+    draft2020_narrowed = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"a": {"type": "integer"}},
+    }
+
+    await _register(registry_async_client, subject, draft7)
+    config_res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD"})
+    assert config_res.status_code == 200
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schema": json.dumps(draft2020_narrowed), "schemaType": SchemaType.JSONSCHEMA.value},
+    )
+    assert res.status_code == 409, res.json()
+
+
+@pytest.mark.parametrize(
+    "unsupported_fragment",
+    [
+        {"unevaluatedProperties": False},
+        {"$dynamicRef": "#node", "$dynamicAnchor": "node"},
+    ],
+)
+async def test_schemaregistry_unsupported_keyword_rejected_under_compat(
+    registry_async_client: Client,
+    unsupported_fragment: dict,
+) -> None:
+    """Under a compatibility-checked subject, registering a second version that uses a keyword the
+    engine cannot evaluate is rejected (fail-closed)."""
+    subject = new_random_name("subject")
+    base = {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object"}
+
+    await _register(registry_async_client, subject, base)
+    config_res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "BACKWARD"})
+    assert config_res.status_code == 200
+
+    res = await registry_async_client.post(
+        f"subjects/{subject}/versions",
+        json={"schema": json.dumps({**base, **unsupported_fragment}), "schemaType": SchemaType.JSONSCHEMA.value},
+    )
+    assert res.status_code == 409, res.json()
+
+
+async def test_schemaregistry_unsupported_keyword_allowed_under_none(registry_async_client: Client) -> None:
+    """The same unsupported-keyword schema can still be registered under compatibility NONE."""
+    subject = new_random_name("subject")
+    base = {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object"}
+
+    await _register(registry_async_client, subject, base)
+    config_res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "NONE"})
+    assert config_res.status_code == 200
+
+    second_id = await _register(registry_async_client, subject, {**base, "unevaluatedProperties": False})
+    assert second_id

--- a/tests/integration/test_jsonschema.py
+++ b/tests/integration/test_jsonschema.py
@@ -1329,13 +1329,14 @@ async def test_schemaregistry_cross_draft_breaking_evolution_is_rejected(registr
     assert res.status_code == 409, res.json()
 
 
-@pytest.mark.parametrize(
-    "unsupported_fragment",
-    [
-        {"unevaluatedProperties": False},
-        {"$dynamicRef": "#node", "$dynamicAnchor": "node"},
-    ],
-)
+# Keyword fragments the compatibility engine cannot evaluate; used by the fail-closed tests below.
+UNSUPPORTED_KEYWORD_FRAGMENTS = [
+    {"unevaluatedProperties": False},
+    {"$dynamicRef": "#node", "$dynamicAnchor": "node"},
+]
+
+
+@pytest.mark.parametrize("unsupported_fragment", UNSUPPORTED_KEYWORD_FRAGMENTS)
 async def test_schemaregistry_unsupported_keyword_rejected_under_compat(
     registry_async_client: Client,
     unsupported_fragment: dict,
@@ -1354,9 +1355,17 @@ async def test_schemaregistry_unsupported_keyword_rejected_under_compat(
         json={"schema": json.dumps({**base, **unsupported_fragment}), "schemaType": SchemaType.JSONSCHEMA.value},
     )
     assert res.status_code == 409, res.json()
+    # The rejection message must name the unsupported keyword(s) so the cause is actionable.
+    message = res.json()["message"]
+    for keyword in unsupported_fragment:
+        assert keyword in message, message
 
 
-async def test_schemaregistry_unsupported_keyword_allowed_under_none(registry_async_client: Client) -> None:
+@pytest.mark.parametrize("unsupported_fragment", UNSUPPORTED_KEYWORD_FRAGMENTS)
+async def test_schemaregistry_unsupported_keyword_allowed_under_none(
+    registry_async_client: Client,
+    unsupported_fragment: dict,
+) -> None:
     """The same unsupported-keyword schema can still be registered under compatibility NONE."""
     subject = new_random_name("subject")
     base = {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object"}
@@ -1365,5 +1374,5 @@ async def test_schemaregistry_unsupported_keyword_allowed_under_none(registry_as
     config_res = await registry_async_client.put(f"config/{subject}", json={"compatibility": "NONE"})
     assert config_res.status_code == 200
 
-    second_id = await _register(registry_async_client, subject, {**base, "unevaluatedProperties": False})
+    second_id = await _register(registry_async_client, subject, {**base, **unsupported_fragment})
     assert second_id

--- a/tests/unit/compatibility/jsonschema/test_draft_2019_2020_compatibility.py
+++ b/tests/unit/compatibility/jsonschema/test_draft_2019_2020_compatibility.py
@@ -1,0 +1,219 @@
+"""
+karapace - Test JSON Schema Draft 2019-09 / 2020-12 compatibility
+
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+
+Covers the compatibility behaviour for newer-draft keywords:
+- renamed/relocated keywords are canonicalized to Draft-7 shapes and compared correctly
+  (including cross-draft comparisons), and
+- keywords the engine cannot yet evaluate are rejected (fail-closed) in compatibility-checked modes.
+
+See docs/json-schema-draft-compatibility-strategy.md.
+"""
+
+import json
+import warnings
+
+import pytest
+from avro.compatibility import SchemaCompatibilityType
+
+from karapace.core.compatibility import CompatibilityModes
+from karapace.core.compatibility.jsonschema.checks import compatibility
+from karapace.core.compatibility.schema_compatibility import SchemaCompatibility
+from karapace.core.schema_models import parse_jsonschema_definition, ParsedTypedSchema, ValidatedTypedSchema
+from karapace.core.schema_type import SchemaType
+
+DRAFT7_URI = "http://json-schema.org/draft-07/schema#"
+DRAFT201909_URI = "https://json-schema.org/draft/2019-09/schema"
+DRAFT202012_URI = "https://json-schema.org/draft/2020-12/schema"
+
+
+def _validator(schema: dict):
+    return parse_jsonschema_definition(json.dumps(schema))
+
+
+def _is_compatible(reader: dict, writer: dict) -> bool:
+    """Low-level engine check (post-canonicalization). reader can read writer's data."""
+    result = compatibility(_validator(reader), _validator(writer))
+    return result.compatibility is SchemaCompatibilityType.compatible
+
+
+def _check(old: dict, new: dict, mode: CompatibilityModes):
+    """Full compatibility check through the public entry point (exercises the fail-closed guard)."""
+    return SchemaCompatibility.check_compatibility(
+        ParsedTypedSchema.parse(SchemaType.JSONSCHEMA, json.dumps(old)),
+        ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, json.dumps(new)),
+        mode,
+    )
+
+
+class TestCanonicalEquivalence:
+    """Renamed/relocated keywords compare as equivalent to their Draft-7 spelling."""
+
+    def test_definitions_and_defs_are_equivalent(self):
+        draft7 = {"$schema": DRAFT7_URI, "definitions": {"a": {"type": "string"}}, "$ref": "#/definitions/a"}
+        draft2020 = {"$schema": DRAFT202012_URI, "$defs": {"a": {"type": "string"}}, "$ref": "#/$defs/a"}
+        assert _is_compatible(reader=draft2020, writer=draft7)
+        assert _is_compatible(reader=draft7, writer=draft2020)
+
+    def test_items_list_and_prefix_items_are_equivalent(self):
+        draft7 = {"$schema": DRAFT7_URI, "type": "array", "items": [{"type": "integer"}]}
+        draft2020 = {"$schema": DRAFT202012_URI, "type": "array", "prefixItems": [{"type": "integer"}]}
+        assert _is_compatible(reader=draft2020, writer=draft7)
+        assert _is_compatible(reader=draft7, writer=draft2020)
+
+    def test_closed_tuple_additional_items_and_items_false_are_equivalent(self):
+        draft7 = {
+            "$schema": DRAFT7_URI,
+            "type": "array",
+            "items": [{"type": "integer"}],
+            "additionalItems": False,
+        }
+        draft2020 = {
+            "$schema": DRAFT202012_URI,
+            "type": "array",
+            "prefixItems": [{"type": "integer"}],
+            "items": False,
+        }
+        assert _is_compatible(reader=draft2020, writer=draft7)
+        assert _is_compatible(reader=draft7, writer=draft2020)
+
+    def test_dependencies_and_dependent_required_are_equivalent(self):
+        draft7 = {"$schema": DRAFT7_URI, "type": "object", "dependencies": {"a": ["b"]}}
+        draft2019 = {"$schema": DRAFT201909_URI, "type": "object", "dependentRequired": {"a": ["b"]}}
+        assert _is_compatible(reader=draft2019, writer=draft7)
+        assert _is_compatible(reader=draft7, writer=draft2019)
+
+
+class TestEvolutionRulesAfterCanonicalization:
+    """Draft-7 evolution rules still apply to the canonicalized newer-draft keywords."""
+
+    def test_adding_prefix_items_position_is_backward_incompatible(self):
+        # Reader requires a 2nd tuple position the writer does not produce -> reader restricts.
+        writer = {"$schema": DRAFT202012_URI, "type": "array", "prefixItems": [{"type": "integer"}]}
+        reader = {
+            "$schema": DRAFT202012_URI,
+            "type": "array",
+            "prefixItems": [{"type": "integer"}, {"type": "string"}],
+        }
+        assert not _is_compatible(reader=reader, writer=writer)
+
+    def test_dependent_required_matches_dependencies_behaviour(self):
+        # dependentRequired must behave identically to Draft-7 dependencies for the same change.
+        draft7_writer = {"$schema": DRAFT7_URI, "type": "object"}
+        draft7_reader = {"$schema": DRAFT7_URI, "type": "object", "dependencies": {"a": ["b"]}}
+        draft2020_writer = {"$schema": DRAFT202012_URI, "type": "object"}
+        draft2020_reader = {"$schema": DRAFT202012_URI, "type": "object", "dependentRequired": {"a": ["b"]}}
+        assert _is_compatible(reader=draft2020_reader, writer=draft2020_writer) == _is_compatible(
+            reader=draft7_reader, writer=draft7_writer
+        )
+
+
+class TestCrossDraftCompatibility:
+    """A subject may evolve across drafts; compatibility is computed on the canonical form."""
+
+    @pytest.mark.parametrize(
+        "mode",
+        [CompatibilityModes.BACKWARD, CompatibilityModes.FORWARD, CompatibilityModes.FULL],
+    )
+    def test_structurally_equal_cross_draft_is_compatible(self, mode: CompatibilityModes):
+        old = {"$schema": DRAFT7_URI, "type": "object", "properties": {"a": {"type": "string"}}}
+        new = {"$schema": DRAFT202012_URI, "type": "object", "properties": {"a": {"type": "string"}}}
+        result = _check(old, new, mode)
+        assert result.compatibility is SchemaCompatibilityType.compatible
+
+    def test_structurally_breaking_cross_draft_is_incompatible(self):
+        # New (reader) narrows type from string to integer -> not backward compatible.
+        old = {"$schema": DRAFT7_URI, "type": "object", "properties": {"a": {"type": "number"}}}
+        new = {"$schema": DRAFT202012_URI, "type": "object", "properties": {"a": {"type": "integer"}}}
+        result = _check(old, new, CompatibilityModes.BACKWARD)
+        assert result.compatibility is SchemaCompatibilityType.incompatible
+
+
+class TestFailClosedGuard:
+    """Keywords the engine cannot evaluate are rejected in compatibility-checked modes."""
+
+    @pytest.mark.parametrize(
+        "keyword_fragment",
+        [
+            {"unevaluatedProperties": False},
+            {"unevaluatedItems": False},
+            {"$dynamicRef": "#node"},
+            {"$dynamicAnchor": "node"},
+            {"$recursiveRef": "#"},
+            {"$vocabulary": {"https://json-schema.org/draft/2020-12/vocab/core": True}},
+        ],
+    )
+    def test_unsupported_keyword_is_rejected(self, keyword_fragment: dict):
+        old = {"$schema": DRAFT202012_URI, "type": "object"}
+        new = {"$schema": DRAFT202012_URI, "type": "object", **keyword_fragment}
+        result = _check(old, new, CompatibilityModes.BACKWARD)
+        assert result.compatibility is SchemaCompatibilityType.incompatible
+        keyword = next(iter(keyword_fragment))
+        assert any(keyword in message for message in result.messages)
+
+    def test_unsupported_keyword_allowed_under_none_mode(self):
+        old = {"$schema": DRAFT202012_URI, "type": "object"}
+        new = {"$schema": DRAFT202012_URI, "type": "object", "unevaluatedProperties": False}
+        result = _check(old, new, CompatibilityModes.NONE)
+        assert result.compatibility is SchemaCompatibilityType.compatible
+
+    def test_unsupported_keyword_detected_when_nested(self):
+        old = {"$schema": DRAFT202012_URI, "type": "object"}
+        new = {
+            "$schema": DRAFT202012_URI,
+            "type": "object",
+            "properties": {"a": {"type": "object", "unevaluatedProperties": False}},
+        }
+        result = _check(old, new, CompatibilityModes.BACKWARD)
+        assert result.compatibility is SchemaCompatibilityType.incompatible
+
+    @pytest.mark.parametrize(
+        "schema_fragment",
+        [
+            # An author-chosen property name that collides with a keyword must NOT trip the guard.
+            {"properties": {"unevaluatedItems": {"type": "string"}}},
+            {"properties": {"$vocabulary": {"type": "string"}}},
+            # A $defs entry named like a keyword is a name, not a keyword.
+            {"$defs": {"unevaluatedProperties": {"type": "string"}}},
+            # Keyword-like strings that are instance data, not schema keywords.
+            {"enum": ["$dynamicRef", "unevaluatedItems"]},
+            {"const": {"$vocabulary": {"x": True}}},
+        ],
+    )
+    def test_keyword_like_names_and_values_do_not_trip_guard(self, schema_fragment: dict):
+        old = {"$schema": DRAFT202012_URI, "type": "object", **schema_fragment}
+        new = {"$schema": DRAFT202012_URI, "type": "object", **schema_fragment}
+        result = _check(old, new, CompatibilityModes.BACKWARD)
+        assert result.compatibility is SchemaCompatibilityType.compatible
+
+
+class TestNoDraft7Regression:
+    """Spot-check that plain Draft-7 schemas are unaffected by canonicalization."""
+
+    def test_widening_a_constraint_still_compatible(self):
+        # Reader relaxes the numeric upper bound the writer had -> backward compatible.
+        writer = {"$schema": DRAFT7_URI, "type": "integer", "maximum": 10}
+        reader = {"$schema": DRAFT7_URI, "type": "integer"}
+        assert _is_compatible(reader=reader, writer=writer)
+
+
+class TestNoResolverDeprecationNoise:
+    """The resolver access shim keeps compatibility checks free of deprecation warnings."""
+
+    def test_compat_check_emits_no_resolver_deprecation(self):
+        old = {"$schema": DRAFT202012_URI, "type": "object", "properties": {"a": {"type": "string"}}}
+        new = {"$schema": DRAFT202012_URI, "type": "object", "properties": {"a": {"type": "string"}}}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check(old, new, CompatibilityModes.BACKWARD)
+        resolver_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning) and "resolver" in str(w.message)
+        ]
+        assert resolver_warnings == []
+
+    def test_type_narrowing_still_incompatible(self):
+        writer = {"$schema": DRAFT7_URI, "type": "number"}
+        reader = {"$schema": DRAFT7_URI, "type": "integer"}
+        assert not _is_compatible(reader=reader, writer=writer)

--- a/tests/unit/test_schema_models.py
+++ b/tests/unit/test_schema_models.py
@@ -244,6 +244,12 @@ class TestJsonSchemaDraftRouting:
         with pytest.raises(InvalidSchema):
             ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, json.dumps({"$schema": DRAFT202012_URI, "type": 123}))
 
+    @pytest.mark.parametrize("bad_schema_value", [123, ["x"], {"k": 1}])
+    def test_non_string_schema_keyword_raises_invalid_schema(self, bad_schema_value: Any):
+        """A non-string `$schema` must raise InvalidSchema, not an uncaught AttributeError."""
+        with pytest.raises(InvalidSchema):
+            ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, json.dumps({"$schema": bad_schema_value, "type": "object"}))
+
     def test_no_network_fetch_on_parse(self, monkeypatch: pytest.MonkeyPatch):
         """Parsing/validating any built-in draft must not trigger network I/O."""
 
@@ -272,60 +278,4 @@ class TestJsonSchemaDraftRouting:
         assert type(parsed.schema).__name__ == "Draft202012Validator"
 
         result = SchemaCompatibility.check_compatibility(parsed, parsed, CompatibilityModes.BACKWARD)
-        assert result is not None
-
-    # Cross-draft smoke tests: the compatibility engine is still Draft-7-shaped (cross-draft
-    # *semantics* are a later ticket, see docs/json-schema-draft-compatibility-strategy.md).
-    # These pin only that mixing drafts across versions does NOT crash the engine — they assert a
-    # result is returned, never a specific compatible/incompatible verdict.
-    @pytest.mark.parametrize(
-        "old_uri, new_uri",
-        [
-            (DRAFT7_URI, DRAFT202012_URI),
-            (DRAFT202012_URI, DRAFT7_URI),
-            (DRAFT7_URI, DRAFT201909_URI),
-            (DRAFT201909_URI, DRAFT202012_URI),
-            (None, DRAFT202012_URI),
-        ],
-    )
-    @pytest.mark.parametrize(
-        "compatibility_mode",
-        [CompatibilityModes.BACKWARD, CompatibilityModes.FORWARD, CompatibilityModes.FULL],
-    )
-    def test_cross_draft_compatibility_check_does_not_crash(
-        self,
-        old_uri: str | None,
-        new_uri: str | None,
-        compatibility_mode: CompatibilityModes,
-    ):
-        def _schema(uri: str | None, extra_property: bool) -> str:
-            schema: dict[str, Any] = {
-                "type": "object",
-                "properties": {"a": {"type": "string"}},
-                "additionalProperties": True,
-            }
-            if extra_property:
-                schema["properties"]["b"] = {"type": "integer"}
-            if uri is not None:
-                schema["$schema"] = uri
-            return json.dumps(schema)
-
-        old = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, _schema(old_uri, extra_property=False))
-        new = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, _schema(new_uri, extra_property=True))
-
-        result = SchemaCompatibility.check_compatibility(old, new, compatibility_mode)
-        assert result is not None
-
-    def test_cross_draft_array_model_check_does_not_crash(self):
-        """Draft-7 list-`items` tuple vs 2020-12 `prefixItems` tuple must not crash the engine.
-
-        This is the §9 "array-model ambiguity" case; we only assert it returns a result, since the
-        canonicalization that makes the verdict correct is a later ticket.
-        """
-        draft7_tuple = json.dumps({"$schema": DRAFT7_URI, "type": "array", "items": [{"type": "integer"}]})
-        draft2020_tuple = json.dumps({"$schema": DRAFT202012_URI, "type": "array", "prefixItems": [{"type": "integer"}]})
-        old = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, draft7_tuple)
-        new = ValidatedTypedSchema.parse(SchemaType.JSONSCHEMA, draft2020_tuple)
-
-        result = SchemaCompatibility.check_compatibility(old, new, CompatibilityModes.BACKWARD)
         assert result is not None


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

**Summary :** 
Karapace's JSON Schema compatibility engine was written entirely around Draft-7 keyword shapes, so newer-draft keywords (prefixItems, $defs, dependentRequired, unevaluatedProperties, $dynamicRef) were silently ignored during compatibility checks — a false-compatible hazard. This PR makes compatibility checking correct for Draft 2019-09 / 2020-12.

1. Canonicalize renamed/relocated keywords → Draft-7 shapes (compatibility/jsonschema/utils.py)
2. Fail-closed guard for keywords the engine can't evaluate (schema_compatibility.py)
3. Unit and intgrtn tests supporting cross-draft compatible/breaking evolution, and fail-closed reject


<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
