### PR TITLE
Return Confluent-shaped 404 for unknown routes

### DIFF
--- a/src/karapace/api/http_handlers/__init__.py
+++ b/src/karapace/api/http_handlers/__init__.py
@@ -7,14 +7,29 @@ from fastapi import FastAPI, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from http import HTTPStatus
-from karapace.api.routers.errors import KarapaceValidationError
+from karapace.api.content_type import SCHEMA_RESPONSE_DEFAULT_CONTENT_TYPE
+from karapace.api.routers.errors import KarapaceValidationError, SchemaErrorCodes
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request as StarletteHTTPRequest
 
 
 def setup_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(StarletteHTTPException)
-    async def http_exception_handler(_: StarletteHTTPRequest, exc: StarletteHTTPException) -> JSONResponse:
+    async def http_exception_handler(request: StarletteHTTPRequest, exc: StarletteHTTPException) -> JSONResponse:
+        if (
+            exc.status_code == status.HTTP_404_NOT_FOUND
+            and exc.detail == "Not Found"
+            and request.scope.get("route") is None
+            and request.scope.get("endpoint") is None
+        ):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={
+                    "error_code": SchemaErrorCodes.HTTP_NOT_FOUND.value,
+                    "message": "Not Found",
+                },
+                media_type=SCHEMA_RESPONSE_DEFAULT_CONTENT_TYPE,
+            )
         return JSONResponse(status_code=exc.status_code, content=exc.detail)
 
     @app.exception_handler(RequestValidationError)

--- a/tests/unit/api/test_schema_registry_route.py
+++ b/tests/unit/api/test_schema_registry_route.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 from karapace.api.content_type import SCHEMA_RESPONSE_DEFAULT_CONTENT_TYPE
+from karapace.api.http_handlers import setup_exception_handlers
 from karapace.api.routers.raw_path_router import SchemaRegistryRoute
 
 
@@ -31,6 +32,7 @@ def app() -> FastAPI:
 
     app = FastAPI()
     app.include_router(router)
+    setup_exception_handlers(app)
 
     @app.get("/metrics")
     async def metrics():
@@ -118,3 +120,15 @@ class TestSchemaRegistryRouteDoesNotAffectOtherEndpoints:
         )
         response = client.get("/metrics", headers={"Accept": prometheus_accept})
         assert response.status_code == 200
+
+
+class TestSchemaRegistryUnknownRouteErrors:
+    def test_unknown_schema_registry_route_returns_confluent_404(self, client: TestClient) -> None:
+        response = client.get("/associations/resources/%2A/some-topic")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error_code": 404,
+            "message": "Not Found",
+        }
+        assert response.headers["Content-Type"].split(";", maxsplit=1)[0] == SCHEMA_RESPONSE_DEFAULT_CONTENT_TYPE


### PR DESCRIPTION
﻿### What changed

Normalize framework-generated unknown-route 404 responses to the Schema Registry error format.

Unknown routes now return a JSON object with:

- error_code: 404
- message: Not Found

and use the Schema Registry response media type instead of a bare JSON "Not Found" string.

The normalization is intentionally limited to unmatched route 404s. Matched-route errors and existing structured Schema Registry errors keep their current behavior.

### Why

The Confluent JavaScript Schema Registry client v1.9.0+ probes /associations/resources/{namespace}/{name} and expects a Confluent-shaped 404 before falling back to the configured subject-name strategy.

Karapace currently returns a bare JSON string for unregistered routes, causing that fallback to fail.

### Tests

Added unit coverage for the affected /associations/resources/%2A/some-topic request.

Validated locally with:

- targeted regression test
- relevant API unit tests
- full unit suite (1306 passed)
- mypy
- pre-commit

Fixes #1273
