### PR TITLE
Fix JSON Schema compatibility checks that never ran

### DIFF
--- a/src/karapace/core/compatibility/jsonschema/checks.py
+++ b/src/karapace/core/compatibility/jsonschema/checks.py
@@ -37,6 +37,7 @@ from karapace.core.compatibility.jsonschema.utils import (
 from karapace.core.typing import JsonSchemaValidator
 from typing import Any
 
+import json
 import networkx as nx
 
 INTRODUCED_INCOMPATIBILITY_MSG_FMT = "Introduced incompatible assertion {assert_name} with value {introduced_value}"
@@ -381,9 +382,12 @@ def compatibility_enum(
     assert Keyword.ENUM.value in reader_schema, "types should have been previously checked"
     assert Keyword.ENUM.value in writer_schema, "types should have been previously checked"
 
-    options_removed_by_reader = set(writer_schema[Keyword.ENUM.value]) - set(reader_schema[Keyword.ENUM.value])
+    reader_options = {json.dumps(option, sort_keys=True) for option in reader_schema[Keyword.ENUM.value]}
+    options_removed_by_reader = [
+        option for option in writer_schema[Keyword.ENUM.value] if json.dumps(option, sort_keys=True) not in reader_options
+    ]
     if options_removed_by_reader:
-        options = ", ".join(options_removed_by_reader)
+        options = ", ".join(json.dumps(option) for option in options_removed_by_reader)
         return incompatible_schema(
             Incompatibility.enum_array_narrowed,
             message=f"some of enum options are no longer valid {options}",
@@ -593,16 +597,16 @@ def compatibility_array(
         )
         result = merge(result, check_result)
 
-    reader_unique_items = reader_schema.get(Keyword.UNIQUE_ITEMS)
-    writer_unique_items = reader_schema.get(Keyword.UNIQUE_ITEMS)
+    reader_unique_items = reader_schema.get(Keyword.UNIQUE_ITEMS.value, False)
+    writer_unique_items = writer_schema.get(Keyword.UNIQUE_ITEMS.value, False)
 
-    if introduced_constraint(reader_unique_items, writer_unique_items):
+    if reader_unique_items and not writer_unique_items:
         add_incompatibility(
             result,
             incompat_type=Incompatibility.unique_items_added,
             message=INTRODUCED_INCOMPATIBILITY_MSG_FMT.format(
                 assert_name=Keyword.UNIQUE_ITEMS.value,
-                introduced_value=writer_unique_items,
+                introduced_value=reader_unique_items,
             ),
             location=location,
         )
@@ -656,8 +660,8 @@ def compatibility_object(
         reader_property = reader_properties[common_property]
         writer_property = writer_properties[common_property]
 
-        is_required_by_reader = reader_property.get(Keyword.REQUIRED.value)
-        is_required_by_writer = writer_property.get(Keyword.REQUIRED.value)
+        is_required_by_reader = common_property in reader_schema.get(Keyword.REQUIRED.value, [])
+        is_required_by_writer = common_property in writer_schema.get(Keyword.REQUIRED.value, [])
         if not is_required_by_writer and is_required_by_reader:
             add_incompatibility(
                 result,

--- a/src/karapace/core/compatibility/jsonschema/types.py
+++ b/src/karapace/core/compatibility/jsonschema/types.py
@@ -22,7 +22,7 @@ class Keyword(Enum):
     MINIMUM = "minimum"
     EXCLUSIVE_MAXIMUM = "exclusiveMaximum"
     EXCLUSIVE_MINIMUM = "exclusiveMinimum"
-    MULTIPLE = "multiple"
+    MULTIPLE = "multipleOf"
     MAX_PROPERTIES = "maxProperties"
     MIN_PROPERTIES = "minProperties"
     ADDITIONAL_PROPERTIES = "additionalProperties"

--- a/tests/schemas/json_schemas.py
+++ b/tests/schemas/json_schemas.py
@@ -59,6 +59,13 @@ MAX_ITEMS_SCHEMA = parse_jsonschema_definition('{"type":"array","maxItems":61}')
 MAX_ITEMS_DECREASED_SCHEMA = parse_jsonschema_definition('{"type":"array","maxItems":59}')
 MIN_ITEMS_SCHEMA = parse_jsonschema_definition('{"type":"array","minItems":67}')
 MIN_ITEMS_INCREASED_SCHEMA = parse_jsonschema_definition('{"type":"array","minItems":71}')
+UNIQUE_ITEMS_SCHEMA = parse_jsonschema_definition('{"type":"array","uniqueItems":true}')
+UNIQUE_ITEMS_FALSE_SCHEMA = parse_jsonschema_definition('{"type":"array","uniqueItems":false}')
+MULTIPLE_OF_NUMBER_SCHEMA = parse_jsonschema_definition('{"type":"number","multipleOf":2}')
+MULTIPLE_OF_NARROWED_NUMBER_SCHEMA = parse_jsonschema_definition('{"type":"number","multipleOf":4}')
+MULTIPLE_OF_CHANGED_NUMBER_SCHEMA = parse_jsonschema_definition('{"type":"number","multipleOf":3}')
+MULTIPLE_OF_INTEGER_SCHEMA = parse_jsonschema_definition('{"type":"integer","multipleOf":2}')
+MULTIPLE_OF_NARROWED_INTEGER_SCHEMA = parse_jsonschema_definition('{"type":"integer","multipleOf":4}')
 
 TUPLE_OF_INT_INT_SCHEMA = parse_jsonschema_definition(
     '{"type":"array","items":[{"type":"integer"},{"type":"integer"}],"additionalItems":false}'
@@ -77,6 +84,10 @@ ARRAY_OF_STRING_SCHEMA = parse_jsonschema_definition('{"type":"array","items":{"
 ENUM_AB_SCHEMA = parse_jsonschema_definition('{"enum":["A","B"]}')
 ENUM_ABC_SCHEMA = parse_jsonschema_definition('{"enum":["A","B","C"]}')
 ENUM_BC_SCHEMA = parse_jsonschema_definition('{"enum":["B","C"]}')
+ENUM_12_SCHEMA = parse_jsonschema_definition('{"enum":[1,2]}')
+ENUM_123_SCHEMA = parse_jsonschema_definition('{"enum":[1,2,3]}')
+ENUM_OBJECT_A_SCHEMA = parse_jsonschema_definition('{"enum":[{"a":1}]}')
+ENUM_OBJECT_AB_SCHEMA = parse_jsonschema_definition('{"enum":[{"a":1},{"b":2}]}')
 ONEOF_STRING_SCHEMA = parse_jsonschema_definition('{"oneOf":[{"type":"string"}]}')
 ONEOF_STRING_INT_SCHEMA = parse_jsonschema_definition('{"oneOf":[{"type":"string"},{"type":"integer"}]}')
 ONEOF_INT_SCHEMA = parse_jsonschema_definition('{"oneOf":[{"type":"integer"}]}')
@@ -97,6 +108,9 @@ EMPTY_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","additionalP
 A_OBJECT_SCHEMA = parse_jsonschema_definition('{"type":"object","properties":{"a":{}}}')
 A_INT_OBJECT_SCHEMA = parse_jsonschema_definition(
     '{"type":"object","additionalProperties":false,"properties":{"a":{"type":"integer"}}}'
+)
+A_INT_REQUIRED_OBJECT_SCHEMA = parse_jsonschema_definition(
+    '{"type":"object","additionalProperties":false,"required":["a"],"properties":{"a":{"type":"integer"}}}'
 )
 A_DINT_OBJECT_SCHEMA = parse_jsonschema_definition(
     '{"type":"object","additionalProperties":false,"properties":{"a":{"type":"integer","default":0}}}'

--- a/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
+++ b/tests/unit/compatibility/jsonschema/test_jsonschema_compatibility.py
@@ -19,6 +19,7 @@ from tests.schemas.json_schemas import (
     A_INT_B_INT_REQUIRED_OBJECT_SCHEMA,
     A_INT_OBJECT_SCHEMA,
     A_INT_OPEN_OBJECT_SCHEMA,
+    A_INT_REQUIRED_OBJECT_SCHEMA,
     A_OBJECT_SCHEMA,
     ARRAY_OF_INT_SCHEMA,
     ARRAY_OF_NUMBER_SCHEMA,
@@ -36,9 +37,13 @@ from tests.schemas.json_schemas import (
     BOOLEAN_SCHEMAS,
     EMPTY_OBJECT_SCHEMA,
     EMPTY_SCHEMA,
+    ENUM_12_SCHEMA,
+    ENUM_123_SCHEMA,
     ENUM_AB_SCHEMA,
     ENUM_ABC_SCHEMA,
     ENUM_BC_SCHEMA,
+    ENUM_OBJECT_A_SCHEMA,
+    ENUM_OBJECT_AB_SCHEMA,
     EVERY_TYPE_SCHEMA,
     EXCLUSIVE_MAXIMUM_DECREASED_INTEGER_SCHEMA,
     EXCLUSIVE_MAXIMUM_DECREASED_NUMBER_SCHEMA,
@@ -72,6 +77,11 @@ from tests.schemas.json_schemas import (
     MINIMUM_INCREASED_NUMBER_SCHEMA,
     MINIMUM_INTEGER_SCHEMA,
     MINIMUM_NUMBER_SCHEMA,
+    MULTIPLE_OF_CHANGED_NUMBER_SCHEMA,
+    MULTIPLE_OF_INTEGER_SCHEMA,
+    MULTIPLE_OF_NARROWED_INTEGER_SCHEMA,
+    MULTIPLE_OF_NARROWED_NUMBER_SCHEMA,
+    MULTIPLE_OF_NUMBER_SCHEMA,
     NON_OBJECT_SCHEMAS,
     NOT_ARRAY_SCHEMA,
     NOT_BOOLEAN_SCHEMA,
@@ -105,6 +115,8 @@ from tests.schemas.json_schemas import (
     TYPES_STRING_NULL_BOOL_SCHEMA,
     TYPES_STRING_NULL_SCHEMA,
     TYPES_STRING_SCHEMA,
+    UNIQUE_ITEMS_FALSE_SCHEMA,
+    UNIQUE_ITEMS_SCHEMA,
     A_INT_OR_BOOL_OBJECT_SCHEMA,
     A_STRING_OBJECT_SCHEMA,
     A_STRING_OR_NULL_OBJECT_SCHEMA,
@@ -1526,4 +1538,131 @@ def test_ref():
         reader=ARRAY_OF_POSITIVE_INTEGER_THROUGH_REF,
         writer=ARRAY_OF_POSITIVE_INTEGER,
         msg="the schemas are the same",
+    )
+
+
+def test_unique_items_added() -> None:
+    not_schemas_are_compatible(
+        reader=UNIQUE_ITEMS_SCHEMA,
+        writer=ARRAY_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=ARRAY_SCHEMA,
+        writer=UNIQUE_ITEMS_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_unique_items_turned_on_from_explicit_false() -> None:
+    not_schemas_are_compatible(
+        reader=UNIQUE_ITEMS_SCHEMA,
+        writer=UNIQUE_ITEMS_FALSE_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=UNIQUE_ITEMS_FALSE_SCHEMA,
+        writer=UNIQUE_ITEMS_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_unique_items_false_is_the_same_as_absent() -> None:
+    schemas_are_compatible(
+        reader=UNIQUE_ITEMS_FALSE_SCHEMA,
+        writer=ARRAY_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+    schemas_are_compatible(
+        reader=ARRAY_SCHEMA,
+        writer=UNIQUE_ITEMS_FALSE_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_multiple_of_added() -> None:
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_NUMBER_SCHEMA,
+        writer=NUMBER_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_INTEGER_SCHEMA,
+        writer=INT_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=NUMBER_SCHEMA,
+        writer=MULTIPLE_OF_NUMBER_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_multiple_of_narrowed() -> None:
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_NARROWED_NUMBER_SCHEMA,
+        writer=MULTIPLE_OF_NUMBER_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_NARROWED_INTEGER_SCHEMA,
+        writer=MULTIPLE_OF_INTEGER_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=MULTIPLE_OF_NUMBER_SCHEMA,
+        writer=MULTIPLE_OF_NARROWED_NUMBER_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_multiple_of_changed_to_a_non_divisor() -> None:
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_CHANGED_NUMBER_SCHEMA,
+        writer=MULTIPLE_OF_NUMBER_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    not_schemas_are_compatible(
+        reader=MULTIPLE_OF_NUMBER_SCHEMA,
+        writer=MULTIPLE_OF_CHANGED_NUMBER_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+
+
+def test_existing_property_became_required() -> None:
+    not_schemas_are_compatible(
+        reader=A_INT_REQUIRED_OBJECT_SCHEMA,
+        writer=A_INT_OBJECT_SCHEMA,
+        msg=INCOMPATIBLE_READER_HAS_A_NEW_REQUIRED_FIELDg,
+    )
+    schemas_are_compatible(
+        reader=A_INT_OBJECT_SCHEMA,
+        writer=A_INT_REQUIRED_OBJECT_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_enum_narrowed_with_number_options() -> None:
+    not_schemas_are_compatible(
+        reader=ENUM_12_SCHEMA,
+        writer=ENUM_123_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=ENUM_123_SCHEMA,
+        writer=ENUM_12_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
+    )
+
+
+def test_enum_narrowed_with_object_options() -> None:
+    not_schemas_are_compatible(
+        reader=ENUM_OBJECT_A_SCHEMA,
+        writer=ENUM_OBJECT_AB_SCHEMA,
+        msg=INCOMPATIBLE_READER_RESTRICTED_ACCEPTED_VALUES,
+    )
+    schemas_are_compatible(
+        reader=ENUM_OBJECT_AB_SCHEMA,
+        writer=ENUM_OBJECT_A_SCHEMA,
+        msg=COMPATIBLE_READER_EVERY_VALUE_IS_ACCEPTED,
     )


### PR DESCRIPTION
# About this change - What it does

Four checks in `compatibility/jsonschema/checks.py` look up the wrong key, so they never fire (or raise). The rules themselves were already written and correct.

1. `uniqueItems` is read as `reader_schema.get(Keyword.UNIQUE_ITEMS)` (the enum member, not `.value`), and the writer's value is read from `reader_schema`. Both are always `None`, so `unique_items_added` is never reported. Registering `{"type":"array","uniqueItems":true}` over `{"type":"array"}` in BACKWARD is accepted today, and `[1,1]` written under the old schema no longer validates.
2. `Keyword.MULTIPLE` is `"multiple"`. JSON Schema spells it `multipleOf`, so `multiple_added` / `multiple_expanded` / `multiple_changed` never fire. Adding `multipleOf: 2`, or going from `multipleOf: 2` to `multipleOf: 4`, is accepted today.
3. A property becoming required is detected by reading a boolean `required` from inside the property subschema. That is the draft-3 spelling; since draft 4 `required` is an array on the parent, so `required_attribute_added` never fires for a property both schemas declare. I only changed where the flag is read from, not the rule, so there is still no exemption for properties that have a `default`.
4. Narrowing an `enum` whose options are not strings raises `TypeError` - once from `", ".join()` over non-strings, once from putting unhashable options in a `set`. `{"enum":[1,2,3]}` -> `{"enum":[1,2]}` is a 500 instead of a 409 today.

# Why this way

I compared karapace's verdict against an instance-level oracle: for BACKWARD, `L(writer)` must be a subset of `L(reader)`, so a document that validates under the old schema and fails under the new one proves an "compatible" verdict wrong. Validation was done with the `jsonschema` library the project already depends on. 842 schema-pair/mode combinations, 45 unsound verdicts and 6 crashes before, 0 of both for these keywords after.

For 1 and 3 I did not just fix the lookup. `introduced_constraint` only fires when the writer's value is absent, which would still miss `uniqueItems: false` -> `uniqueItems: true`, so the check is now an explicit boolean comparison. `test_unique_items_false_is_the_same_as_absent` pins the other direction so this does not become a false positive.

I dumped the verdict for all 9025 ordered pairs of the repo's own `ALL_SCHEMAS` corpus before and after. Exactly 10 flip, all `compatible -> incompatible`, all from 3, and I checked none of them is asserted compatible in `tests/integration/test_jsonschema.py`. `pytest tests/unit` goes from 1300 to 1309 passing with no new failures.

What this does not cover: the same oracle still finds 36 unsound verdicts from checks that were never written at all, around `propertyNames`, `patternProperties`, narrowing `additionalProperties`, and tuple `additionalItems`. Those are missing rules rather than broken lookups, so I left them out. Related, `compatibility_array` also reads `Keyword.ITEMS` without `.value` at line 576, which makes that block dead; the variable names there say `additional_items`, so I did not want to guess the intent.

I used Claude Code to write the oracle harness and the patch. Every number above is from output I ran.
