### PR TITLE
feat(rest-proxy): support Kafka message headers on produce and consume

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,12 @@ Produce a message backed up by schema registry::
     '{"value_schema": "{\"namespace\": \"example.avro\", \"type\": \"record\", \"name\": \"simple\", \"fields\": \
     [{\"name\": \"name\", \"type\": \"string\"}]}", "records": [{"value": {"name": "name0"}}]}' http://localhost:8082/topics/my_topic
 
+A record may carry optional Kafka message ``headers``, a list of ``{"name": <string>, "value": <base64 string | null>}`` objects (header values are raw bytes, so they are base64-encoded)::
+
+  $ curl -H "Content-Type: application/vnd.kafka.json.v2+json" -X POST -d \
+    '{"records": [{"value": {"name": "name0"}, "headers": [{"name": "traceId", "value": "YWJjMTIz"}]}]}' \
+    http://localhost:8082/topics/my_topic
+
 Create a consumer with consumer group 'avro_consumers' and consumer instance 'my_consumer' ::
 
   $ curl -X POST -H "Content-Type: application/vnd.kafka.v2+json" -H "Accept: application/vnd.kafka.v2+json" \
@@ -289,6 +295,8 @@ Consume previously produced message::
 
   $ curl -X GET -H "Accept: application/vnd.kafka.avro.v2+json" \
     http://localhost:8082/consumers/avro_consumers/instances/my_consumer/records?timeout=1000
+
+When a consumed record has headers, they are returned in a ``headers`` field using the same ``{"name": ..., "value": <base64 string | null>}`` form (the field is omitted for records without headers).
 
 Commit offsets for a particular topic partition::
 

--- a/src/karapace/kafka_rest_apis/__init__.py
+++ b/src/karapace/kafka_rest_apis/__init__.py
@@ -1057,7 +1057,8 @@ class UserRestProxy:
             if key is not None:
                 key = await self.serialize(content_type, key, ser_format, key_schema_id)
             value = await self.serialize(content_type, value, ser_format, value_schema_id)
-            prepared_records.append((key, value, record.get("partition", default_partition)))
+            headers = self._decode_record_headers(record)
+            prepared_records.append((key, value, record.get("partition", default_partition), headers))
         return prepared_records
 
     async def get_partition_info(self, topic: str, partition: str, content_type: str) -> dict:
@@ -1161,12 +1162,13 @@ class UserRestProxy:
                     status=HTTPStatus.BAD_REQUEST,
                 )
             convert_to_int(r, "partition", content_type)
-            if set(r.keys()).difference({subject_type.value for subject_type in SubjectType}):
+            if set(r.keys()).difference({*(subject_type.value for subject_type in SubjectType), "headers"}):
                 KafkaRest.unprocessable_entity(
                     message="Invalid request format",
                     content_type=content_type,
                     sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
                 )
+            self.validate_record_headers(r, content_type)
         # disallow missing id and schema for any key/value list that has at least one populated element
         if formats["embedded_format"] in {"avro", "jsonschema", "protobuf"}:
             for subject_type, code in zip(SUBJECT_VALID_POSTFIX, RECORD_CODES):
@@ -1188,6 +1190,51 @@ class UserRestProxy:
                         sub_code=RESTErrorCodes.INVALID_DATA.value,
                     )
 
