### PR TITLE
feat: expose Schema Registry health metrics

### DIFF
--- a/src/karapace/api/routers/health.py
+++ b/src/karapace/api/routers/health.py
@@ -58,30 +58,14 @@ async def health(
     tracer: Tracer = Depends(Provide[SchemaRegistryContainer.telemetry_container.tracer]),
 ) -> HealthCheck:
     with tracer.get_tracer().start_as_current_span("APIRouter: health_check") as health_check_span:
-        starttime = 0.0
-
-        schema_reader_is_ready = schema_registry.schema_reader.ready()
-        if schema_reader_is_ready:
-            starttime = schema_registry.schema_reader.last_check - schema_registry.schema_reader.start_time
-
-        cs = schema_registry.mc.get_coordinator_status()
-        health_status = HealthStatus(
-            schema_registry_ready=schema_reader_is_ready,
-            schema_registry_startup_time_sec=starttime,
-            schema_registry_reader_current_offset=schema_registry.schema_reader.offset,
-            schema_registry_reader_highest_offset=schema_registry.schema_reader.highest_offset(),
-            schema_registry_is_primary=cs.is_primary,
-            schema_registry_is_primary_eligible=cs.is_primary_eligible,
-            schema_registry_primary_url=cs.primary_url,
-            schema_registry_coordinator_running=cs.is_running,
-            schema_registry_coordinator_generation_id=cs.group_generation_id,
-        )
+        health_check = await schema_registry.health_monitor.check()
+        health_status = HealthStatus.model_validate(health_check.status, from_attributes=True)
         set_health_status_tracing_attributes(health_check_span=health_check_span, health_status=health_status)
 
         # if self._auth is not None:
         #    resp["schema_registry_authfile_timestamp"] = self._auth.authfile_last_modified
 
-        if not await schema_registry.schema_reader.is_healthy():
+        if not health_check.healthy:
             health_check_span.set_status(status=StatusCode.ERROR, description="Schema reader is not healthy")
             raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
 

