### PR TITLE
Fix schema reader stall on trailing transaction control record

### DIFF
--- a/src/karapace/core/kafka/consumer.py
+++ b/src/karapace/core/kafka/consumer.py
@@ -194,6 +194,18 @@ class KafkaConsumer(_KafkaConfigMixin, Consumer):
         except KafkaException as exc:
             raise_from_kafkaexception(exc)
 
+    def position(self, partitions: list[TopicPartition]) -> list[TopicPartition]:
+        """Consumer fetch position for the given partitions.
+
+        The position advances past records the consumer never delivers to the
+        application (transaction control records, aborted transactional
+        messages), unlike an app-tracked message offset.
+        """
+        try:
+            return super().position(partitions)
+        except KafkaException as exc:
+            raise_from_kafkaexception(exc)
+
 
 T = TypeVar("T")
 

--- a/src/karapace/core/schema_reader.py
+++ b/src/karapace/core/schema_reader.py
@@ -191,6 +191,9 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         self.last_check = time.monotonic()
         self.start_time = time.monotonic()
         self.startup_previous_processed_offset = 0
+        # Log replay completion only on the first catch-up, not on every
+        # re-readiness after a rebalance / master transition (set_not_ready).
+        self._replay_completed_logged = False
 
         self.consecutive_unexpected_errors: int = 0
         self.consecutive_unexpected_errors_start: float = 0
@@ -353,7 +356,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             LOG.exception("Unexpected exception when reading begin offsets.")
         return OFFSET_UNINITIALIZED
 