+    @staticmethod
+    def validate_record_headers(record: dict, content_type: str) -> None:
+        # Optional per-record `headers`: a list of {"name": str, "value": base64-str|null} objects.
+        headers = record.get("headers")
+        if headers is None:
+            return
+        if not isinstance(headers, list):
+            KafkaRest.unprocessable_entity(
+                message="'headers' must be an array",
+                content_type=content_type,
+                sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
+            )
+        for header in headers:
+            valid = (
+                isinstance(header, dict)
+                and not set(header.keys()).difference({"name", "value"})
+                and isinstance(header.get("name"), str)
+                and (header.get("value") is None or isinstance(header.get("value"), str))
+            )
+            if not valid:
+                KafkaRest.unprocessable_entity(
+                    message="Each header must be an object with a string 'name' and an optional base64 string 'value'",
+                    content_type=content_type,
+                    sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
+                )
+            value = header.get("value")
+            if value is not None:
+                try:
+                    base64.b64decode(value, validate=True)
+                except (B64DecodeError, ValueError):
+                    KafkaRest.unprocessable_entity(
+                        message="header 'value' must be a base64-encoded string",
+                        content_type=content_type,
+                        sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
+                    )
+
+    @staticmethod
+    def _decode_record_headers(record: dict) -> list[tuple[str, bytes | None]] | None:
+        # Returns None when no headers so the produce call stays identical to a headerless request.
+        # Values are already validated as base64 in validate_record_headers.
+        headers = record.get("headers")
+        if not headers:
+            return None
+        return [(h["name"], base64.b64decode(h["value"]) if h.get("value") is not None else None) for h in headers]
+
     async def produce_messages(self, *, topic: str, prepared_records: list) -> list:
         """
         :raises NoBrokersAvailable:
@@ -1196,10 +1243,10 @@ class UserRestProxy:
         producer = await self._maybe_create_async_producer()
 
         produce_futures = []
-        for key, value, partition in prepared_records:
+        for key, value, partition, headers in prepared_records:
             # Cancelling the returned future **will not** stop event from being sent, but cancelling
             # the ``send`` coroutine itself **will**.
-            coroutine = producer.send(topic, key=key, value=value, partition=partition)
+            coroutine = producer.send(topic, key=key, value=value, partition=partition, headers=headers)
 
             # Schedule the co-routine, it will be cancelled if is not complete in
             # `kafka_timeout` seconds.

--- a/src/karapace/kafka_rest_apis/consumer_manager.py
+++ b/src/karapace/kafka_rest_apis/consumer_manager.py
@@ -574,7 +574,7 @@ class ConsumerManager:
                             raise translate_from_kafkaerror(message.error())
                         key_bytes = len(message.key()) if message.key() else 0
                         value_bytes = len(message.value()) if message.value() else 0
-                        read_bytes += key_bytes + value_bytes
+                        read_bytes += key_bytes + value_bytes + self._header_bytes(message)
                         consumed_messages.append(message)
                         # Stop if we've reached max_bytes
                         if read_bytes >= max_bytes:
@@ -700,6 +700,36 @@ class ConsumerManager:
 
         return deserialize_strict
 
+    @staticmethod
+    def _header_bytes(msg) -> int:
+        # Raw header size for the max_bytes budget; never raises so it can't break a fetch.
+        try:
+            return sum((len(k) if k else 0) + (len(v) if v else 0) for k, v in msg.headers() or [])
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _encode_headers(msg) -> list[dict]:
+        # Symmetric with produce API; unencodable headers are skipped, never breaking record delivery.
+        try:
+            raw_headers = msg.headers() or []
+        except Exception:
+            LOG.debug("Failed to read record headers; omitting them", exc_info=True)
+            return []
+        encoded = []
+        for header in raw_headers:
+            try:
+                name, value = header
+                encoded.append(
+                    {
+                        "name": name.decode("utf-8", errors="replace") if isinstance(name, bytes) else name,
+                        "value": base64.b64encode(value).decode("utf-8") if value is not None else None,
+                    }
+                )
+            except Exception:
+                LOG.warning("Skipping unencodable record header %r", header)
+        return encoded
+
     def _deserialize_messages_sync(
         self, consumed_messages, content_type: str, request_format: str, deserialize_key_func, deserialize_value_func
     ):
@@ -722,6 +752,8 @@ class ConsumerManager:
                     sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
                     content_type=content_type,
                 )
+            # headers key only present when the record actually has them (unchanged shape otherwise)
+            headers = self._encode_headers(msg)
             response.append(
                 {
                     "topic": msg.topic(),
@@ -730,6 +762,7 @@ class ConsumerManager:
                     "timestamp": msg.timestamp()[1] if msg.timestamp()[0] != Timestamp.NOT_AVAILABLE else None,
                     "key": key,
                     "value": value,
+                    **({"headers": headers} if headers else {}),
                 }
             )
         return response
@@ -756,6 +789,8 @@ class ConsumerManager:
                     sub_code=RESTErrorCodes.HTTP_UNPROCESSABLE_ENTITY.value,
                     content_type=content_type,
                 )
+            # headers key only present when the record actually has them (unchanged shape otherwise)
+            headers = self._encode_headers(msg)
             return {
                 "topic": msg.topic(),
                 "partition": msg.partition(),
@@ -763,6 +798,7 @@ class ConsumerManager:
                 "timestamp": msg.timestamp()[1] if msg.timestamp()[0] != Timestamp.NOT_AVAILABLE else None,
                 "key": key,
                 "value": value,
+                **({"headers": headers} if headers else {}),
             }
 
         response = await asyncio.gather(*[deserialize_message(msg) for msg in consumed_messages])

--- a/tests/integration/kafka_rest_apis/test_rest.py
+++ b/tests/integration/kafka_rest_apis/test_rest.py
@@ -17,6 +17,7 @@ import pytest
 
 from karapace.core.client import Client
 from karapace.core.kafka.admin import KafkaAdminClient
+from karapace.core.kafka.consumer import KafkaConsumer
 from karapace.core.kafka.producer import KafkaProducer
 from karapace.kafka_rest_apis import SUBJECT_VALID_POSTFIX, KafkaRest
 from karapace.core.schema_type import SchemaType
@@ -213,8 +214,8 @@ async def test_avro_publish(
 async def test_internal(rest_async: KafkaRest | None, admin_client: KafkaAdminClient) -> None:
     topic_name = new_topic(admin_client)
     prepared_records = [
-        [b"key", b"value", 0],
-        [b"key", b"value", None],
+        [b"key", b"value", 0, None],
+        [b"key", b"value", None, [("traceId", b"abc123")]],
     ]
     rest_async_proxy = await rest_async.get_user_proxy(None)
     results = await rest_async_proxy.produce_messages(topic=topic_name, prepared_records=prepared_records)
@@ -227,7 +228,7 @@ async def test_internal(rest_async: KafkaRest | None, admin_client: KafkaAdminCl
         assert actual_part == 0, "Returned partition id should be %d but is %d" % (0, actual_part)
 
     prepared_records = [
-        [b"key", b"value", 100],
+        [b"key", b"value", 100, None],
     ]
 
     results = await rest_async_proxy.produce_messages(topic=topic_name, prepared_records=prepared_records)
@@ -301,6 +302,36 @@ async def test_publish(rest_async_client: Client, admin_client: KafkaAdminClient
                     assert o["partition"] == 0
 
 
+async def test_publish_with_headers(
+    rest_async_client: Client, admin_client: KafkaAdminClient, consumer: KafkaConsumer
+) -> None:
+    topic = new_topic(admin_client)
+    await wait_for_topics(rest_async_client, topic_names=[topic], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+    consumer.subscribe([topic])
+
+    payload = {
+        "records": [
+            {
+                "value": {"foo": "bar"},
+                "headers": [
+                    {"name": "traceId", "value": base64.b64encode(b"abc123").decode()},
+                    {"name": "tombstone", "value": None},
+                ],
+            }
+        ]
+    }
+    res = await rest_async_client.post(f"/topics/{topic}", json=payload, headers=REST_HEADERS["json"])
+    assert res.ok, res.json()
+
+    # Consume the produced record with a raw Kafka consumer and assert the headers round-trip.
+    message = None
+    deadline = time.monotonic() + 30
+    while message is None and time.monotonic() < deadline:
+        message = consumer.poll(timeout=1)
+    assert message is not None, "Timed out waiting for the produced record"
+    assert dict(message.headers() or []) == {"traceId": b"abc123", "tombstone": None}
+
+
 # Produce messages to a topic without key and without explicit partition to verify that
 # partitioner assigns partition randomly
 async def test_publish_random_partitioning(rest_async_client: Client, admin_client: KafkaAdminClient) -> None:
@@ -358,6 +389,25 @@ async def test_publish_malformed_requests(rest_async_client: Client, admin_clien
 
         res = await rest_async_client.post(url, json={"records": [{"value": "not b64"}]}, headers=REST_HEADERS["avro"])
         assert res.status_code == 422
+
+        # Malformed per-record headers — every case must return the same 422 error code (unified handling).
+        header_error_codes = set()
+        for bad_headers in [
+            "not-a-list",
+            [{"value": "YWJj"}],  # missing "name"
+            [{"name": 1, "value": "YWJj"}],  # non-string name
+            [{"name": "k", "value": 123}],  # non-string value
+            [{"name": "k", "extra": "x"}],  # unexpected field
+            [{"name": "k", "value": "hello world"}],  # value is not valid base64
+        ]:
+            res = await rest_async_client.post(
+                url,
+                json={"records": [{"value": {"foo": "bar"}, "headers": bad_headers}]},
+                headers=REST_HEADERS["json"],
+            )
+            assert res.status_code == 422
+            header_error_codes.add(res.json()["error_code"])
+        assert len(header_error_codes) == 1, f"Header errors should share one code, got {header_error_codes}"
 
 
 async def test_too_large_record(rest_async_client: Client, admin_client: KafkaAdminClient) -> None:

--- a/tests/integration/kafka_rest_apis/test_rest_consumer.py
+++ b/tests/integration/kafka_rest_apis/test_rest_consumer.py
@@ -605,6 +605,112 @@ async def test_consume(rest_async_client, admin_client, producer, trail):
             ), f"Extracted data {deserializers[fmt](data[i]['value'])} does not match {values[fmt][i]} for format {fmt}"
 
 
+async def test_consume_headers(rest_async_client, admin_client, producer):
+    group_name = "consume_headers_group"
+    fmt = "json"
+    header = copy.deepcopy(REST_HEADERS[fmt])
+    instance_id = await new_consumer(rest_async_client, group_name, fmt=fmt)
+    consume_path = f"/consumers/{group_name}/instances/{instance_id}/records?timeout=5000"
+    topic_name = new_topic(admin_client)
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    # Produce with a raw Kafka producer (independent of the REST produce path): one record with
+    # headers (including a null value), one without. Same partition keeps consume order deterministic.
+    producer.send(
+        topic_name,
+        value=json.dumps({"foo": "bar"}).encode("utf-8"),
+        headers=[("traceId", b"abc123"), ("tombstone", None)],
+        partition=0,
+    )
+    producer.send(topic_name, value=json.dumps({"foo": "baz"}).encode("utf-8"), partition=0)
+    producer.flush()
+
+    await assign_and_seek_to_beginning(rest_async_client, group_name, instance_id, topic_name, header)
+    header["Accept"] = f"application/vnd.kafka.{fmt}.v2+json"
+    resp = await rest_async_client.get(consume_path, headers=header)
+    assert resp.ok, f"Expected a successful response: {resp}"
+    data = resp.json()
+    assert len(data) == 2, f"Expected 2 elements in response: {resp}"
+    assert data[0]["headers"] == [
+        {"name": "traceId", "value": base64.b64encode(b"abc123").decode("utf-8")},
+        {"name": "tombstone", "value": None},
+    ]
+    # Header-less records omit the "headers" key entirely (response shape unchanged for such records).
+    assert "headers" not in data[1]
+
+
+async def test_publish_and_consume_headers(rest_async_client, admin_client):
+    # Full REST round-trip: produce headers via the REST API, then consume them back via the REST API.
+    group_name = "publish_consume_headers_group"
+    fmt = "json"
+    header = copy.deepcopy(REST_HEADERS[fmt])
+    instance_id = await new_consumer(rest_async_client, group_name, fmt=fmt)
+    consume_path = f"/consumers/{group_name}/instances/{instance_id}/records?timeout=5000"
+    topic_name = new_topic(admin_client)
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    trace_value = base64.b64encode(b"abc123").decode("utf-8")
+    publish_payload = {
+        "records": [
+            {
+                "value": {"foo": "bar"},
+                "partition": 0,
+                "headers": [
+                    {"name": "traceId", "value": trace_value},
+                    {"name": "tombstone", "value": None},
+                ],
+            },
+            {"value": {"foo": "baz"}, "partition": 0},
+        ]
+    }
+    res = await rest_async_client.post(f"/topics/{topic_name}", json=publish_payload, headers=header)
+    assert res.ok, res.json()
+
+    # New consumer seeks to the beginning, then reads the records we just produced.
+    await assign_and_seek_to_beginning(rest_async_client, group_name, instance_id, topic_name, header)
+    header["Accept"] = f"application/vnd.kafka.{fmt}.v2+json"
+    resp = await rest_async_client.get(consume_path, headers=header)
+    assert resp.ok, f"Expected a successful response: {resp}"
+    data = resp.json()
+    assert len(data) == 2, f"Expected 2 elements in response: {resp}"
+    assert data[0]["headers"] == [
+        {"name": "traceId", "value": trace_value},
+        {"name": "tombstone", "value": None},
+    ]
+    # Header-less records omit the "headers" key entirely (response shape unchanged for such records).
+    assert "headers" not in data[1]
+
+
+async def test_consume_headers_count_toward_max_bytes(rest_async_client, admin_client, producer):
+    # Large headers must count toward max_bytes so the response stays within the caller's bound.
+    group_name = "consume_headers_maxbytes_group"
+    fmt = "json"
+    header = copy.deepcopy(REST_HEADERS[fmt])
+    instance_id = await new_consumer(rest_async_client, group_name, fmt=fmt)
+    consume_path = f"/consumers/{group_name}/instances/{instance_id}/records?timeout=5000&max_bytes=1000"
+    topic_name = new_topic(admin_client)
+    await wait_for_topics(rest_async_client, topic_names=[topic_name], timeout=NEW_TOPIC_TIMEOUT, sleep=1)
+
+    num_records = 5
+    big_header_value = b"x" * 2000  # raw header bytes per record far exceed max_bytes
+    for i in range(num_records):
+        producer.send(
+            topic_name,
+            value=json.dumps({"n": i}).encode("utf-8"),
+            headers=[("big", big_header_value)],
+            partition=0,
+        )
+    producer.flush()
+
+    await assign_and_seek_to_beginning(rest_async_client, group_name, instance_id, topic_name, header)
+    header["Accept"] = f"application/vnd.kafka.{fmt}.v2+json"
+    resp = await rest_async_client.get(consume_path, headers=header)
+    assert resp.ok, f"Expected a successful response: {resp}"
+    data = resp.json()
+    # Values are tiny; without header accounting all records fit under max_bytes. With it, the loop stops early.
+    assert 0 < len(data) < num_records, f"Expected fewer than {num_records} records due to header size, got {len(data)}"
+
+
 async def test_consume_timeout(rest_async_client, admin_client, producer):
     values = {
         "json": [json.dumps({"foo": f"bar{i}"}).encode("utf-8") for i in range(3)],

--- a/tests/unit/kafka_rest_apis/test_consumer_headers.py
+++ b/tests/unit/kafka_rest_apis/test_consumer_headers.py
@@ -1,0 +1,77 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+from karapace.kafka_rest_apis.consumer_manager import ConsumerManager
+
+
+def _msg(headers):
+    msg = MagicMock()
+    msg.headers.return_value = headers
+    return msg
+
+
+def test_encode_headers_none_returns_empty() -> None:
+    assert ConsumerManager._encode_headers(_msg(None)) == []
+
+
+def test_encode_headers_empty_returns_empty() -> None:
+    assert ConsumerManager._encode_headers(_msg([])) == []
+
+
+def test_encode_headers_encodes_values_as_base64() -> None:
+    result = ConsumerManager._encode_headers(_msg([("traceId", b"abc123"), ("tombstone", None)]))
+    assert result == [
+        {"name": "traceId", "value": base64.b64encode(b"abc123").decode("utf-8")},
+        {"name": "tombstone", "value": None},
+    ]
+
+
+def test_encode_headers_handles_bytes_key() -> None:
+    result = ConsumerManager._encode_headers(_msg([(b"traceId", b"v")]))
+    assert result == [{"name": "traceId", "value": base64.b64encode(b"v").decode("utf-8")}]
+
+
+def test_encode_headers_non_utf8_key_does_not_raise() -> None:
+    # A non-UTF-8 header key (e.g. written by a non-REST client) must not break consume.
+    result = ConsumerManager._encode_headers(_msg([(b"\xff\xfe", b"v")]))
+    assert len(result) == 1
+    assert result[0]["value"] == base64.b64encode(b"v").decode("utf-8")
+
+
+def test_encode_headers_swallows_headers_call_failure() -> None:
+    # If msg.headers() itself raises, degrade to empty headers rather than failing the batch.
+    msg = MagicMock()
+    msg.headers.side_effect = RuntimeError("boom")
+    assert ConsumerManager._encode_headers(msg) == []
+
+
+def test_encode_headers_skips_only_the_bad_header() -> None:
+    # A single unencodable header (value is not bytes) is skipped; its siblings survive.
+    result = ConsumerManager._encode_headers(_msg([("good", b"ok"), ("bad", "not-bytes"), ("also_good", None)]))
+    assert result == [
+        {"name": "good", "value": base64.b64encode(b"ok").decode("utf-8")},
+        {"name": "also_good", "value": None},
+    ]
+
+
+def test_header_bytes_sums_key_and_value_lengths() -> None:
+    # 7 (traceId) + 6 (abc123) + 5 (count) + 0 (None value) = 18
+    assert ConsumerManager._header_bytes(_msg([("traceId", b"abc123"), ("count", None)])) == 18
+
+
+def test_header_bytes_none_or_empty_is_zero() -> None:
+    assert ConsumerManager._header_bytes(_msg(None)) == 0
+    assert ConsumerManager._header_bytes(_msg([])) == 0
+
+
+def test_header_bytes_never_raises() -> None:
+    msg = MagicMock()
+    msg.headers.side_effect = RuntimeError("boom")
+    assert ConsumerManager._header_bytes(msg) == 0

--- a/website/docs/api-examples.md
+++ b/website/docs/api-examples.md
@@ -145,6 +145,14 @@ curl -H "Content-Type: application/vnd.kafka.avro.v2+json" -X POST -d \
   http://localhost:8082/topics/my_topic
 ```
 
+A record may carry optional Kafka message `headers`, a list of `{"name": <string>, "value": <base64 string | null>}` objects (header values are raw bytes, so they are base64-encoded):
+
+```bash
+curl -H "Content-Type: application/vnd.kafka.json.v2+json" -X POST -d \
+  '{"records": [{"value": {"name": "name0"}, "headers": [{"name": "traceId", "value": "YWJjMTIz"}]}]}' \
+  http://localhost:8082/topics/my_topic
+```
+
 Create a consumer with consumer group `avro_consumers` and instance `my_consumer`:
 
 ```bash
@@ -166,6 +174,8 @@ Consume previously produced messages:
 curl -X GET -H "Accept: application/vnd.kafka.avro.v2+json" \
   http://localhost:8082/consumers/avro_consumers/instances/my_consumer/records?timeout=1000
 ```
+
+When a consumed record has headers, they are returned in a `headers` field using the same `{"name": ..., "value": <base64 string | null>}` form (the field is omitted for records without headers).
 
 Commit offsets for a topic partition:
 


### PR DESCRIPTION
# About this change - What it does

Add optional per-record `headers` to the REST Proxy. 

- On produce, records may include a headers list of {"key": str, "value": base64-str|null} objects, which are decoded and forwarded to the Kafka producer. Values are decoded with validate=True, so non-base64 values fail fast with a 422.

- On consume, each record now returns a symmetric `headers` field. The field is omitted when the record has no headers, so the response shape is unchanged for existing consumers on header-less topics. Header values are base64-encoded since they are raw bytes.

- Never breaks consumers: header encoding can never fail a fetch — any malformed/unexpected header degrades to omitting the field and logging a warning, so existing and new consumers are unaffected regardless of who produced the record.

- Headers are opt-in and orthogonal to schema validation: value/key bytes and schema IDs are unchanged, so existing producers, consumers, and stored data are unaffected.

Integration tests cover produce/consume with headers — each side verified against a raw Kafka client, plus a full REST round-trip and malformed-header 422 cases. A unit test covers the consume-side header-encoding robustness (non-UTF-8 keys, encode failures).

Docs updated with examples: https://mbasani-rest-proxy-headers.karapace.pages.dev/docs/api-examples#rest-proxy

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