--- a/src/karapace/core/health.py
+++ b/src/karapace/core/health.py
@@ -1,0 +1,124 @@
+"""
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+import asyncio
+import logging
+import time
+
+if TYPE_CHECKING:
+    from karapace.core.schema_registry import KarapaceSchemaRegistry
+    from karapace.core.stats import StatsClient
+
+
+LOG = logging.getLogger(__name__)
+
+HEALTH_CHECK_INTERVAL_SECONDS: Final = 10.0
+
+
+@dataclass(frozen=True)
+class SchemaRegistryHealthStatus:
+    schema_registry_ready: bool
+    schema_registry_startup_time_sec: float
+    schema_registry_reader_current_offset: int
+    schema_registry_reader_highest_offset: int
+    schema_registry_is_primary: bool | None
+    schema_registry_is_primary_eligible: bool
+    schema_registry_primary_url: str | None
+    schema_registry_coordinator_running: bool
+    schema_registry_coordinator_generation_id: int
+
+
+@dataclass(frozen=True)
+class SchemaRegistryHealthCheck:
+    status: SchemaRegistryHealthStatus
+    healthy: bool
+    checked_at: float
+
+
+class SchemaRegistryHealthMonitor:
+    """Share Schema Registry health state between the HTTP API and metrics."""
+
+    def __init__(
+        self,
+        *,
+        schema_registry: KarapaceSchemaRegistry,
+        stats: StatsClient,
+        check_interval_seconds: float = HEALTH_CHECK_INTERVAL_SECONDS,
+    ) -> None:
+        self._schema_registry = schema_registry
+        self._stats = stats
+        self._check_interval_seconds = check_interval_seconds
+        self._task: asyncio.Task[None] | None = None
+
+    def status(self) -> SchemaRegistryHealthStatus:
+        schema_reader = self._schema_registry.schema_reader
+        schema_reader_is_ready = schema_reader.ready()
+        startup_time_sec = schema_reader.last_check - schema_reader.start_time if schema_reader_is_ready else 0.0
+        coordinator_status = self._schema_registry.mc.get_coordinator_status()
+
+        return SchemaRegistryHealthStatus(
+            schema_registry_ready=schema_reader_is_ready,
+            schema_registry_startup_time_sec=startup_time_sec,
+            schema_registry_reader_current_offset=schema_reader.offset,
+            schema_registry_reader_highest_offset=schema_reader.highest_offset(),
+            schema_registry_is_primary=coordinator_status.is_primary,
+            schema_registry_is_primary_eligible=coordinator_status.is_primary_eligible,
+            schema_registry_primary_url=coordinator_status.primary_url,
+            schema_registry_coordinator_running=coordinator_status.is_running,
+            schema_registry_coordinator_generation_id=coordinator_status.group_generation_id,
+        )
+
+    async def check(self) -> SchemaRegistryHealthCheck:
+        status = self.status()
+        healthy = await self._schema_registry.schema_reader.is_healthy()
+        checked_at = time.time()
+        self._stats.set_schema_registry_health(
+            healthy=healthy,
+            ready=status.schema_registry_ready,
+            startup_time_sec=status.schema_registry_startup_time_sec,
+            reader_current_offset=status.schema_registry_reader_current_offset,
+            reader_highest_offset=status.schema_registry_reader_highest_offset,
+            is_primary=status.schema_registry_is_primary,
+            is_primary_eligible=status.schema_registry_is_primary_eligible,
+            coordinator_running=status.schema_registry_coordinator_running,
+            coordinator_generation_id=status.schema_registry_coordinator_generation_id,
+            checked_at=checked_at,
+        )
+        return SchemaRegistryHealthCheck(status=status, healthy=healthy, checked_at=checked_at)
+
+    async def start(self) -> None:
+        if self._task is None:
+            await self._check_and_report()
+            self._task = asyncio.create_task(self._run(), name="schema-registry-health-monitor")
+
+    async def close(self) -> None:
+        if self._task is None:
+            return
+
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(self._check_interval_seconds)
+            await self._check_and_report()
+
+    async def _check_and_report(self) -> None:
+        try:
+            await self.check()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            checked_at = time.time()
+            self._stats.set_schema_registry_health_failed(checked_at=checked_at)
+            LOG.exception("Unexpected exception while collecting Schema Registry health metrics")

--- a/src/karapace/core/schema_registry.py
+++ b/src/karapace/core/schema_registry.py
@@ -26,6 +26,7 @@ from karapace.core.errors import (
     SubjectSoftDeletedException,
     VersionNotFoundException,
 )
+from karapace.core.health import SchemaRegistryHealthMonitor
 from karapace.core.in_memory_database import InMemoryDatabase
 from karapace.core.key_format import KeyFormatter
 from karapace.core.messaging import KarapaceProducer
@@ -72,6 +73,7 @@ class KarapaceSchemaRegistry:
             stats=stats,
         )
         self.mc.set_stoppper(self.schema_reader)
+        self.health_monitor = SchemaRegistryHealthMonitor(schema_registry=self, stats=stats)
 
         self.schema_lock = asyncio.Lock()
         self._master_lock = asyncio.Lock()
@@ -91,8 +93,10 @@ class KarapaceSchemaRegistry:
         self.mc.start()
         self.schema_reader.start()
         self.producer.initialize_karapace_producer()
+        await self.health_monitor.start()
 
     async def close(self) -> None:
+        await self.health_monitor.close()
         async with AsyncExitStack() as stack:
             stack.push_async_callback(self.mc.close)
             stack.enter_context(closing(self.schema_reader))

--- a/src/karapace/core/stats.py
+++ b/src/karapace/core/stats.py
@@ -11,6 +11,7 @@ from karapace.core.config import Config
 from karapace.core.instrumentation.meter import Meter
 from karapace.core.key_format import KeyMode
 from karapace.core.sentry import get_sentry_client
+from karapace.version import __version__
 from opentelemetry.metrics import Counter
 from prometheus_client import CollectorRegistry, Gauge as PrometheusGauge, REGISTRY
 from typing import Final, Mapping
@@ -25,6 +26,18 @@ METRIC_SCHEMAS_GAUGE: Final = "karapace_schema_reader_schemas"
 METRIC_SUBJECTS_GAUGE: Final = "karapace_schema_reader_subjects"
 METRIC_SUBJECT_DATA_SCHEMA_VERSIONS_GAUGE: Final = "karapace_schema_reader_subject_data_schema_versions"
 METRIC_EXCEPTIONS = "karapace_exceptions_total"
+METRIC_HEALTH_GAUGE: Final = "karapace_health"
+METRIC_SCHEMA_REGISTRY_READY_GAUGE: Final = "karapace_schema_registry_ready"
+METRIC_SCHEMA_REGISTRY_STARTUP_DURATION_GAUGE: Final = "karapace_schema_registry_startup_duration_seconds"
+METRIC_SCHEMA_REGISTRY_READER_CURRENT_OFFSET_GAUGE: Final = "karapace_schema_registry_reader_current_offset"
+METRIC_SCHEMA_REGISTRY_READER_HIGHEST_OFFSET_GAUGE: Final = "karapace_schema_registry_reader_highest_offset"
+METRIC_SCHEMA_REGISTRY_READER_LAG_GAUGE: Final = "karapace_schema_registry_reader_lag"
+METRIC_SCHEMA_REGISTRY_PRIMARY_GAUGE: Final = "karapace_schema_registry_primary"
+METRIC_SCHEMA_REGISTRY_PRIMARY_ELIGIBLE_GAUGE: Final = "karapace_schema_registry_primary_eligible"
+METRIC_SCHEMA_REGISTRY_COORDINATOR_RUNNING_GAUGE: Final = "karapace_schema_registry_coordinator_running"
+METRIC_SCHEMA_REGISTRY_COORDINATOR_GENERATION_GAUGE: Final = "karapace_schema_registry_coordinator_generation"
+METRIC_HEALTH_CHECK_TIMESTAMP_GAUGE: Final = "karapace_health_check_timestamp_seconds"
+METRIC_BUILD_INFO_GAUGE: Final = "karapace_build_info"
 
 
 class StatsClient:
@@ -63,6 +76,63 @@ class StatsClient:
             labelnames=["state", *sorted(self._tags.keys())],
             registry=registry,
         )
+        self._health_gauge = self._gauge(METRIC_HEALTH_GAUGE, "Whether this Karapace instance is healthy", registry)
+        self._schema_registry_ready_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_READY_GAUGE, "Whether the Schema Registry reader is ready", registry
+        )
+        self._schema_registry_startup_duration_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_STARTUP_DURATION_GAUGE,
+            "Seconds required for the Schema Registry reader to become ready",
+            registry,
+        )
+        self._schema_registry_reader_current_offset_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_READER_CURRENT_OFFSET_GAUGE,
+            "Current consumed offset of the Schema Registry reader",
+            registry,
+        )
+        self._schema_registry_reader_highest_offset_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_READER_HIGHEST_OFFSET_GAUGE,
+            "Highest known offset of the schema topic",
+            registry,
+        )
+        self._schema_registry_reader_lag_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_READER_LAG_GAUGE,
+            "Difference between the highest known and current Schema Registry reader offsets",
+            registry,
+        )
+        self._schema_registry_primary_gauge = PrometheusGauge(
+            METRIC_SCHEMA_REGISTRY_PRIMARY_GAUGE,
+            "Schema Registry primary-election state",
+            labelnames=["state", *sorted(self._tags.keys())],
+            registry=registry,
+        )
+        self._schema_registry_primary_eligible_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_PRIMARY_ELIGIBLE_GAUGE,
+            "Whether this Schema Registry instance is eligible to become primary",
+            registry,
+        )
+        self._schema_registry_coordinator_running_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_COORDINATOR_RUNNING_GAUGE,
+            "Whether the Schema Registry coordinator is running",
+            registry,
+        )
+        self._schema_registry_coordinator_generation_gauge = self._gauge(
+            METRIC_SCHEMA_REGISTRY_COORDINATOR_GENERATION_GAUGE,
+            "Current Schema Registry coordinator generation ID",
+            registry,
+        )
+        self._health_check_timestamp_gauge = self._gauge(
+            METRIC_HEALTH_CHECK_TIMESTAMP_GAUGE,
+            "Unix timestamp of the most recent completed Schema Registry health check",
+            registry,
+        )
+        self._build_info_gauge = PrometheusGauge(
+            METRIC_BUILD_INFO_GAUGE,
+            "Karapace build information",
+            labelnames=["version", *sorted(self._tags.keys())],
+            registry=registry,
+        )
+        self._build_info_gauge.labels(version=__version__, **self._tags).set(1)
         self._exceptions_total: Final[Counter] = self._meter.get_meter().create_counter(
             name=METRIC_EXCEPTIONS, description="Unexpected exceptions"
         )
@@ -84,6 +154,49 @@ class StatsClient:
     def set_schema_versions_num_total(self, *, live_versions: int, soft_deleted_versions: int) -> None:
         self._schema_versions_gauge.labels(state="live", **self._tags).set(live_versions)
         self._schema_versions_gauge.labels(state="soft_deleted", **self._tags).set(soft_deleted_versions)
+
+    def _gauge(self, name: str, description: str, registry: CollectorRegistry) -> PrometheusGauge:
+        return PrometheusGauge(
+            name,
+            description,
+            labelnames=sorted(self._tags.keys()),
+            registry=registry,
+        )
+
+    def set_schema_registry_health(
+        self,
+        *,
+        healthy: bool,
+        ready: bool,
+        startup_time_sec: float,
+        reader_current_offset: int,
+        reader_highest_offset: int,
+        is_primary: bool | None,
+        is_primary_eligible: bool,
+        coordinator_running: bool,
+        coordinator_generation_id: int,
+        checked_at: float,
+    ) -> None:
+        self._health_gauge.labels(**self._tags).set(healthy)
+        self._schema_registry_ready_gauge.labels(**self._tags).set(ready)
+        self._schema_registry_startup_duration_gauge.labels(**self._tags).set(startup_time_sec)
+        self._schema_registry_reader_current_offset_gauge.labels(**self._tags).set(reader_current_offset)
+        self._schema_registry_reader_highest_offset_gauge.labels(**self._tags).set(reader_highest_offset)
+        self._schema_registry_reader_lag_gauge.labels(**self._tags).set(
+            max(reader_highest_offset - reader_current_offset, 0)
+        )
+        primary_state = "unknown" if is_primary is None else "primary" if is_primary else "replica"
+        for state in ("primary", "replica", "unknown"):
+            self._schema_registry_primary_gauge.labels(state=state, **self._tags).set(state == primary_state)
+        self._schema_registry_primary_eligible_gauge.labels(**self._tags).set(is_primary_eligible)
+        self._schema_registry_coordinator_running_gauge.labels(**self._tags).set(coordinator_running)
+        self._schema_registry_coordinator_generation_gauge.labels(**self._tags).set(coordinator_generation_id)
+        self._health_check_timestamp_gauge.labels(**self._tags).set(checked_at)
+
+    def set_schema_registry_health_failed(self, *, checked_at: float) -> None:
+        """Record a failed health evaluation while retaining the last component snapshot."""
+        self._health_gauge.labels(**self._tags).set(0)
+        self._health_check_timestamp_gauge.labels(**self._tags).set(checked_at)
 
     def unexpected_exception(self, ex: Exception, where: str, tags: dict | None = None) -> None:
         all_tags = {

--- a/tests/e2e/instrumentation/test_prometheus.py
+++ b/tests/e2e/instrumentation/test_prometheus.py
@@ -53,3 +53,17 @@ async def test_metrics_endpoint_parsed_response(registry_async_client: Client) -
 
     # Backwards-compatible karapace_* metrics
     assert "karapace_http_requests" in metrics
+
+    # Schema Registry health metrics
+    assert "karapace_health" in metrics
+    assert "karapace_schema_registry_ready" in metrics
+    assert "karapace_schema_registry_startup_duration_seconds" in metrics
+    assert "karapace_schema_registry_reader_current_offset" in metrics
+    assert "karapace_schema_registry_reader_highest_offset" in metrics
+    assert "karapace_schema_registry_reader_lag" in metrics
+    assert "karapace_schema_registry_primary" in metrics
+    assert "karapace_schema_registry_primary_eligible" in metrics
+    assert "karapace_schema_registry_coordinator_running" in metrics
+    assert "karapace_schema_registry_coordinator_generation" in metrics
+    assert "karapace_health_check_timestamp_seconds" in metrics
+    assert "karapace_build_info" in metrics

--- a/tests/unit/core/test_health.py
+++ b/tests/unit/core/test_health.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) 2026 Aiven Ltd
+See LICENSE for details
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from karapace.core.health import SchemaRegistryHealthMonitor
+
+
+def schema_registry_mock(*, healthy: bool = True, is_primary: bool | None = False) -> Mock:
+    schema_registry = Mock()
+    schema_registry.schema_reader.ready.return_value = True
+    schema_registry.schema_reader.last_check = 14.5
+    schema_registry.schema_reader.start_time = 10.0
+    schema_registry.schema_reader.offset = 17
+    schema_registry.schema_reader.highest_offset.return_value = 23
+    schema_registry.schema_reader.is_healthy = AsyncMock(return_value=healthy)
+    schema_registry.mc.get_coordinator_status.return_value = SimpleNamespace(
+        is_primary=is_primary,
+        is_primary_eligible=True,
+        primary_url="http://primary:8081",
+        is_running=True,
+        group_generation_id=7,
+    )
+    return schema_registry
+
+
+def test_status_collects_in_memory_schema_registry_state() -> None:
+    monitor = SchemaRegistryHealthMonitor(schema_registry=schema_registry_mock(), stats=Mock())
+
+    status = monitor.status()
+
+    assert status.schema_registry_ready is True
+    assert status.schema_registry_startup_time_sec == 4.5
+    assert status.schema_registry_reader_current_offset == 17
+    assert status.schema_registry_reader_highest_offset == 23
+    assert status.schema_registry_is_primary is False
+    assert status.schema_registry_is_primary_eligible is True
+    assert status.schema_registry_primary_url == "http://primary:8081"
+    assert status.schema_registry_coordinator_running is True
+    assert status.schema_registry_coordinator_generation_id == 7
+
+
+async def test_check_reports_shared_health_snapshot() -> None:
+    stats = Mock()
+    schema_registry = schema_registry_mock(healthy=False, is_primary=None)
+    monitor = SchemaRegistryHealthMonitor(schema_registry=schema_registry, stats=stats)
+
+    with patch("karapace.core.health.time.time", return_value=1234.5):
+        health_check = await monitor.check()
+
+    assert health_check.healthy is False
+    assert health_check.checked_at == 1234.5
+    stats.set_schema_registry_health.assert_called_once_with(
+        healthy=False,
+        ready=True,
+        startup_time_sec=4.5,
+        reader_current_offset=17,
+        reader_highest_offset=23,
+        is_primary=None,
+        is_primary_eligible=True,
+        coordinator_running=True,
+        coordinator_generation_id=7,
+        checked_at=1234.5,
+    )
+
+
+async def test_background_monitor_records_evaluation_failure() -> None:
+    stats = Mock()
+    monitor = SchemaRegistryHealthMonitor(schema_registry=schema_registry_mock(), stats=stats, check_interval_seconds=0)
+    check = AsyncMock(side_effect=RuntimeError("failed"))
+
+    with (
+        patch.object(monitor, "check", check),
+        patch("karapace.core.health.time.time", return_value=1234.5),
+    ):
+        await monitor.start()
+        await monitor.close()
+
+    stats.set_schema_registry_health_failed.assert_called_once_with(checked_at=1234.5)

--- a/tests/unit/test_stats.py
+++ b/tests/unit/test_stats.py
@@ -12,6 +12,7 @@ from prometheus_client import CollectorRegistry, Gauge
 
 from karapace.core.instrumentation.meter import Meter
 from karapace.core.stats import (
+    METRIC_HEALTH_GAUGE,
     METRIC_SCHEMAS_GAUGE,
     METRIC_SUBJECT_DATA_SCHEMA_VERSIONS_GAUGE,
     METRIC_SUBJECTS_GAUGE,
@@ -46,6 +47,10 @@ class TestSchemaGaugeMetrics:
         assert isinstance(stats._total_subjects_gauge, Gauge)
         assert stats._total_subjects_gauge._name == METRIC_SUBJECTS_GAUGE
 
+    def test_health_gauge_is_prometheus_gauge(self, stats: StatsClient) -> None:
+        assert isinstance(stats._health_gauge, Gauge)
+        assert stats._health_gauge._name == METRIC_HEALTH_GAUGE
+
     def test_schema_versions_gauge_is_prometheus_gauge(self, stats: StatsClient) -> None:
         assert isinstance(stats._schema_versions_gauge, Gauge)
         assert stats._schema_versions_gauge._name == METRIC_SUBJECT_DATA_SCHEMA_VERSIONS_GAUGE
@@ -74,3 +79,55 @@ class TestSchemaGaugeMetrics:
         assert stats._total_subjects_gauge.labels(app="Karapace")._value.get() == 5.0
         stats.set_subjects_num_total(value=3)
         assert stats._total_subjects_gauge.labels(app="Karapace")._value.get() == 3.0
+
+
+class TestSchemaRegistryHealthMetrics:
+    @staticmethod
+    def set_health(stats: StatsClient, *, is_primary: bool | None = True) -> None:
+        stats.set_schema_registry_health(
+            healthy=True,
+            ready=True,
+            startup_time_sec=4.5,
+            reader_current_offset=17,
+            reader_highest_offset=23,
+            is_primary=is_primary,
+            is_primary_eligible=True,
+            coordinator_running=True,
+            coordinator_generation_id=7,
+            checked_at=1234.5,
+        )
+
+    def test_set_schema_registry_health_values(self, stats: StatsClient) -> None:
+        self.set_health(stats)
+
+        labels = {"app": "Karapace"}
+        assert stats._health_gauge.labels(**labels)._value.get() == 1.0
+        assert stats._schema_registry_ready_gauge.labels(**labels)._value.get() == 1.0
+        assert stats._schema_registry_startup_duration_gauge.labels(**labels)._value.get() == 4.5
+        assert stats._schema_registry_reader_current_offset_gauge.labels(**labels)._value.get() == 17.0
+        assert stats._schema_registry_reader_highest_offset_gauge.labels(**labels)._value.get() == 23.0
+        assert stats._schema_registry_reader_lag_gauge.labels(**labels)._value.get() == 6.0
+        assert stats._schema_registry_primary_eligible_gauge.labels(**labels)._value.get() == 1.0
+        assert stats._schema_registry_coordinator_running_gauge.labels(**labels)._value.get() == 1.0
+        assert stats._schema_registry_coordinator_generation_gauge.labels(**labels)._value.get() == 7.0
+        assert stats._health_check_timestamp_gauge.labels(**labels)._value.get() == 1234.5
+
+    @pytest.mark.parametrize(
+        ("is_primary", "expected_state"),
+        [(True, "primary"), (False, "replica"), (None, "unknown")],
+    )
+    def test_primary_state_is_not_collapsed(self, stats: StatsClient, is_primary: bool | None, expected_state: str) -> None:
+        self.set_health(stats, is_primary=is_primary)
+
+        for state in ("primary", "replica", "unknown"):
+            value = stats._schema_registry_primary_gauge.labels(state=state, app="Karapace")._value.get()
+            assert value == float(state == expected_state)
+
+    def test_failed_health_evaluation_preserves_component_values(self, stats: StatsClient) -> None:
+        self.set_health(stats)
+
+        stats.set_schema_registry_health_failed(checked_at=1300.0)
+
+        assert stats._health_gauge.labels(app="Karapace")._value.get() == 0.0
+        assert stats._schema_registry_reader_current_offset_gauge.labels(app="Karapace")._value.get() == 17.0
+        assert stats._health_check_timestamp_gauge.labels(app="Karapace")._value.get() == 1300.0

--- a/website/docs/observability.md
+++ b/website/docs/observability.md
@@ -11,6 +11,33 @@ monitor it in production.
 
 Karapace exposes Prometheus-native metrics that a scraper can collect.
 
+Schema Registry health values returned by `/_health` are also exposed as metrics:
+
+| Metric | Description |
+| --- | --- |
+| `karapace_health` | Whether the instance is healthy (`1`) or unhealthy (`0`). |
+| `karapace_schema_registry_ready` | Whether the schema reader is ready. |
+| `karapace_schema_registry_startup_duration_seconds` | Time required for the schema reader to become ready. |
+| `karapace_schema_registry_reader_current_offset` | Current consumed schema-topic offset. |
+| `karapace_schema_registry_reader_highest_offset` | Highest known schema-topic offset. |
+| `karapace_schema_registry_reader_lag` | Difference between the highest and current offsets. |
+| `karapace_schema_registry_primary` | Primary, replica, or unknown election state. |
+| `karapace_schema_registry_primary_eligible` | Whether the instance is eligible to become primary. |
+| `karapace_schema_registry_coordinator_running` | Whether the coordinator is running. |
+| `karapace_schema_registry_coordinator_generation` | Current coordinator generation ID. |
+| `karapace_health_check_timestamp_seconds` | Unix timestamp of the latest health evaluation. |
+| `karapace_build_info` | Karapace build information, including the version label. |
+
+For example, alert when the instance is unhealthy or its health evaluation is stale:
+
+```promql
+karapace_health == 0
+```
+
+```promql
+time() - karapace_health_check_timestamp_seconds > 30
+```
+
 ## OpenTelemetry
 
 Karapace integrates with OpenTelemetry for traces and metrics. Point it at your collector


### PR DESCRIPTION
# About this change - What it does

Exposes Schema Registry health, readiness, reader progress and lag, primary-election state, coordinator state, health freshness, and build information as Prometheus metrics.

The existing `/_health` route and the new metrics now use the same health monitor and underlying state. A background evaluation refreshes the asynchronous Kafka-dependent health result without making Prometheus scrapes perform blocking Kafka I/O.

The primary URL is deliberately not exported as a label.

Closes #1370

# Why this way

Most health fields are inexpensive in-memory values, while the overall health result requires the asynchronous `KafkaSchemaReader.is_healthy()` check. A shared asynchronous monitor keeps those semantics aligned and publishes the result to gauges on a bounded interval.

The timestamp metric makes stale evaluations observable, and primary state uses bounded `primary`, `replica`, and `unknown` values instead of collapsing the nullable state.

# Validation

* Ruff formatting and lint checks
* mypy on changed source and unit-test files
* 162 focused and related unit tests
* Prometheus exposition smoke test
* Full local unit run reached 1,316 passing tests; the remaining 19 protobuf-only tests require the real Go `protopace` library/`protoc`, which were unavailable locally
