### PR TITLE
Support OIDC (JWT) and basic auth side by side on the Schema Registry

### DIFF
--- a/container/compose.yml
+++ b/container/compose.yml
@@ -188,6 +188,54 @@ services:
       KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: ${OIDC_SUB_CLAIM_NAME:-sub}
       KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
 
+  # OIDC authentication + file-based basic auth on one SR. Scheme-based dispatch:
+  # Bearer -> OIDC, Basic -> authfile. Target for scheme-dispatch e2e tests.
+  karapace-schema-registry-oidc-basic:
+    profiles:
+      - e2e
+    networks:
+      - karapace
+    image: ghcr.io/aiven-open/karapace:develop
+    hostname: karapace-schema-registry-oidc-basic
+    container_name: karapace-schema-registry-oidc-basic
+    entrypoint:
+      - python3
+      - -m
+      - karapace
+    depends_on:
+      - kafka
+    ports:
+      - 8681:8681
+    volumes:
+      - ../tests/integration/config/karapace.auth.json:/opt/karapace/karapace.auth.json:ro
+    environment:
+      KARAPACE_KARAPACE_REGISTRY: true
+      KARAPACE_ADVERTISED_HOSTNAME: karapace-schema-registry-oidc-basic
+      KARAPACE_ADVERTISED_PROTOCOL: http
+      KARAPACE_BOOTSTRAP_URI: kafka:29092
+      KARAPACE_PORT: 8681
+      KARAPACE_HOST: 0.0.0.0
+      KARAPACE_CLIENT_ID: karapace-schema-registry-oidc-basic
+      KARAPACE_GROUP_ID: karapace-schema-registry-oidc-basic
+      KARAPACE_MASTER_ELECTION_STRATEGY: highest
+      KARAPACE_MASTER_ELIGIBILITY: true
+      KARAPACE_TOPIC_NAME: _schemas_oidc_basic
+      KARAPACE_LOG_LEVEL: INFO
+      KARAPACE_COMPATIBILITY: FULL
+      KARAPACE_KAFKA_SCHEMA_READER_STRICT_MODE: false
+      KARAPACE_KAFKA_RETRIABLE_ERRORS_SILENCED: true
+      KARAPACE_TAGS__APP: karapace-schema-registry-oidc-basic
+      KARAPACE_REGISTRY_AUTHFILE: /opt/karapace/karapace.auth.json
+      KARAPACE_SASL_OAUTHBEARER_AUTHENTICATION_ENABLED: true
+      KARAPACE_SASL_OAUTHBEARER_AUTHORIZATION_ENABLED: false
+      # Dev-only: keycloak in compose serves http. Production must use https:// JWKS.
+      KARAPACE_SASL_OAUTHBEARER_JWKS_ENDPOINT_URL: ${OIDC_JWKS_ENDPOINT_URL:-http://keycloak:8080/realms/karapace/protocol/openid-connect/certs}
+      KARAPACE_SASL_OAUTHBEARER_ALLOW_INSECURE_JWKS: ${OIDC_ALLOW_INSECURE_JWKS:-true}
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_ISSUER: ${OIDC_EXPECTED_ISSUER:-http://keycloak:8080/realms/karapace}
+      KARAPACE_SASL_OAUTHBEARER_EXPECTED_AUDIENCE: ${OIDC_EXPECTED_AUDIENCE:-karapace-audience}
+      KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: ${OIDC_SUB_CLAIM_NAME:-sub}
+      KARAPACE_SASL_OAUTHBEARER_SKIP_AUTH_PATHS: '["/_health", "/metrics"]'
+
   # Full OIDC (authentication + role-based authorization). Target for the
   # authn+authz e2e tests (registry_async_client_oidc* fixtures).
   karapace-schema-registry-oidc:

--- a/src/karapace/api/middlewares/__init__.py
+++ b/src/karapace/api/middlewares/__init__.py
@@ -21,49 +21,63 @@ log = logging.getLogger(__name__)
 
 
 def _authenticate_and_authorize(request: Request, config: Config, oidc_validator: OIDCTokenValidator) -> JSONResponse | None:
-    """Run the OIDC auth gate. Return a JSONResponse on failure, or None to continue."""
+    """Dispatch on the Authorization scheme: Bearer -> OIDC check, Basic -> defer to basic auth.
+
+    Return a JSONResponse on failure, or None to continue (route runs; Basic is handled by the
+    basic-auth dependency). Bearer takes priority; there is no fallback between schemes.
+    """
     auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        return JSONResponse(
-            status_code=401,
-            content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
-        )
+    # Auth schemes are case-insensitive; split "<scheme> <credentials>" and match on the lowered scheme.
+    scheme, _, credentials = (auth_header or "").partition(" ")
+    scheme = scheme.lower()
 
-    token = auth_header[len("Bearer ") :].strip()
-    if not token:
-        return JSONResponse(
-            status_code=401,
-            content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
-        )
-
-    try:
-        payload = oidc_validator.validate_jwt(token)
-    except TokenExpiredError:
-        return JSONResponse(
-            status_code=401,
-            content={"error": "Unauthorized", "reason": "Token expired"},
-        )
-    except AuthenticationError:
-        return JSONResponse(
-            status_code=401,
-            content={"error": "Unauthorized", "reason": "Invalid token/payload"},
-        )
-
-    # Expose only the configured subject claim to handlers, never the full payload.
-    # Prevents downstream code from picking up attacker-controlled claims (e.g. "roles")
-    # and using them for authz decisions.
-    request.state.user = payload.get(oidc_validator.claim_name) if oidc_validator.claim_name else None
-    log.debug("Authenticated")
-
-    if config.sasl_oauthbearer_authorization_enabled:
-        try:
-            oidc_validator.authorize_request(payload, request.method)
-        except HTTPException as e:
+    if scheme == "bearer":
+        token = credentials.strip()
+        if not token:
             return JSONResponse(
-                {"error": "Authorization error", "reason": e.detail},
-                status_code=e.status_code,
+                status_code=401,
+                content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
             )
-    return None
+
+        try:
+            payload = oidc_validator.validate_jwt(token)
+        except TokenExpiredError:
+            return JSONResponse(
+                status_code=401,
+                content={"error": "Unauthorized", "reason": "Token expired"},
+            )
+        except AuthenticationError:
+            return JSONResponse(
+                status_code=401,
+                content={"error": "Unauthorized", "reason": "Invalid token/payload"},
+            )
+
+        # Expose only the configured subject claim to handlers, never the full payload.
+        # Prevents downstream code from picking up attacker-controlled claims (e.g. "roles")
+        # and using them for authz decisions.
+        request.state.user = payload.get(oidc_validator.claim_name) if oidc_validator.claim_name else None
+        # Marks the request as OIDC-authenticated so the basic-auth dependency is skipped.
+        request.state.oidc_authenticated = True
+        log.debug("Authenticated")
+
+        if config.sasl_oauthbearer_authorization_enabled:
+            try:
+                oidc_validator.authorize_request(payload, request.method)
+            except HTTPException as e:
+                return JSONResponse(
+                    {"error": "Authorization error", "reason": e.detail},
+                    status_code=e.status_code,
+                )
+        return None
+
+    # Basic requests are handled by the basic-auth dependency, but only when an authfile is configured.
+    if scheme == "basic" and config.registry_authfile:
+        return None
+
+    return JSONResponse(
+        status_code=401,
+        content={"error": "Unauthorized", "reason": "Missing or invalid Authorization header"},
+    )
 
 
 # Paths that bypass the OIDC auth gate: API docs endpoints are always public.

--- a/src/karapace/api/user.py
+++ b/src/karapace/api/user.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 
 from dependency_injector.wiring import inject, Provide
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from karapace.core.auth import AuthenticationError, AuthenticatorAndAuthorizer, User
 from typing import Annotated
@@ -14,9 +14,13 @@ from karapace.core.auth_container import AuthContainer
 
 @inject
 async def get_current_user(
+    request: Request,
     credentials: Annotated[HTTPBasicCredentials, Depends(HTTPBasic(auto_error=False))],
     authorizer: AuthenticatorAndAuthorizer = Depends(Provide[AuthContainer.authorizer]),
 ) -> User | None:
+    # The OIDC middleware already authenticated a Bearer request; skip basic auth and bypass ACL.
+    if getattr(request.state, "oidc_authenticated", False):
+        return User.externally_authenticated(getattr(request.state, "user", None) or "")
     if authorizer.MUST_AUTHENTICATE and not credentials:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/karapace/core/auth.py
+++ b/src/karapace/core/auth.py
@@ -65,12 +65,21 @@ def hash_password(algorithm: HashAlgorithm, salt: str, plaintext_password: str) 
 @dataclass
 class User:
     username: str
-    algorithm: HashAlgorithm
-    salt: str
-    password_hash: str = field(repr=False)
+    # Credentials are absent for externally-authenticated users (e.g. OIDC).
+    algorithm: HashAlgorithm | None = None
+    salt: str | None = None
+    password_hash: str | None = field(default=None, repr=False)
+    # Authenticated by an external gate (OIDC middleware); ACL checks are bypassed.
+    authenticated_externally: bool = False
 
     def compare_password(self, plaintext_password: str) -> bool:
+        if self.algorithm is None or self.salt is None or self.password_hash is None:
+            return False
         return compare_digest(self.password_hash, hash_password(self.algorithm, self.salt, plaintext_password))
+
+    @classmethod
+    def externally_authenticated(cls, username: str) -> User:
+        return cls(username=username, authenticated_externally=True)
 
 
 @dataclass(frozen=True)
@@ -168,17 +177,7 @@ class ACLAuthorizer(AuthorizeProtocol):
 
     @override
     def check_authorization(self, user: User | None, operation: Operation, resource: str) -> bool:
-        if user is None:
-            return False
-
-        for aclentry in self.permissions:
-            if (
-                aclentry.username == user.username
-                and self._check_operation(operation, aclentry)
-                and self._check_resources([resource], aclentry)
-            ):
-                return True
-        return False
+        return self.check_authorization_any(user, operation, [resource])
 
     @override
     def check_authorization_any(self, user: User | None, operation: Operation, resources: list[str]) -> bool:
@@ -189,6 +188,9 @@ class ACLAuthorizer(AuthorizeProtocol):
         """
         if user is None:
             return False
+        # Externally authenticated (e.g. OIDC) users are authorized elsewhere; the ACL is bypassed.
+        if user.authenticated_externally:
+            return True
 
         for aclentry in self.permissions:
             if (

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -473,6 +473,39 @@ async def fixture_registry_async_client_basic(
         await client.close()
 
 
+# OIDC authentication + file-based basic auth on one SR (scheme dispatch). Compose profile: e2e.
+_OIDC_BASIC_URI = "http://karapace-schema-registry-oidc-basic:8681"
+
+
+@pytest.fixture(scope="function", name="registry_async_client_oidc_basic_bearer")
+async def fixture_registry_async_client_oidc_basic_bearer(
+    loop: asyncio.AbstractEventLoop,
+    oidc_token,
+) -> AsyncGenerator[Client, None]:
+    """Bearer client to the OIDC+basic SR (dispatches to the OIDC path)."""
+
+    async def factory(auth):
+        return ClientSession(headers={"Authorization": f"Bearer {oidc_token}"})
+
+    client = Client(server_uri=_OIDC_BASIC_URI, client_factory=factory, session_auth=None)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="function", name="registry_async_client_oidc_basic")
+async def fixture_registry_async_client_oidc_basic(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[Client, None]:
+    """Plain client to the OIDC+basic SR; pass per-request auth=BasicAuth(...) for the Basic path."""
+    client = Client(server_uri=_OIDC_BASIC_URI, session_auth=None)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
 class TokenProvider:
     def __init__(self, token: str, expiry_seconds: int = 3600):
         self._token = token

--- a/tests/e2e/schema_registry/test_oidc_basic_dispatch.py
+++ b/tests/e2e/schema_registry/test_oidc_basic_dispatch.py
@@ -1,0 +1,86 @@
+"""
+Scheme-based auth dispatch e2e: one SR with OIDC authentication AND file-based basic auth.
+A `Bearer` request is validated as OIDC; a `Basic` request is checked against the authfile
+(users + ACL). Bearer takes priority; there is no fallback between schemes.
+
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+import asyncio
+import json
+
+from aiohttp import BasicAuth
+
+from karapace.core.client import Client
+from karapace.core.schema_reader import SchemaType
+from tests.utils import new_random_name
+
+_SCHEMA = {"schema": json.dumps({"type": "string"}), "schemaType": SchemaType.JSONSCHEMA.value}
+
+# Credentials from tests/integration/config/karapace.auth.json:
+#   admin/admin      -> Write .*            (full access)
+#   aladdin/opensesame -> Write Subject:cave-.*
+_ADMIN = BasicAuth("admin", "admin")
+_ALADDIN = BasicAuth("aladdin", "opensesame")
+
+
+async def _wait_for_primary(client: Client, auth: BasicAuth | None = None, timeout: float = 30.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        res = await client.get("master_available", auth=auth)
+        if res.status_code == 200 and res.json_result and res.json_result.get("master_available") is True:
+            return
+        await asyncio.sleep(1.0)
+    raise TimeoutError("Schema registry did not elect a primary within timeout")
+
+
+async def test_bearer_request_dispatches_to_oidc(
+    registry_async_client_oidc_basic_bearer: Client,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc_basic_bearer)
+    subject = new_random_name("subject")
+
+    res = await registry_async_client_oidc_basic_bearer.post(f"subjects/{subject}/versions", json=_SCHEMA)
+
+    assert res.status_code == 200
+
+
+async def test_basic_admin_request_dispatches_to_authfile(
+    registry_async_client_oidc_basic: Client,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc_basic, auth=_ADMIN)
+    subject = new_random_name("subject")
+
+    # admin has Write on any resource, so the basic-auth ACL allows the write.
+    res = await registry_async_client_oidc_basic.post(f"subjects/{subject}/versions", json=_SCHEMA, auth=_ADMIN)
+
+    assert res.status_code == 200
+
+
+async def test_basic_acl_is_enforced_for_authfile_user(
+    registry_async_client_oidc_basic: Client,
+) -> None:
+    await _wait_for_primary(registry_async_client_oidc_basic, auth=_ADMIN)
+
+    # aladdin may write cave-* subjects.
+    cave = new_random_name("cave-")
+    allowed = await registry_async_client_oidc_basic.post(f"subjects/{cave}/versions", json=_SCHEMA, auth=_ALADDIN)
+    assert allowed.status_code == 200
+
+    # aladdin has no permission on carpet-*, which looks identical to a missing subject (404).
+    carpet = new_random_name("carpet-")
+    denied = await registry_async_client_oidc_basic.post(f"subjects/{carpet}/versions", json=_SCHEMA, auth=_ALADDIN)
+    assert denied.status_code == 404
+
+
+async def test_basic_wrong_password_is_rejected(
+    registry_async_client_oidc_basic: Client,
+) -> None:
+    subject = new_random_name("subject")
+
+    res = await registry_async_client_oidc_basic.get(
+        f"subjects/{subject}/versions", auth=BasicAuth("admin", "wrong-password")
+    )
+
+    assert res.status_code == 401

--- a/tests/unit/api/test_middlewares.py
+++ b/tests/unit/api/test_middlewares.py
@@ -116,6 +116,65 @@ def test_non_bearer_authorization_returns_401() -> None:
     assert response.status_code == 401
 
 
+# ---- Scheme dispatch: Basic coexists with OIDC when an authfile is configured ----
+
+
+def test_basic_scheme_deferred_to_basic_auth_when_authfile_set() -> None:
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, registry_authfile="authfile.json")
+
+    # A Basic request must not be 401'd by the OIDC middleware; it is deferred to the basic-auth
+    # dependency (here the bare stub route just runs).
+    response = _client(config).get("/subjects", headers={"Authorization": "Basic abc"})
+
+    assert response.status_code == 200
+
+
+def test_basic_scheme_rejected_when_no_authfile() -> None:
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+
+    response = _client(config).get("/subjects", headers={"Authorization": "Basic abc"})
+
+    assert response.status_code == 401
+
+
+def test_bearer_stamps_oidc_authenticated_state() -> None:
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, registry_authfile="authfile.json")
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict:
+        return {
+            "oidc_authenticated": getattr(request.state, "oidc_authenticated", False),
+            "user": getattr(request.state, "user", None),
+        }
+
+    setup_middlewares(app, config)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    with patch("karapace.api.middlewares.OIDCTokenValidator.validate_jwt", return_value={"sub": "u1"}):
+        response = client.get("/whoami", headers={"Authorization": "Bearer good-token"})
+
+    assert response.status_code == 200
+    assert response.json() == {"oidc_authenticated": True, "user": "u1"}
+
+
+def test_scheme_matching_is_case_insensitive_for_bearer() -> None:
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
+
+    with patch("karapace.api.middlewares.OIDCTokenValidator.validate_jwt", return_value={"sub": "u1"}):
+        response = _client(config).get("/subjects", headers={"Authorization": "bearer good-token"})
+
+    assert response.status_code == 200
+
+
+def test_scheme_matching_is_case_insensitive_for_basic() -> None:
+    config = _oidc_config(sasl_oauthbearer_authentication_enabled=True, registry_authfile="authfile.json")
+
+    response = _client(config).get("/subjects", headers={"Authorization": "basic abc"})
+
+    assert response.status_code == 200
+
+
 # ---- Authorization enabled: JWT validation outcomes ----
 
 

--- a/tests/unit/api/test_user.py
+++ b/tests/unit/api/test_user.py
@@ -1,0 +1,61 @@
+"""
+Tests for the basic-auth dependency (``karapace.api.user.get_current_user``), including the
+OIDC pass-through branch used by scheme-based auth dispatch.
+
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from karapace.api.user import get_current_user
+
+
+def _request(**state) -> MagicMock:
+    request = MagicMock()
+    request.state = SimpleNamespace(**state)
+    return request
+
+
+async def test_returns_external_user_when_oidc_authenticated() -> None:
+    authorizer = MagicMock()
+
+    user = await get_current_user(
+        request=_request(oidc_authenticated=True, user="subject-1"),
+        credentials=None,
+        authorizer=authorizer,
+    )
+
+    assert user is not None
+    assert user.username == "subject-1"
+    assert user.authenticated_externally is True
+    # Basic authentication is skipped entirely when OIDC already authenticated the request.
+    authorizer.authenticate.assert_not_called()
+
+
+async def test_external_user_uses_empty_username_when_subject_missing() -> None:
+    user = await get_current_user(
+        request=_request(oidc_authenticated=True, user=None),
+        credentials=None,
+        authorizer=MagicMock(),
+    )
+
+    assert user is not None
+    assert user.username == ""
+    assert user.authenticated_externally is True
+
+
+async def test_requires_basic_when_not_oidc_authenticated() -> None:
+    authorizer = MagicMock()
+    authorizer.MUST_AUTHENTICATE = True
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request=_request(), credentials=None, authorizer=authorizer)
+
+    assert exc_info.value.status_code == 401

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -39,6 +39,32 @@ def test_empty_acl_authorizer() -> None:
     )
 
 
+def test_externally_authenticated_user_bypasses_acl() -> None:
+    authorizer = ACLAuthorizer(
+        user_db={},
+        permissions=[ACLEntry("someone", Operation.Read, re.compile(r"Subject:allowed"))],
+    )
+    external = User.externally_authenticated("oidc-subject")
+    # No ACL entry matches this user, but external authentication (OIDC) bypasses the ACL entirely.
+    assert authorizer.check_authorization(user=external, operation=Operation.Write, resource="Subject:anything") is True
+    assert (
+        authorizer.check_authorization_any(user=external, operation=Operation.Write, resources=["Subject:anything"]) is True
+    )
+
+
+def test_externally_authenticated_factory_has_no_credentials() -> None:
+    external = User.externally_authenticated("oidc-subject")
+    assert external.username == "oidc-subject"
+    assert external.authenticated_externally is True
+    assert external.algorithm is None
+    assert external.salt is None
+    assert external.password_hash is None
+
+
+def test_external_user_compare_password_is_false() -> None:
+    assert User.externally_authenticated("oidc-subject").compare_password("anything") is False
+
+
 def test_acl_authorizer() -> None:
     admin_password_hash = hash_password(
         algorithm=HashAlgorithm.SHA256,

--- a/tests/unit/test_oidc.py
+++ b/tests/unit/test_oidc.py
@@ -563,8 +563,7 @@ _BASIC_HEADER = "Basic " + base64.b64encode(b"user:pass").decode()
 @pytest.mark.parametrize(
     "auth_header",
     [
-        _BASIC_HEADER,  # wrong scheme
-        "bearer good.token",  # lowercase scheme — check is case-sensitive
+        _BASIC_HEADER,  # Basic scheme with no authfile configured
         "Bearer",  # scheme only, no token/space
         "Bearer ",  # empty token
         "Bearer    ",  # whitespace-only token
@@ -578,11 +577,12 @@ def test_middleware_rejects_non_bearer_or_empty_token(monkeypatch, auth_header):
     assert r.json()["reason"] == "Missing or invalid Authorization header"
 
 
-def test_middleware_accepts_bearer_with_valid_token(monkeypatch):
-    """Control for the rejection cases above."""
+@pytest.mark.parametrize("auth_header", ["Bearer good.token", "bearer good.token"], ids=["capitalized", "lowercase"])
+def test_middleware_accepts_bearer_with_valid_token(monkeypatch, auth_header):
+    """Control for the rejection cases above; scheme match is case-insensitive."""
     config = _oidc_config(sasl_oauthbearer_authentication_enabled=True)
     client = _build_app_with_middleware(monkeypatch, config, validate_jwt_payload={"sub": "u"})
-    r = client.get("/subjects", headers={"Authorization": "Bearer good.token"})
+    r = client.get("/subjects", headers={"Authorization": auth_header})
     assert r.status_code == 200
 
 

--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -4,10 +4,14 @@ title: Authentication & authorization
 
 # Authentication & authorization
 
-Karapace supports two independent authentication systems for the Schema Registry:
+Karapace supports two authentication systems for the Schema Registry:
 **HTTP basic auth** (file-based users and access rules) and **OAuth2 / OIDC** (bearer
 token validation). The REST proxy forwards OAuth2 tokens to Kafka and the Schema
 Registry rather than validating them itself.
+
+Each can be used on its own, or **both at once** — when both are enabled the Schema
+Registry routes each request by its `Authorization` scheme. See
+[Using OIDC and basic auth together](#using-oidc-and-basic-auth-together).
 
 ## HTTP basic authentication
 
@@ -143,6 +147,30 @@ KARAPACE_SASL_OAUTHBEARER_SUB_CLAIM_NAME: sub
 - `sasl_oauthbearer_jwks_endpoint_url` must use `https://`; startup fails otherwise.
 - `/docs`, `/redoc` and `/openapi.json` bypass the auth gate by design (for Swagger UI).
   Block them at your reverse proxy in production to avoid exposing the API surface.
+
+## Using OIDC and basic auth together
+
+When `sasl_oauthbearer_authentication_enabled` is `true` **and** `registry_authfile` is
+set, the Schema Registry serves both systems at once and dispatches on each request's
+`Authorization` scheme (case-insensitive). This lets clients migrate from basic auth to
+OIDC one at a time — no client ever sends more than one header, and no coordinated
+switch is required.
+
+| `Authorization` header | Handled as                                                                                                                                                                                                                                          |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Bearer <jwt>`         | **OIDC.** Token is validated; invalid or expired → `401` (no fallback). Authorization uses role mapping when `sasl_oauthbearer_authorization_enabled` is `true`, otherwise a valid token is allowed. The authorization file's ACL is not consulted. |
+| `Basic <base64>`       | **Basic.** Credentials are checked against the authorization file, and its ACL is enforced — regardless of the OIDC authorization flag.                                                                                                             |
+| missing / other        | `401`                                                                                                                                                                                                                                               |
+
+Notes:
+
+- `Bearer` takes priority; there is no fallback between schemes — a bad token is never
+  retried as basic.
+- With `sasl_oauthbearer_authentication_enabled: false`, the OIDC gate is skipped
+  entirely and only basic auth applies (unchanged behavior).
+- The REST proxy needs no extra configuration: it forwards the inbound `Authorization`
+  header to the Schema Registry, so both `Bearer` and `Basic` requests work through the
+  proxy.
 
 ## OAuth2 (REST proxy)
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Support OIDC (JWT) and basic auth side by side on the Schema Registry

Currently when sasl_oauthbearer_authentication_enabled is on, basic auth doesn't work. The JWT check is Bearer-only and rejects anything else before basic auth runs. This is difficult for migrating customers.

Solution : 

With sasl_oauthbearer_authentication_enabled=true

| Header value      | Authentication                                              | Authorization                                                    |
|--------------------|--------------------------------------------------------------|--------------------------------------------------------------------|
| `Bearer <jwt>`     | OIDC JWT validation; invalid/expired → `401`, no fallback     | authz **on** → method-based roles; authz **off** → allowed (authn only) |
| `Basic <b64>`      | authfile credentials (requires `registry_authfile`)           | authfile ACL — always enforced, regardless of the OIDC authz flag  |
| missing / other    | —                                                              | `401`                                                               |

If sasl_oauthbearer_authentication_enabled is true and sasl_oauthbearer_authorization_enabled=false, and if its bearer token, we go with oidc validation and if invalid token, it fails. 

and if sasl_oauthbearer_authentication_enabled is true and sasl_oauthbearer_authorization_enabled=true, and bearer is sent, and if valid token, then authz is done based on method/roles.

if sasl_oauthbearer_authentication_enabled=true and sasl_oauthbearer_authorization_enabled=false or true, and if Basic is sent inheader instead of Bearer, then we go with basic authentication and basic authorization. 

if sasl_oauthbearer_authentication_enabled=false, everything basic authn and authz

New tests to simulate this fallback situation.

Update website docs

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
References: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