-    def _is_ready(self) -> bool:
+    def _is_ready(self, consumed_batch_empty: bool = True) -> bool:
         """
         Always call `_is_ready` only if `self._ready` is False.
         Removed the check since now with the Lock the lookup it's a costly operation.
@@ -402,14 +405,44 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
         self.last_check = cur_time
         self.startup_previous_processed_offset = self.offset
         ready = self.offset >= self._highest_offset
+
+        # The consumer never delivers transaction control records (or aborted
+        # transactional messages) to the application, so `self.offset` can stall
+        # one or more offsets short of `_highest_offset` when the topic tail is
+        # such a record (e.g. a topic replicated via MirrorMaker with EOS). The
+        # consumer's fetch position does advance past these, so use it as a
+        # fallback catch-up signal. Only trust it when the last consume returned
+        # an empty batch: otherwise pending unprocessed messages could flip the
+        # reader ready before they are stored.
+        if not ready and consumed_batch_empty:
+            try:
+                positions = self.consumer.position([TopicPartition(self.config.topic_name, 0)])
+                position_offset = positions[0].offset if positions else None
+                if isinstance(position_offset, int) and position_offset >= end_offset:
+                    if not self._replay_completed_logged:
+                        LOG.info(
+                            "Reader caught up via consumer position %s (offset %s, end %s); "
+                            "topic tail is a non-deliverable record",
+                            position_offset,
+                            self.offset,
+                            end_offset,
+                        )
+                    ready = True
+            except Exception as e:  # noqa: BLE001
+                self.stats.unexpected_exception(ex=e, where="_is_ready_position")
+                LOG.warning("Unexpected exception when reading consumer position.")
+
         if ready:
             self.max_messages_to_process = MAX_MESSAGES_TO_CONSUME_AFTER_STARTUP
-            # Always log when replay completes - this is important for operators
-            LOG.info(
-                "Schema replay completed in %.2f seconds (processed %s messages)",
-                time.monotonic() - self.start_time,
-                self.offset,
-            )
+            # Log completion only once, not on every re-readiness after a
+            # rebalance / master transition that flipped the flag back.
+            if not self._replay_completed_logged:
+                LOG.info(
+                    "Schema replay completed in %.2f seconds (processed %s messages)",
+                    time.monotonic() - self.start_time,
+                    self.offset,
+                )
+                self._replay_completed_logged = True
             # Initialize metrics with current database state when becoming ready
             self._initialize_metrics()
         return ready
@@ -441,7 +474,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
     def handle_messages(self) -> None:
         assert self.consumer is not None, "Thread must be started"
         msgs: list[Message] = self.consumer.consume(timeout=self.timeout_s, num_messages=self.max_messages_to_process)
-        self._update_is_ready_flag()
+        self._update_is_ready_flag(consumed_batch_empty=not msgs)
 
         watch_offsets = False
         if self.master_coordinator is not None:
@@ -539,7 +572,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
             schema_records_processed_keymode_deprecated_karapace,
         )
 
-    def _update_is_ready_flag(self) -> None:
+    def _update_is_ready_flag(self, consumed_batch_empty: bool = True) -> None:
         update_ready_flag = False
 
         # to keep the lock as few as possible.
@@ -548,7 +581,7 @@ class KafkaSchemaReader(Thread, SchemaReaderStoppper):
                 update_ready_flag = True
 
         if update_ready_flag:
-            new_ready_flag = self._is_ready()
+            new_ready_flag = self._is_ready(consumed_batch_empty=consumed_batch_empty)
             with self._ready_lock:
                 self._ready = new_ready_flag
 

--- a/tests/integration/test_schema_reader.py
+++ b/tests/integration/test_schema_reader.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 from karapace.core.stats import StatsClient
 
 import pytest
+from confluent_kafka import Producer
 
 from karapace.core.config import Config
 from karapace.core.constants import DEFAULT_SCHEMA_TOPIC
@@ -287,6 +288,101 @@ async def test_schema_reader_skips_empty_message_and_advances_offset(
 
             # Ensure we actually advanced past the empty offset
             assert schema_reader.offset >= empty_offset
+    finally:
+        await master_coordinator.close()
+
+
+async def test_schema_reader_becomes_ready_with_trailing_transaction_control_record(
+    kafka_servers: KafkaServers,
+    producer: KafkaProducer,
+    admin_client: KafkaAdminClient,
+) -> None:
+    """A committed transaction leaves a control record as the topic tail.
+
+    The control record is never delivered to the consumer, so the app-tracked
+    offset stalls one short of the watermark. The reader must still catch up
+    (via the consumer fetch position) and become ready.
+    """
+    test_name = "test_schema_reader_becomes_ready_with_trailing_transaction_control_record"
+    topic_name = new_topic(admin_client)
+    group_id = create_group_name_factory(test_name)()
+    stats_mock = Mock(spec=StatsClient)
+
+    # A normal schema record first.
+    key = {"subject": "trx-subject", "version": 1, "magic": 1, "keytype": "SCHEMA"}
+    value = {
+        "deleted": False,
+        "id": 1,
+        "subject": "trx-subject",
+        "version": 1,
+        "schema": json_encode(TRUE_SCHEMA.schema),
+    }
+    producer.send(topic_name, key=json_encode(key, binary=True), value=json_encode(value, binary=True))
+    producer.flush()
+
+    # A committed transactional record: this writes a data record followed by a
+    # commit control record, so the last offset in the topic is a control record.
+    transactional_producer = Producer(
+        {
+            "bootstrap.servers": kafka_servers.bootstrap_servers[0],
+            "transactional.id": new_random_name("karapace-txn"),
+        }
+    )
+    transactional_producer.init_transactions()
+    transactional_producer.begin_transaction()
+    txn_key = {"subject": "trx-subject", "version": 2, "magic": 1, "keytype": "SCHEMA"}
+    txn_value = {
+        "deleted": False,
+        "id": 2,
+        "subject": "trx-subject",
+        "version": 2,
+        "schema": json_encode(FALSE_SCHEMA.schema),
+    }
+    transactional_producer.produce(
+        topic_name,
+        key=json_encode(txn_key, binary=True),
+        value=json_encode(txn_value, binary=True),
+    )
+    transactional_producer.commit_transaction()
+    transactional_producer.flush()
+
+    config = Config()
+    config.bootstrap_uri = kafka_servers.bootstrap_servers[0]
+    config.admin_metadata_max_age = 2
+    config.group_id = group_id
+    config.topic_name = topic_name
+
+    master_coordinator = MasterCoordinator(config=config)
+    master_coordinator.set_stoppper(AlwaysAvailableSchemaReaderStoppper())
+    try:
+        master_coordinator.start()
+        database = InMemoryDatabase()
+        offset_watcher = OffsetWatcher()
+        schema_reader = KafkaSchemaReader(
+            config=config,
+            offset_watcher=offset_watcher,
+            key_formatter=KeyFormatter(),
+            master_coordinator=master_coordinator,
+            database=database,
+            stats=stats_mock,
+        )
+        schema_reader.start()
+
+        with closing(schema_reader):
+            # Without the fix the reader never becomes ready because the trailing
+            # control record is never delivered, so this would time out.
+            await asyncio.wait_for(
+                _wait_until_reader_is_ready_and_master(master_coordinator, schema_reader),
+                timeout=15,
+            )
+
+            # Both real records were consumed.
+            schemas = database.find_subject_schemas(subject=Subject("trx-subject"), include_deleted=True)
+            assert len(schemas) == 2
+            # The reader became ready even though its delivered offset never
+            # reached the high watermark: the gap is the trailing control record,
+            # which is the exact condition the fix handles.
+            assert schema_reader.offset < schema_reader._highest_offset
     finally:
         await master_coordinator.close()
 

--- a/tests/unit/test_schema_reader.py
+++ b/tests/unit/test_schema_reader.py
@@ -18,7 +18,7 @@ import confluent_kafka
 from karapace.core.stats import StatsClient
 import pytest
 from _pytest.logging import LogCaptureFixture
-from confluent_kafka import Message
+from confluent_kafka import Message, TopicPartition
 from pytest import MonkeyPatch
 
 from karapace.core.container import KarapaceContainer
@@ -238,6 +238,103 @@ def test_schema_reader_skips_empty_message_and_advances_offset(karapace_containe
     assert schema_reader.offset == 5
     schema_reader._update_is_ready_flag()  # pylint: disable=protected-access
     assert schema_reader.ready() is True
+
+
+def test_schema_reader_becomes_ready_when_topic_tail_is_control_record(karapace_container: KarapaceContainer) -> None:
+    """A transaction control record at the topic tail is never delivered to the
+    application, so `self.offset` stalls one short of `_highest_offset`. The
+    consumer's fetch position advances past it and must drive readiness.
+    """
+    key_formatter_mock = Mock(spec=KeyFormatter)
+    stats_mock = Mock(spec=StatsClient)
+    consumer_mock = Mock(spec=KafkaConsumer)
+
+    # No deliverable messages: the last consume returns an empty batch.
+    consumer_mock.consume.return_value = []
+    # end_offset 22 => _highest_offset 21 (offset 21 is the commit control record)
+    consumer_mock.get_watermark_offsets.return_value = (0, 22)
+    # Fetch position has advanced past the control record to the end.
+    consumer_mock.position.return_value = [TopicPartition("_schemas", 0, 22)]
+
+    schema_reader = KafkaSchemaReader(
+        config=karapace_container.config(),
+        offset_watcher=OffsetWatcher(),
+        key_formatter=key_formatter_mock,
+        master_coordinator=None,
+        database=InMemoryDatabase(),
+        stats=stats_mock,
+    )
+    schema_reader.consumer = consumer_mock
+    schema_reader.offset = 20  # last delivered (real) record
+
+    schema_reader.handle_messages()
+
+    assert schema_reader.ready() is True
+
+
+def test_schema_reader_not_ready_when_position_behind_end(karapace_container: KarapaceContainer) -> None:
+    """If the fetch position has not reached the end, the reader stays not ready."""
+    key_formatter_mock = Mock(spec=KeyFormatter)
+    stats_mock = Mock(spec=StatsClient)
+    consumer_mock = Mock(spec=KafkaConsumer)
+
+    consumer_mock.consume.return_value = []
+    consumer_mock.get_watermark_offsets.return_value = (0, 22)
+    # Position still behind the end offset.
+    consumer_mock.position.return_value = [TopicPartition("_schemas", 0, 20)]
+
+    schema_reader = KafkaSchemaReader(
+        config=karapace_container.config(),
+        offset_watcher=OffsetWatcher(),
+        key_formatter=key_formatter_mock,
+        master_coordinator=None,
+        database=InMemoryDatabase(),
+        stats=stats_mock,
+    )
+    schema_reader.consumer = consumer_mock
+    schema_reader.offset = 20
+
+    schema_reader.handle_messages()
+
+    assert schema_reader.ready() is False
+
+
+def test_schema_reader_position_ignored_when_batch_not_empty(karapace_container: KarapaceContainer) -> None:
+    """Position must not mark the reader ready while a non-empty batch is still
+    pending processing, even if the position already reached the end.
+    """
+    key_formatter_mock = Mock(spec=KeyFormatter)
+    stats_mock = Mock(spec=StatsClient)
+    consumer_mock = Mock(spec=KafkaConsumer)
+
+    pending_message = Mock(spec=Message)
+    pending_message.key.return_value = b'{"keytype":"SCHEMA","subject":"test","version":1,"magic":1}'
+    pending_message.value.return_value = json.dumps(
+        {"name": "init", "type": "record", "fields": [{"name": "inner", "type": ["string", "int"]}]}
+    ).encode()
+    pending_message.error.return_value = None
+    pending_message.offset.return_value = 20
+
+    consumer_mock.consume.return_value = [pending_message]
+    consumer_mock.get_watermark_offsets.return_value = (0, 22)
+    consumer_mock.position.return_value = [TopicPartition("_schemas", 0, 22)]
+
+    schema_reader = KafkaSchemaReader(
+        config=karapace_container.config(),
+        offset_watcher=OffsetWatcher(),
+        key_formatter=key_formatter_mock,
+        master_coordinator=None,
+        database=InMemoryDatabase(),
+        stats=stats_mock,
+    )
+    schema_reader.consumer = consumer_mock
+    schema_reader.offset = 19
+
+    schema_reader.handle_messages()
+
+    # Readiness was evaluated before the batch was processed; position is ignored
+    # for a non-empty batch, so the reader is not ready yet.
+    assert schema_reader.ready() is False
 
 
 def test_schema_reader_can_end_to_ready_state_if_last_message_is_invalid_in_schemas_topic(


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Context : 
When the last offset in the _schemas topic is a Kafka transaction control record (commit/abort marker) — as happens on topics replicated via MirrorMaker with exactly-once enabled — the consumer never delivers it to the application. The app-tracked self.offset therefore stalls one short of _highest_offset (end_offset - 1), so the readiness check `offset >= _highest_offset` is never true and the reader never becomes ready, even though all schema records were consumed.

Fix : 
Consult the consumer's fetch position (which advances past control and aborted records) as a fallback readiness signal, gated on an empty consume batch so pending messages can never flip readiness prematurely.

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
