### PR TITLE
fix(protobuf): allow empty line comments

### DIFF
--- a/src/karapace/core/protobuf/syntax_reader.py
+++ b/src/karapace/core/protobuf/syntax_reader.py
@@ -257,7 +257,7 @@ class SyntaxReader:
                     self.newline()
                     break
             result = self.data[start : self.pos - 1]
-        if not result:
+        else:
             self.unexpected("unexpected '/'")
         return result
 

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -186,6 +186,34 @@ async def test_protobuf_schema_normalization(registry_async_client: Client) -> N
 
 
 @pytest.mark.parametrize("registry_cluster", [{"config": {}}, {"config": {"use_protobuf_formatter": True}}], indirect=True)
+async def test_protobuf_schema_with_blank_documentation_lines(registry_async_client: Client) -> None:
+    subject = create_subject_name_factory("test_protobuf_blank_documentation_lines")()
+    schema = trim_margin(
+        """
+        |syntax = "proto3";
+        |
+        |/*
+        | Some Important Event
+        |
+        | Overview
+        | What this event is for.
+        |*/
+        |message Test {}
+        """
+    )
+
+    res = await registry_async_client.post_subjects_versions(
+        subject=subject,
+        json={"schemaType": "PROTOBUF", "schema": schema},
+    )
+    assert res.status_code == 200
+
+    res = await registry_async_client.get_subjects_subject_version(subject=subject, version="latest")
+    assert res.status_code == 200
+    assert res.json()["schemaType"] == "PROTOBUF"
+
+
+@pytest.mark.parametrize("registry_cluster", [{"config": {}}, {"config": {"use_protobuf_formatter": True}}], indirect=True)
 async def test_protobuf_schema_references(registry_async_client: Client) -> None:
     customer_schema = """
                 |syntax = "proto3";

--- a/tests/integration/test_schema_protobuf.py
+++ b/tests/integration/test_schema_protobuf.py
@@ -196,9 +196,25 @@ async def test_protobuf_schema_with_blank_documentation_lines(registry_async_cli
         | Some Important Event
         |
         | Overview
-        | What this event is for.
         |*/
+        |// Additional context
+        |//
+        |// What this event is for.
         |message Test {}
+        """
+    )
+    expected_schema = trim_margin(
+        f"""
+        |syntax = "proto3";
+        |
+        |// Some Important Event
+        |//{" "}
+        |// Overview
+        |// Additional context
+        |//{" "}
+        |// What this event is for.
+        |message Test {{}}
+        |
         """
     )
 
@@ -206,11 +222,14 @@ async def test_protobuf_schema_with_blank_documentation_lines(registry_async_cli
         subject=subject,
         json={"schemaType": "PROTOBUF", "schema": schema},
     )
+    # A successful response proves the schema reader replayed the record without timing out.
     assert res.status_code == 200
 
     res = await registry_async_client.get_subjects_subject_version(subject=subject, version="latest")
     assert res.status_code == 200
-    assert res.json()["schemaType"] == "PROTOBUF"
+    response = res.json()
+    assert response["schemaType"] == "PROTOBUF"
+    assert response["schema"] == expected_schema
 
 
 @pytest.mark.parametrize("registry_cluster", [{"config": {}}, {"config": {"use_protobuf_formatter": True}}], indirect=True)

--- a/tests/unit/protobuf/test_proto_parser.py
+++ b/tests/unit/protobuf/test_proto_parser.py
@@ -242,6 +242,19 @@ def test_multiple_single_line_comments():
     assert element_type.documentation == expected
 
 
+@pytest.mark.parametrize("empty_comment", ["//", "// "])
+def test_empty_single_line_comment(empty_comment: str):
+    proto = f"// Before\n{empty_comment}\n// After\nmessage Test {{}}\n"
+    parsed = ProtoParser.parse(location, proto)
+    element_type = parsed.types[0]
+    assert element_type.documentation == "Before\n\nAfter"
+
+
+def test_invalid_comment_delimiter():
+    with pytest.raises(IllegalStateException, match="unexpected '/'"):
+        ProtoParser.parse(location, "/\nmessage Test {}\n")
+
+
 def test_single_line_javadoc_comment():
     proto = """
         |/** Test */
@@ -272,6 +285,28 @@ def test_multiline_javadoc_comment():
     parsed = ProtoParser.parse(location, proto)
     element_type = parsed.types[0]
     assert element_type.documentation == expected
+
+
+def test_multiline_comment_with_blank_lines_round_trip():
+    proto = """
+        |syntax = "proto3";
+        |
+        |/*
+        | Some Important Event
+        |
+        | Overview
+        | What this event is for.
+        |*/
+        |message Test {}
+        """
+    proto = trim_margin(proto)
+    parsed = ProtoParser.parse(location, proto)
+    element_type = parsed.types[0]
+    assert element_type.documentation == "Some Important Event\n\nOverview\nWhat this event is for."
+
+    formatted = parsed.to_schema()
+    reparsed = ProtoParser.parse(location, formatted)
+    assert reparsed.to_schema() == formatted
 
 
 def test_multiple_single_line_comments_with_leading_whitespace():


### PR DESCRIPTION
# About this change - What it does

Fix Protobuf schema registrations that return HTTP 500 when documentation comments contain blank lines.

Karapace renders block comments as multiple `//` comments. A blank documentation line is rendered as `// `. When the schema reader replays the schema from the schema topic, `SyntaxReader.read_comment()` parses that line as an empty string, but the subsequent `if not result` check incorrectly treats the valid empty comment as an invalid `/`.

This PR:

- Accepts valid empty `//` and `// ` comments.
- Adds a parser/formatter round-trip test for a block comment containing blank lines.
- Adds a Schema Registry integration test covering mixed block and single-line comments, blank documentation lines, registration, and exact retrieval.
- Adds a regression test confirming that a standalone `/` is still rejected.

Fixes #1343

# Why this way

Comment validity should be determined by the delimiter following `/`, not by whether the comment body is non-empty.

The previous `if not result` check conflated two cases:

- `/` is followed by neither `*` nor `/`, which is an invalid delimiter.
- `//` is matched but its body is empty, which is a valid comment.

Moving the error handling to the delimiter branch's `else` restores delimiter-based parsing and matches the behavior of the Square Wire parser from which this code was ported.

The production change is limited to one control-flow branch and does not alter parsing of non-empty comments. Completely empty block comments remain outside the scope of this fix.

The successful POST assertion is the key regression check for the schema-reader replay path: registration returns HTTP 200 only after the reader has replayed the schema record successfully. Before this fix, replay failed and the POST timed out with HTTP 500. The subsequent GET asserts the complete canonical schema content, including the blank documentation lines.

# Testing

- `tests/unit/protobuf/test_proto_parser.py`: 78 passed
- `tests/integration/test_schema_protobuf.py::test_protobuf_schema_with_blank_documentation_lines`: 2 passed (default and `use_protobuf_formatter=True`)
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy src/karapace/core/protobuf/syntax_reader.py`: passed
